### PR TITLE
feat. 퀴즈 답안 제출 API 구현 (#25)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
@@ -1,0 +1,25 @@
+package com.ditto.api.quiz.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.quiz.dto.SubmitAnswerRequest
+import com.ditto.api.quiz.service.QuizProgressService
+import com.ditto.common.response.ApiResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+import java.time.LocalDateTime
+
+@RestController
+class QuizProgressController(
+    private val quizProgressService: QuizProgressService,
+) {
+    @PostMapping("/api/v1/quiz-progress/answers")
+    fun submitAnswer(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestBody request: SubmitAnswerRequest,
+    ): ApiResponse<Unit> {
+        quizProgressService.submitAnswer(principal, request, LocalDateTime.now())
+        return ApiResponse(success = true)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/quiz/dto/SubmitAnswerRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/dto/SubmitAnswerRequest.kt
@@ -1,0 +1,6 @@
+package com.ditto.api.quiz.dto
+
+data class SubmitAnswerRequest(
+    val quizId: Long,
+    val choiceId: Long,
+)

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -1,0 +1,93 @@
+package com.ditto.api.quiz.service
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.quiz.dto.SubmitAnswerRequest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.ErrorException
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.quiz.entity.QuizAnswer
+import com.ditto.domain.quiz.repository.QuizAnswerRepository
+import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.time.LocalDateTime
+
+@Service
+class QuizProgressService(
+    private val quizAnswerRepository: QuizAnswerRepository,
+    private val quizRepository: QuizRepository,
+    private val quizChoiceRepository: QuizChoiceRepository,
+    private val quizSetRepository: QuizSetRepository,
+    private val socialAccountRepository: SocialAccountRepository,
+) {
+    @Transactional
+    fun submitAnswer(
+        principal: MemberPrincipal,
+        request: SubmitAnswerRequest,
+        now: LocalDateTime,
+    ) {
+        val memberId = resolveMemberId(principal)
+
+        validateQuizInActiveSet(request.quizId, now)
+        validateChoice(request.quizId, request.choiceId)
+
+        upsertAnswer(memberId, request.quizId, request.choiceId)
+    }
+
+    private fun resolveMemberId(principal: MemberPrincipal): Long {
+        val socialAccount =
+            socialAccountRepository
+                .findByProviderAndProviderUserId(principal.provider, principal.providerUserId)
+                ?: throw ErrorException(ErrorCode.UNAUTHORIZED_ERROR)
+        return socialAccount.memberId
+    }
+
+    private fun validateQuizInActiveSet(
+        quizId: Long,
+        now: LocalDateTime,
+    ) {
+        val quiz =
+            quizRepository
+                .findById(quizId)
+                .orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+        val quizSet =
+            quizSetRepository
+                .findById(quiz.quizSetId)
+                .orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+
+        val isInPeriod = !now.isBefore(quizSet.startDate) && !now.isAfter(quizSet.endDate)
+        if (!quizSet.isActive || !isInPeriod) {
+            throw ErrorException(ErrorCode.QUIZ_NOT_IN_ACTIVE_SET)
+        }
+    }
+
+    private fun validateChoice(
+        quizId: Long,
+        choiceId: Long,
+    ) {
+        val choices = quizChoiceRepository.findByQuizIdInOrderByDisplayOrderAsc(listOf(quizId))
+        val valid = choices.any { it.id == choiceId }
+        if (!valid) {
+            throw ErrorException(ErrorCode.INVALID_CHOICE)
+        }
+    }
+
+    private fun upsertAnswer(
+        memberId: Long,
+        quizId: Long,
+        choiceId: Long,
+    ) {
+        val existing = quizAnswerRepository.findByMemberIdAndQuizId(memberId, quizId)
+
+        if (existing != null) {
+            existing.changeChoice(choiceId)
+            return
+        }
+
+        val newQuizAnswer = QuizAnswer.create(memberId, quizId, choiceId)
+        quizAnswerRepository.save(newQuizAnswer)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -52,11 +52,11 @@ class QuizProgressService(
         val quiz =
             quizRepository
                 .findById(quizId)
-                .orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+                .orElseThrow { ErrorException(ErrorCode.NOT_FOUND) }
         val quizSet =
             quizSetRepository
                 .findById(quiz.quizSetId)
-                .orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+                .orElseThrow { ErrorException(ErrorCode.NOT_FOUND) }
 
         val isInPeriod = !now.isBefore(quizSet.startDate) && !now.isAfter(quizSet.endDate)
         if (!quizSet.isActive || !isInPeriod) {

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -58,7 +58,7 @@ class QuizProgressService(
                 .findById(quiz.quizSetId)
                 .orElseThrow { ErrorException(ErrorCode.NOT_FOUND) }
 
-        val isInPeriod = !now.isBefore(quizSet.startDate) && !now.isAfter(quizSet.endDate)
+        val isInPeriod = now >= quizSet.startDate && now <= quizSet.endDate
         if (!quizSet.isActive || !isInPeriod) {
             throw ErrorException(ErrorCode.QUIZ_NOT_IN_ACTIVE_SET)
         }

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
@@ -1,0 +1,146 @@
+package com.ditto.api.quiz
+
+import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.QuizChoiceFixture
+import com.ditto.domain.quiz.QuizFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import com.ditto.domain.socialaccount.entity.SocialAccount
+import com.ditto.domain.socialaccount.entity.SocialProvider
+import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
+
+class QuizProgressControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var quizSetRepository: QuizSetRepository
+
+    @Autowired
+    private lateinit var quizRepository: QuizRepository
+
+    @Autowired
+    private lateinit var quizChoiceRepository: QuizChoiceRepository
+
+    @Autowired
+    private lateinit var memberRepository: MemberRepository
+
+    @Autowired
+    private lateinit var socialAccountRepository: SocialAccountRepository
+
+    private val now = LocalDateTime.now()
+
+    private fun setupAuthenticatedMember() {
+        val member = memberRepository.save(Member(nickname = "테스트유저"))
+        socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "test-user"))
+    }
+
+    @Test
+    @DisplayName("퀴즈 답안을 제출한다")
+    fun submitAnswer() {
+        setupAuthenticatedMember()
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+        )
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+        val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+        val request = mapOf("quizId" to quiz.id, "choiceId" to choice.id)
+
+        mockMvc.perform(
+            post("/api/v1/quiz-progress/answers")
+                .withApiKey()
+                .withBearerToken()
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data").doesNotExist())
+            .andDo(
+                document(
+                    "quiz-progress-submit-answer",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("QuizProgress")
+                            .summary("퀴즈 답안 제출")
+                            .description("퀴즈에 대한 답안을 제출합니다. 이미 답변한 퀴즈에 재제출하면 선택지가 업데이트됩니다.")
+                            .requestFields(
+                                fieldWithPath("quizId").description("퀴즈 ID"),
+                                fieldWithPath("choiceId").description("선택한 선택지 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data").description("데이터 (답안 제출 시 null)"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("비활성 퀴즈에 답안을 제출하면 에러를 반환한다")
+    fun submitAnswerInactiveQuiz() {
+        setupAuthenticatedMember()
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = false),
+        )
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+        val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+        val request = mapOf("quizId" to quiz.id, "choiceId" to choice.id)
+
+        mockMvc.perform(
+            post("/api/v1/quiz-progress/answers")
+                .withApiKey()
+                .withBearerToken()
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("4001"))
+    }
+
+    @Test
+    @DisplayName("유효하지 않은 선택지로 답안을 제출하면 에러를 반환한다")
+    fun submitAnswerInvalidChoice() {
+        setupAuthenticatedMember()
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+        )
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+        val request = mapOf("quizId" to quiz.id, "choiceId" to 99999)
+
+        mockMvc.perform(
+            post("/api/v1/quiz-progress/answers")
+                .withApiKey()
+                .withBearerToken()
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("4002"))
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
@@ -109,7 +109,7 @@ class QuizProgressServiceTest(
         "존재하지 않는 quizId로 제출하면 예외가 발생한다" {
             val principal = setupMember()
 
-            val exception = shouldThrow<WarnException> {
+            val exception = shouldThrow<ErrorException> {
                 quizProgressService.submitAnswer(principal, SubmitAnswerRequest(99999L, 1L), now)
             }
             exception.errorCode shouldBe ErrorCode.NOT_FOUND

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
@@ -1,0 +1,138 @@
+package com.ditto.api.quiz
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.quiz.dto.SubmitAnswerRequest
+import com.ditto.api.quiz.service.QuizProgressService
+import com.ditto.api.support.IntegrationTest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.ErrorException
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.QuizChoiceFixture
+import com.ditto.domain.quiz.QuizFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.repository.QuizAnswerRepository
+import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import com.ditto.domain.socialaccount.entity.SocialAccount
+import com.ditto.domain.socialaccount.entity.SocialProvider
+import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import java.time.LocalDateTime
+import javax.sql.DataSource
+
+class QuizProgressServiceTest(
+    private val quizProgressService: QuizProgressService,
+    private val quizSetRepository: QuizSetRepository,
+    private val quizRepository: QuizRepository,
+    private val quizChoiceRepository: QuizChoiceRepository,
+    private val quizAnswerRepository: QuizAnswerRepository,
+    private val memberRepository: MemberRepository,
+    private val socialAccountRepository: SocialAccountRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    val now = LocalDateTime.now()
+
+    fun setupMember(): MemberPrincipal {
+        val member = memberRepository.save(Member(nickname = "테스트유저"))
+        socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "test-user"))
+        return MemberPrincipal(providerUserId = "test-user", provider = SocialProvider.KAKAO)
+    }
+
+    fun setupActiveQuizData(): Triple<Long, Long, Long> {
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+        )
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+        val choice1 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "A", displayOrder = 1))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "B", displayOrder = 2))
+        return Triple(quiz.id, choice1.id, quizChoiceRepository.findByQuizIdInOrderByDisplayOrderAsc(listOf(quiz.id)).last().id)
+    }
+
+    "퀴즈 답안 제출" - {
+        "정상적인 답안을 제출하면 QuizAnswer가 저장된다" {
+            val principal = setupMember()
+            val (quizId, choiceId, _) = setupActiveQuizData()
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, choiceId), now)
+
+            val answer = quizAnswerRepository.findByMemberIdAndQuizId(1L, quizId)
+            answer shouldNotBe null
+            answer!!.choiceId shouldBe choiceId
+        }
+
+        "같은 퀴즈에 다른 선택지로 재제출하면 choiceId가 업데이트된다" {
+            val principal = setupMember()
+            val (quizId, choiceId1, choiceId2) = setupActiveQuizData()
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, choiceId1), now)
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, choiceId2), now)
+
+            val answers = quizAnswerRepository.findAll()
+            answers.size shouldBe 1
+            answers[0].choiceId shouldBe choiceId2
+        }
+
+        "비활성 퀴즈 세트의 퀴즈에 답안을 제출하면 예외가 발생한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = false),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+            }
+            exception.errorCode shouldBe ErrorCode.QUIZ_NOT_IN_ACTIVE_SET
+        }
+
+        "기간이 지난 퀴즈 세트의 퀴즈에 답안을 제출하면 예외가 발생한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(7), endDate = now.minusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+            }
+            exception.errorCode shouldBe ErrorCode.QUIZ_NOT_IN_ACTIVE_SET
+        }
+
+        "존재하지 않는 quizId로 제출하면 예외가 발생한다" {
+            val principal = setupMember()
+
+            val exception = shouldThrow<WarnException> {
+                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(99999L, 1L), now)
+            }
+            exception.errorCode shouldBe ErrorCode.NOT_FOUND
+        }
+
+        "해당 퀴즈에 속하지 않는 choiceId로 제출하면 예외가 발생한다" {
+            val principal = setupMember()
+            val (quizId, _, _) = setupActiveQuizData()
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, 99999L), now)
+            }
+            exception.errorCode shouldBe ErrorCode.INVALID_CHOICE
+        }
+
+        "소셜 계정이 없는 principal로 제출하면 예외가 발생한다" {
+            val (quizId, choiceId, _) = setupActiveQuizData()
+            val unknownPrincipal = MemberPrincipal(providerUserId = "unknown", provider = SocialProvider.KAKAO)
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.submitAnswer(unknownPrincipal, SubmitAnswerRequest(quizId, choiceId), now)
+            }
+            exception.errorCode shouldBe ErrorCode.UNAUTHORIZED_ERROR
+        }
+    }
+})

