### PR TITLE
feat. Spring Security JWT 인증 필터 추가

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
@@ -2,6 +2,8 @@ package com.ditto.api.config
 
 import com.ditto.api.config.auth.ApiKeyAuthFilter
 import com.ditto.api.config.auth.ApiKeyProperties
+import com.ditto.api.config.auth.JwtAuthenticationFilter
+import com.ditto.api.config.auth.JwtTokenProvider
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
@@ -15,6 +17,7 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 class SecurityConfig(
     private val apiKeyProperties: ApiKeyProperties,
+    private val jwtTokenProvider: JwtTokenProvider,
 ) {
 
     /**
@@ -47,13 +50,13 @@ class SecurityConfig(
     }
 
     /**
-     * API — API Key 인증 필수
+     * API Key만 필요 (소셜 로그인, 토큰 갱신 등 JWT 불필요)
      */
     @Bean
     @Order(3)
-    fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+    fun apiKeyOnlySecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
-            .securityMatcher("/api/**")
+            .securityMatcher("/api/v1/users/social-login/**", "/api/v1/users/auth/refresh")
             .csrf { it.disable() }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .addFilterBefore(ApiKeyAuthFilter(apiKeyProperties), UsernamePasswordAuthenticationFilter::class.java)
@@ -62,10 +65,26 @@ class SecurityConfig(
     }
 
     /**
-     * 그 외 모든 경로 — 차단
+     * API — API Key + JWT 인증 필수
      */
     @Bean
     @Order(4)
+    fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .securityMatcher("/api/**")
+            .csrf { it.disable() }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .addFilterBefore(ApiKeyAuthFilter(apiKeyProperties), UsernamePasswordAuthenticationFilter::class.java)
+            .addFilterAfter(JwtAuthenticationFilter(jwtTokenProvider), ApiKeyAuthFilter::class.java)
+            .authorizeHttpRequests { it.anyRequest().authenticated() }
+            .build()
+    }
+
+    /**
+     * 그 외 모든 경로 — 차단
+     */
+    @Bean
+    @Order(5)
     fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
             .csrf { it.disable() }

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
@@ -1,0 +1,66 @@
+package com.ditto.api.config.auth
+
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.response.ApiResponse
+import com.ditto.common.serialization.ObjectMapperFactory
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.web.filter.OncePerRequestFilter
+
+class JwtAuthenticationFilter(
+    private val jwtTokenProvider: JwtTokenProvider,
+) : OncePerRequestFilter() {
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain,
+    ) {
+        val token = resolveToken(request)
+
+        if (token == null || !jwtTokenProvider.isValid(token)) {
+            retrieveUnauthorized(response)
+            return
+        }
+
+        setAuthentication(token)
+
+        filterChain.doFilter(request, response)
+    }
+
+    private fun resolveToken(request: HttpServletRequest): String? =
+        request
+            .getHeader(AUTHORIZATION_HEADER)
+            ?.takeIf { it.startsWith(BEARER_PREFIX) }
+            ?.substring(BEARER_PREFIX.length)
+
+    private fun retrieveUnauthorized(response: HttpServletResponse) {
+        response.status = HttpServletResponse.SC_UNAUTHORIZED
+        response.contentType = "application/json"
+        response.writer.write(objectMapper.writeValueAsString(ApiResponse.error(ErrorCode.UNAUTHORIZED_ERROR)))
+    }
+
+    private fun setAuthentication(token: String) {
+        val principal =
+            MemberPrincipal(
+                providerUserId = jwtTokenProvider.getProviderUserId(token),
+                provider = jwtTokenProvider.getProvider(token),
+            )
+
+        val authentication =
+            UsernamePasswordAuthenticationToken(
+                principal,
+                null,
+                SecurityContextHolder.getContext().authentication?.authorities ?: emptyList(),
+            )
+        SecurityContextHolder.getContext().authentication = authentication
+    }
+
+    companion object {
+        private const val AUTHORIZATION_HEADER = "Authorization"
+        private const val BEARER_PREFIX = "Bearer "
+        private val objectMapper = ObjectMapperFactory.create()
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/config/auth/MemberPrincipal.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/MemberPrincipal.kt
@@ -1,0 +1,8 @@
+package com.ditto.api.config.auth
+
+import com.ditto.domain.socialaccount.entity.SocialProvider
+
+data class MemberPrincipal(
+    val providerUserId: String,
+    val provider: SocialProvider,
+)

--- a/api/src/test/kotlin/com/ditto/api/config/GlobalExceptionHandlerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/GlobalExceptionHandlerTest.kt
@@ -16,7 +16,7 @@ class GlobalExceptionHandlerTest : RestDocsTest() {
     @Test
     @DisplayName("WarnException이 발생하면 success=false와 해당 ErrorCode 정보를 반환한다")
     fun warnException() {
-        mockMvc.perform(get("/api/test/warn").withApiKey())
+        mockMvc.perform(get("/api/test/warn").withApiKey().withBearerToken())
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.statusCode").value(400))
@@ -27,7 +27,7 @@ class GlobalExceptionHandlerTest : RestDocsTest() {
     @Test
     @DisplayName("ErrorException이 발생하면 success=false와 해당 ErrorCode 정보를 반환한다")
     fun errorException() {
-        mockMvc.perform(get("/api/test/error").withApiKey())
+        mockMvc.perform(get("/api/test/error").withApiKey().withBearerToken())
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.statusCode").value(500))
@@ -38,7 +38,7 @@ class GlobalExceptionHandlerTest : RestDocsTest() {
     @Test
     @DisplayName("처리되지 않은 예외가 발생하면 success=false와 INTERNAL_ERROR를 반환한다")
     fun unhandledException() {
-        mockMvc.perform(get("/api/test/unhandled").withApiKey())
+        mockMvc.perform(get("/api/test/unhandled").withApiKey().withBearerToken())
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.statusCode").value(500))
@@ -51,6 +51,7 @@ class GlobalExceptionHandlerTest : RestDocsTest() {
         mockMvc.perform(
             post("/api/test/validation")
                 .withApiKey()
+                .withBearerToken()
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("""{"name": ""}"""),
         )
@@ -66,6 +67,7 @@ class GlobalExceptionHandlerTest : RestDocsTest() {
         mockMvc.perform(
             post("/api/test/validation")
                 .withApiKey()
+                .withBearerToken()
                 .contentType(MediaType.APPLICATION_JSON)
                 .content("invalid json"),
         )

--- a/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
@@ -50,9 +50,9 @@ class SecurityConfigTest : RestDocsTest() {
     inner class ApiEndpoints {
 
         @Test
-        @DisplayName("유효한 API Key로 접근하면 성공한다")
-        fun validApiKey() {
-            mockMvc.perform(get("/api/test/warn").withApiKey())
+        @DisplayName("유효한 API Key와 JWT로 접근하면 성공한다")
+        fun validApiKeyAndJwt() {
+            mockMvc.perform(get("/api/test/warn").withApiKey().withBearerToken())
                 .andExpect(status().isOk)
                 .andExpect(jsonPath("$.success").value(false))
                 .andExpect(jsonPath("$.error.statusCode").value(400))

--- a/api/src/test/kotlin/com/ditto/api/config/TestExceptionController.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/TestExceptionController.kt
@@ -1,11 +1,14 @@
 package com.ditto.api.config
 
+import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
 import com.ditto.common.exception.WarnException
 import com.ditto.common.logging.Loggable
+import com.ditto.common.response.ApiResponse
 import jakarta.validation.Valid
 import jakarta.validation.constraints.NotBlank
+import org.springframework.security.core.annotation.AuthenticationPrincipal
 import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
@@ -26,6 +29,10 @@ class TestExceptionController {
 
     @PostMapping("/api/test/validation")
     fun throwValidation(@Valid @RequestBody request: TestRequest): Unit = Unit
+
+    @GetMapping("/api/test/me")
+    fun getMe(@AuthenticationPrincipal principal: MemberPrincipal): ApiResponse<MemberPrincipal> =
+        ApiResponse.ok(principal)
 }
 
 data class TestRequest(

--- a/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
@@ -1,0 +1,72 @@
+package com.ditto.api.config.auth
+
+import com.ditto.api.config.TestExceptionController
+import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.socialaccount.entity.SocialProvider
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.context.annotation.Import
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+@Import(TestExceptionController::class)
+class JwtAuthenticationFilterTest : RestDocsTest() {
+
+    @Test
+    @DisplayName("유효한 Bearer 토큰이면 MemberPrincipal을 받을 수 있다")
+    fun validBearerToken() {
+        val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+
+        mockMvc.perform(
+            get("/api/test/me")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.providerUserId").value("kakao-123"))
+            .andExpect(jsonPath("$.data.provider").value("KAKAO"))
+    }
+
+    @Test
+    @DisplayName("Bearer 토큰이 없으면 401과 에러 정보를 반환한다")
+    fun noBearerToken() {
+        mockMvc.perform(
+            get("/api/test/me")
+                .withApiKey(),
+        )
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.statusCode").value(401))
+            .andExpect(jsonPath("$.error.code").value("0002"))
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 Bearer 토큰이면 401과 에러 정보를 반환한다")
+    fun invalidBearerToken() {
+        mockMvc.perform(
+            get("/api/test/me")
+                .withApiKey()
+                .header("Authorization", "Bearer invalid-token"),
+        )
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.statusCode").value(401))
+            .andExpect(jsonPath("$.error.code").value("0002"))
+    }
+
+    @Test
+    @DisplayName("API Key 없이 Bearer 토큰만 보내면 401과 에러 정보를 반환한다")
+    fun bearerTokenWithoutApiKey() {
+        val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+
+        mockMvc.perform(
+            get("/api/test/me")
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.error.statusCode").value(401))
+            .andExpect(jsonPath("$.error.code").value("0002"))
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/config/logging/LoggingAspectTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/logging/LoggingAspectTest.kt
@@ -45,7 +45,7 @@ class LoggingAspectTest : RestDocsTest() {
         @Test
         @DisplayName("진입 로그에 메서드명과 파라미터가 출력된다")
         fun logMethodEntry() {
-            mockMvc.perform(get("/api/test/logging/echo").withApiKey().param("name", "tuna"))
+            mockMvc.perform(get("/api/test/logging/echo").withApiKey().withBearerToken().param("name", "tuna"))
                 .andExpect(status().isOk)
 
             logs().forAtLeastOne {
@@ -57,7 +57,7 @@ class LoggingAspectTest : RestDocsTest() {
         @Test
         @DisplayName("반환 로그에 결과값과 실행 시간이 출력된다")
         fun logMethodReturn() {
-            mockMvc.perform(get("/api/test/logging/echo").withApiKey().param("name", "tuna"))
+            mockMvc.perform(get("/api/test/logging/echo").withApiKey().withBearerToken().param("name", "tuna"))
                 .andExpect(status().isOk)
 
             logs().forAtLeastOne {
@@ -76,7 +76,7 @@ class LoggingAspectTest : RestDocsTest() {
         @DisplayName("요청 파라미터에서 @Mask 필드는 ** 로 마스킹된다")
         fun maskRequestField() {
             mockMvc.perform(
-                post("/api/test/logging/masked-request").withApiKey()
+                post("/api/test/logging/masked-request").withApiKey().withBearerToken()
                     .contentType(MediaType.APPLICATION_JSON)
                     .content("""{"email":"user@test.com","password":"secret123"}"""),
             ).andExpect(status().isOk)
@@ -91,7 +91,7 @@ class LoggingAspectTest : RestDocsTest() {
         @Test
         @DisplayName("반환값에서 @Mask 필드는 ** 로 마스킹된다")
         fun maskResponseField() {
-            mockMvc.perform(get("/api/test/logging/masked-response").withApiKey())
+            mockMvc.perform(get("/api/test/logging/masked-response").withApiKey().withBearerToken())
                 .andExpect(status().isOk)
 
             logs().forAtLeastOne {
@@ -109,7 +109,7 @@ class LoggingAspectTest : RestDocsTest() {
         @Test
         @DisplayName("@Loggable 컨텍스트 내 내부 메서드 호출은 로깅된다")
         fun logInternalCallInsideLoggable() {
-            mockMvc.perform(get("/api/test/logging/call-service").withApiKey())
+            mockMvc.perform(get("/api/test/logging/call-service").withApiKey().withBearerToken())
                 .andExpect(status().isOk)
 
             logs().forAtLeastOne { it shouldContain "TestLoggingService.process" }
@@ -118,7 +118,7 @@ class LoggingAspectTest : RestDocsTest() {
         @Test
         @DisplayName("@Loggable 컨텍스트 밖의 내부 메서드 호출은 로깅되지 않는다")
         fun skipInternalCallOutsideLoggable() {
-            mockMvc.perform(get("/api/test/logging/direct-service").withApiKey())
+            mockMvc.perform(get("/api/test/logging/direct-service").withApiKey().withBearerToken())
                 .andExpect(status().isOk)
 
             logs().forNone { it shouldContain "TestLoggingService.process" }

--- a/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
@@ -1,6 +1,8 @@
 package com.ditto.api.support
 
+import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.common.serialization.ObjectMapperFactory
+import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.restdocs.AutoConfigureRestDocs
@@ -19,10 +21,18 @@ abstract class RestDocsTest {
     @Autowired
     lateinit var mockMvc: MockMvc
 
+    @Autowired
+    lateinit var jwtTokenProvider: JwtTokenProvider
+
     protected val objectMapper: ObjectMapper = ObjectMapperFactory.create()
 
     protected fun MockHttpServletRequestBuilder.withApiKey(): MockHttpServletRequestBuilder {
         return this.header("X-API-Key", TEST_API_KEY)
+    }
+
+    protected fun MockHttpServletRequestBuilder.withBearerToken(): MockHttpServletRequestBuilder {
+        val token = jwtTokenProvider.generateAccessToken("test-user", SocialProvider.KAKAO)
+        return this.header("Authorization", "Bearer $token")
     }
 
     companion object {


### PR DESCRIPTION
## Summary
- `JwtAuthenticationFilter` 구현으로 JWT Bearer 토큰 기반 사용자 인증 추가
- `MemberPrincipal` DTO를 통해 컨트롤러에서 `@AuthenticationPrincipal`로 인증 정보 주입 가능
- SecurityConfig 필터 체인 분리 (API Key만 필요한 경로 / API Key + JWT 필수 경로)

## 변경 상세

### SecurityConfig 필터 체인
| Order | 매칭 경로 | 인증 |
|-------|-----------|------|
| 1 | `/actuator/**` | 없음 |
| 2 | `/health`, `/docs/**`, `/swagger-ui/**` | 없음 |
| 3 | `/api/v1/users/social-login/**`, `/api/v1/users/auth/refresh` | API Key만 |
| 4 | `/api/**` (나머지) | API Key + JWT |
| 5 | 그 외 | 차단 |

### 인증 흐름 (Order 4)
```
요청 → ApiKeyAuthFilter (X-API-Key 검증)
     → JwtAuthenticationFilter (Bearer 토큰 검증 → MemberPrincipal 생성)
     → Controller (@AuthenticationPrincipal MemberPrincipal)
```

### 컨트롤러 사용 예시
```kotlin
@GetMapping("/api/v1/me")
fun getMe(@AuthenticationPrincipal member: MemberPrincipal): ApiResponse<...> {
    // member.providerUserId, member.provider 사용 가능
}
```

Closes #16

## Test plan
- [x] 유효한 Bearer 토큰이면 MemberPrincipal을 받을 수 있다
- [x] Bearer 토큰이 없으면 401과 에러 정보를 반환한다
- [x] 유효하지 않은 Bearer 토큰이면 401과 에러 정보를 반환한다
- [x] API Key 없이 Bearer 토큰만 보내면 401을 반환한다
- [x] 기존 테스트 전체 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)