### PR TITLE
feat. 수동 배포 워크플로우 추가 (workflow_dispatch)

### DIFF
--- a/.github/workflows/cd-manual.yml
+++ b/.github/workflows/cd-manual.yml
@@ -1,0 +1,70 @@
+name: CD (Manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: '배포할 브랜치'
+        required: true
+        default: 'main'
+
+permissions:
+  contents: read
+  id-token: write
+
+env:
+  AWS_REGION: ap-northeast-2
+  ECR_REPOSITORY: ditto-api
+  ECR_ALLOY_REPOSITORY: ditto-alloy
+  ECS_CLUSTER: ditto-cluster
+  ECS_SERVICE: ditto-api-service
+
+jobs:
+  deploy:
+    name: Build & Deploy to ECS
+    runs-on: ubuntu-24.04-arm
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+
+      - name: Configure AWS credentials
+        uses: aws-actions/configure-aws-credentials@v4
+        with:
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          aws-region: ${{ env.AWS_REGION }}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to Amazon ECR
+        id: login-ecr
+        uses: aws-actions/amazon-ecr-login@v2
+
+      - name: Build and push API image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker buildx build --platform linux/arm64 --push \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_REPOSITORY:latest .
+
+      - name: Build and push Alloy image
+        env:
+          ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
+          IMAGE_TAG: ${{ github.sha }}
+        run: |
+          docker buildx build --platform linux/arm64 --push \
+            -t $ECR_REGISTRY/$ECR_ALLOY_REPOSITORY:$IMAGE_TAG \
+            -t $ECR_REGISTRY/$ECR_ALLOY_REPOSITORY:latest .aws/alloy
+
+      - name: Deploy Amazon ECS task definition
+        uses: aws-actions/amazon-ecs-deploy-task-definition@v2
+        with:
+          task-definition: .aws/task-definition.json
+          service: ${{ env.ECS_SERVICE }}
+          cluster: ${{ env.ECS_CLUSTER }}
+          wait-for-service-stability: true
+          force-new-deployment: true


### PR DESCRIPTION
## Summary

- `workflow_dispatch` 트리거를 사용하는 수동 CD 워크플로우 추가 (`.github/workflows/cd-manual.yml`)
- GitHub Actions UI에서 배포할 브랜치를 직접 입력하여 수동으로 배포 트리거 가능
- 빌드/배포 단계는 기존 `cd.yml`과 동일하게 유지 (API 이미지, Alloy 이미지 빌드 → ECS 배포)

Closes #31

## Test plan

- [ ] GitHub Actions 탭에서 "CD (Manual)" 워크플로우 확인
- [ ] "Run workflow" 버튼 클릭 후 배포할 브랜치 입력하여 수동 실행 테스트

🤖 Generated with [Claude Code](https://claude.com/claude-code)