--- a/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
+++ b/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
@@ -14,5 +14,7 @@ enum class ErrorCode(
     REFRESH_TOKEN_EXPIRED(401, "2002", "리프레시 토큰이 만료되었습니다."),
     MEMBER_ALREADY_EXISTS(409, "3002", "이미 존재하는 사용자입니다."),
     NICKNAME_ALREADY_EXISTS(409, "3003", "이미 사용 중인 닉네임입니다."),
+    QUIZ_NOT_IN_ACTIVE_SET(400, "4001", "현재 활성화된 퀴즈 세트에 속한 퀴즈가 아닙니다."),
+    INVALID_CHOICE(400, "4002", "해당 퀴즈의 유효한 선택지가 아닙니다."),
     INTERNAL_ERROR(500, "9999", "알 수 없는 에러가 발생했습니다."),
 }

--- a/domain/db/V20260411230157_퀴즈 답변 테이블 추가.sql
+++ b/domain/db/V20260411230157_퀴즈 답변 테이블 추가.sql
@@ -7,5 +7,7 @@ CREATE TABLE quiz_answer
     created_at DATETIME(6) NOT NULL COMMENT '생성 일시',
     updated_at DATETIME(6) NOT NULL COMMENT '수정 일시',
     PRIMARY KEY (id),
-    UNIQUE KEY quiz_answer_uk_1 (member_id, quiz_id)
+    UNIQUE KEY quiz_answer_uk_1 (member_id, quiz_id),
+    INDEX quiz_answer_index_1 (quiz_id),
+    INDEX quiz_answer_index_2 (choice_id)
 ) COMMENT ='퀴즈 답변';

--- a/domain/db/V20260411230157_퀴즈 답변 테이블 추가.sql
+++ b/domain/db/V20260411230157_퀴즈 답변 테이블 추가.sql
@@ -1,0 +1,11 @@
+CREATE TABLE quiz_answer
+(
+    id         BIGINT      NOT NULL AUTO_INCREMENT COMMENT '퀴즈 답변 ID',
+    member_id  BIGINT      NOT NULL COMMENT '회원 ID',
+    quiz_id    BIGINT      NOT NULL COMMENT '퀴즈 ID',
+    choice_id  BIGINT      NOT NULL COMMENT '선택지 ID',
+    created_at DATETIME(6) NOT NULL COMMENT '생성 일시',
+    updated_at DATETIME(6) NOT NULL COMMENT '수정 일시',
+    PRIMARY KEY (id),
+    UNIQUE KEY quiz_answer_uk_1 (member_id, quiz_id)
+) COMMENT ='퀴즈 답변';

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizAnswer.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizAnswer.kt
@@ -6,6 +6,7 @@ import jakarta.persistence.Entity
 import jakarta.persistence.GeneratedValue
 import jakarta.persistence.GenerationType
 import jakarta.persistence.Id
+import jakarta.persistence.Index
 import jakarta.persistence.Table
 import jakarta.persistence.UniqueConstraint
 import org.hibernate.annotations.Comment
@@ -15,6 +16,10 @@ import org.hibernate.annotations.Comment
     name = "quiz_answer",
     uniqueConstraints = [
         UniqueConstraint(name = "quiz_answer_uk_1", columnNames = ["member_id", "quiz_id"]),
+    ],
+    indexes = [
+        Index(name = "quiz_answer_index_1", columnList = "quiz_id"),
+        Index(name = "quiz_answer_index_2", columnList = "choice_id"),
     ],
 )
 class QuizAnswer private constructor(

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizAnswer.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizAnswer.kt
@@ -1,0 +1,53 @@
+package com.ditto.domain.quiz.entity
+
+import com.ditto.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.Comment
+
+@Entity
+@Table(
+    name = "quiz_answer",
+    uniqueConstraints = [
+        UniqueConstraint(name = "quiz_answer_uk_1", columnNames = ["member_id", "quiz_id"]),
+    ],
+)
+class QuizAnswer private constructor(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Comment("회원 ID")
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+    @Comment("퀴즈 ID")
+    @Column(name = "quiz_id", nullable = false)
+    val quizId: Long,
+    choiceId: Long,
+) : BaseEntity() {
+    @Comment("선택지 ID")
+    @Column(name = "choice_id", nullable = false)
+    var choiceId: Long = choiceId
+        protected set
+
+    fun changeChoice(choiceId: Long) {
+        this.choiceId = choiceId
+    }
+
+    companion object {
+        fun create(
+            memberId: Long,
+            quizId: Long,
+            choiceId: Long,
+        ): QuizAnswer =
+            QuizAnswer(
+                memberId = memberId,
+                quizId = quizId,
+                choiceId = choiceId,
+            )
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
@@ -1,0 +1,8 @@
+package com.ditto.domain.quiz.repository
+
+import com.ditto.domain.quiz.entity.QuizAnswer
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long> {
+    fun findByMemberIdAndQuizId(memberId: Long, quizId: Long): QuizAnswer?
+}

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/entity/QuizAnswerTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/entity/QuizAnswerTest.kt
@@ -1,0 +1,111 @@
+package com.ditto.domain.quiz.entity
+
+import com.ditto.domain.quiz.QuizAnswerFixture
+import com.ditto.domain.quiz.QuizChoiceFixture
+import com.ditto.domain.quiz.QuizFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.repository.QuizAnswerRepository
+import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import javax.sql.DataSource
+
+class QuizAnswerTest(
+    private val quizSetRepository: QuizSetRepository,
+    private val quizRepository: QuizRepository,
+    private val quizChoiceRepository: QuizChoiceRepository,
+    private val quizAnswerRepository: QuizAnswerRepository,
+    dataSource: DataSource,
+) : IntegrationTest(
+        dataSource,
+        {
+
+            "QuizAnswer 생성" - {
+                "QuizAnswer를 생성하고 저장할 수 있다" {
+                    val quizSet = quizSetRepository.save(QuizSetFixture.create())
+                    val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+                    val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+                    val answer =
+                        quizAnswerRepository.save(
+                            QuizAnswerFixture.create(memberId = 1L, quizId = quiz.id, choiceId = choice.id),
+                        )
+
+                    answer.id shouldNotBe 0L
+                    answer.memberId shouldBe 1L
+                    answer.quizId shouldBe quiz.id
+                    answer.choiceId shouldBe choice.id
+                }
+
+                "같은 memberId, quizId로 중복 저장하면 예외가 발생한다" {
+                    val quizSet = quizSetRepository.save(QuizSetFixture.create())
+                    val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+                    val choice1 =
+                        quizChoiceRepository.save(
+                            QuizChoiceFixture.create(
+                                quizId = quiz.id,
+                                content = "A",
+                                displayOrder = 1,
+                            ),
+                        )
+                    val choice2 =
+                        quizChoiceRepository.save(
+                            QuizChoiceFixture.create(
+                                quizId = quiz.id,
+                                content = "B",
+                                displayOrder = 2,
+                            ),
+                        )
+
+                    quizAnswerRepository.save(
+                        QuizAnswerFixture.create(memberId = 1L, quizId = quiz.id, choiceId = choice1.id),
+                    )
+
+                    shouldThrow<Exception> {
+                        quizAnswerRepository.saveAndFlush(
+                            QuizAnswerFixture.create(memberId = 1L, quizId = quiz.id, choiceId = choice2.id),
+                        )
+                    }
+                }
+            }
+
+            "QuizAnswer 수정" - {
+                "updateChoice()로 선택지를 변경할 수 있다" {
+                    val quizSet = quizSetRepository.save(QuizSetFixture.create())
+                    val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+                    val choice1 =
+                        quizChoiceRepository.save(
+                            QuizChoiceFixture.create(
+                                quizId = quiz.id,
+                                content = "A",
+                                displayOrder = 1,
+                            ),
+                        )
+                    val choice2 =
+                        quizChoiceRepository.save(
+                            QuizChoiceFixture.create(
+                                quizId = quiz.id,
+                                content = "B",
+                                displayOrder = 2,
+                            ),
+                        )
+
+                    val answer =
+                        quizAnswerRepository.save(
+                            QuizAnswerFixture.create(memberId = 1L, quizId = quiz.id, choiceId = choice1.id),
+                        )
+
+                    answer.changeChoice(choice2.id)
+                    quizAnswerRepository.saveAndFlush(answer)
+
+                    val found = quizAnswerRepository.findByMemberIdAndQuizId(1L, quiz.id)
+                    found shouldNotBe null
+                    found!!.choiceId shouldBe choice2.id
+                }
+            }
+        },
+    )

--- a/domain/src/testFixtures/kotlin/com/ditto/domain/quiz/QuizAnswerFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/ditto/domain/quiz/QuizAnswerFixture.kt
@@ -1,0 +1,18 @@
+package com.ditto.domain.quiz
+
+import com.ditto.domain.quiz.entity.QuizAnswer
+import com.ditto.domain.withId
+
+object QuizAnswerFixture {
+
+    fun create(
+        memberId: Long = 1L,
+        quizId: Long = 1L,
+        choiceId: Long = 1L,
+        id: Long = 0L,
+    ): QuizAnswer = QuizAnswer.create(
+        memberId = memberId,
+        quizId = quizId,
+        choiceId = choiceId,
+    ).withId(id)
+}


### PR DESCRIPTION
## Summary
- 퀴즈 답안 제출/수정 API 구현 (`POST /api/v1/quiz-progress/answers`)
- `QuizAnswer` 엔티티 추가 (upsert 지원, unique constraint)
- 검증 로직: 활성 퀴즈셋 여부, 유효한 선택지 여부

## 구현 내용

### 도메인 (`domain`)
- `QuizAnswer` 엔티티 (private constructor + `create()` + `changeChoice()`)
- `QuizAnswerRepository` (`findByMemberIdAndQuizId` — upsert 조회용)
- DDL: `V20260411230157_퀴즈 답변 테이블 추가.sql` (UNIQUE KEY on member_id, quiz_id)

### 공통 (`common`)
- `ErrorCode.QUIZ_NOT_IN_ACTIVE_SET` (400, 4001) — 비활성/기간 외 퀴즈셋
- `ErrorCode.INVALID_CHOICE` (400, 4002) — 유효하지 않은 선택지

### API (`api`)
- `QuizProgressController`: `POST /api/v1/quiz-progress/answers`
- `QuizProgressService`:
  - memberId 추출 (MemberPrincipal → SocialAccount → memberId)
  - 검증: quiz 존재 → quizSet 활성+기간 내 → choiceId 유효
  - upsert: `findByMemberIdAndQuizId` → 있으면 `changeChoice()`, 없으면 `save(create())`
- `SubmitAnswerRequest`: `{ quizId: Long, choiceId: Long }`
- 응답: `{ success: true }` (data 없음, FE fire-and-forget)

### 테스트
- 도메인 테스트 (`QuizAnswerTest`): 생성/저장, unique constraint, changeChoice
- 통합 테스트 (`QuizProgressServiceTest`): 정상 제출, 재제출(upsert), 비활성 퀴즈셋, 기간 만료, 잘못된 quizId/choiceId, 미인증
- 문서화 테스트 (`QuizProgressControllerTest`): RestDocs API 문서 + 에러 케이스

## Test plan
- [x] 정상 답안 제출 → QuizAnswer 저장
- [x] 같은 퀴즈에 재제출 → choiceId 업데이트 (upsert)
- [x] 비활성 퀴즈셋 → ErrorException (4001)
- [x] 기간 만료 퀴즈셋 → ErrorException (4001)
- [x] 존재하지 않는 quizId → ErrorException (0004)
- [x] 유효하지 않은 choiceId → ErrorException (4002)
- [x] 미인증 principal → ErrorException (0002)
- [x] unique constraint (member_id, quiz_id) 위반 시 예외

Closes #25

🤖 Generated with [Claude Code](https://claude.com/claude-code)