### PR TITLE
build. QueryDSL 설정 추가 및 @Query 마이그레이션 (#34)

### DIFF
--- a/buildSrc/src/main/kotlin/DependencyVersions.kt
+++ b/buildSrc/src/main/kotlin/DependencyVersions.kt
@@ -4,7 +4,7 @@ object DependencyVersions {
     const val SPRING_DEPENDENCY_MANAGEMENT = "1.1.7"
     const val H2 = "2.3.232"
     const val MYSQL_CONNECTOR = "8.3.0"
-    const val QUERYDSL = "5.1.0"
+    const val QUERYDSL = "7.1"
     const val KOTEST = "5.9.1"
     const val KOTEST_SPRING = "1.3.0"
     const val MOCKK = "1.13.13"
@@ -49,6 +49,8 @@ object Dependencies {
     const val JJWT_JACKSON = "io.jsonwebtoken:jjwt-jackson:${DependencyVersions.JJWT}"
     const val COROUTINES_CORE = "org.jetbrains.kotlinx:kotlinx-coroutines-core:${DependencyVersions.COROUTINES}"
     const val COROUTINES_REACTOR = "org.jetbrains.kotlinx:kotlinx-coroutines-reactor:${DependencyVersions.COROUTINES}"
+    const val QUERYDSL_JPA = "io.github.openfeign.querydsl:querydsl-jpa:${DependencyVersions.QUERYDSL}"
+    const val QUERYDSL_APT = "io.github.openfeign.querydsl:querydsl-apt:${DependencyVersions.QUERYDSL}:jpa"
     const val SPRING_RESTDOCS_MOCKMVC = "org.springframework.restdocs:spring-restdocs-mockmvc"
     const val RESTDOCS_API_SPEC_MOCKMVC = "com.epages:restdocs-api-spec-mockmvc:${DependencyVersions.RESTDOCS_API_SPEC}"
 }

--- a/domain/build.gradle.kts
+++ b/domain/build.gradle.kts
@@ -1,5 +1,6 @@
 plugins {
     id("spring-convention")
+    kotlin("kapt")
 }
 
 tasks.bootJar { enabled = false }
@@ -9,6 +10,8 @@ dependencies {
     implementation(project(":common"))
 
     api(Dependencies.SPRING_BOOT_STARTER_DATA_JPA)
+    implementation(Dependencies.QUERYDSL_JPA)
+    kapt(Dependencies.QUERYDSL_APT)
     runtimeOnly(Dependencies.MYSQL_CONNECTOR)
     testRuntimeOnly(Dependencies.H2)
 }

--- a/domain/src/main/kotlin/com/ditto/domain/config/DomainConfig.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/config/DomainConfig.kt
@@ -1,6 +1,9 @@
 package com.ditto.domain.config
 
+import com.querydsl.jpa.impl.JPAQueryFactory
+import jakarta.persistence.EntityManager
 import org.springframework.boot.autoconfigure.domain.EntityScan
+import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.data.jpa.repository.config.EnableJpaAuditing
 import org.springframework.data.jpa.repository.config.EnableJpaRepositories
@@ -9,4 +12,8 @@ import org.springframework.data.jpa.repository.config.EnableJpaRepositories
 @EnableJpaAuditing
 @EntityScan("com.ditto.domain")
 @EnableJpaRepositories("com.ditto.domain")
-open class DomainConfig
+open class DomainConfig {
+
+    @Bean
+    open fun jpaQueryFactory(entityManager: EntityManager) = JPAQueryFactory(entityManager)
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizSetRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizSetRepository.kt
@@ -1,13 +1,9 @@
 package com.ditto.domain.quiz.repository
 
 import com.ditto.domain.quiz.entity.QuizSet
+import com.ditto.domain.quiz.repository.querydsl.QuizSetRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import java.time.LocalDateTime
 
-interface QuizSetRepository : JpaRepository<QuizSet, Long> {
-    fun findByYearAndMonthAndWeekAndIsActiveTrue(year: Int, month: Int, week: Int): List<QuizSet>
-
-    @Query("SELECT qs FROM QuizSet qs WHERE qs.startDate <= :now AND qs.endDate >= :now AND qs.isActive = true")
-    fun findCurrentWeekActive(now: LocalDateTime): List<QuizSet>
-}
+interface QuizSetRepository :
+    JpaRepository<QuizSet, Long>,
+    QuizSetRepositoryCustom

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryCustom.kt
@@ -1,0 +1,8 @@
+package com.ditto.domain.quiz.repository.querydsl
+
+import com.ditto.domain.quiz.entity.QuizSet
+import java.time.LocalDateTime
+
+interface QuizSetRepositoryCustom {
+    fun findCurrentWeekActive(now: LocalDateTime): List<QuizSet>
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryImpl.kt
@@ -1,0 +1,21 @@
+package com.ditto.domain.quiz.repository.querydsl
+
+import com.ditto.domain.quiz.entity.QQuizSet.quizSet
+import com.ditto.domain.quiz.entity.QuizSet
+import com.querydsl.jpa.impl.JPAQueryFactory
+import java.time.LocalDateTime
+
+class QuizSetRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : QuizSetRepositoryCustom {
+
+    override fun findCurrentWeekActive(now: LocalDateTime): List<QuizSet> =
+        queryFactory
+            .selectFrom(quizSet)
+            .where(
+                quizSet.startDate.loe(now),
+                quizSet.endDate.goe(now),
+                quizSet.isActive.isTrue,
+            )
+            .fetch()
+}

--- a/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/RefreshTokenRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/RefreshTokenRepository.kt
@@ -1,17 +1,9 @@
 package com.ditto.domain.refreshtoken.repository
 
 import com.ditto.domain.refreshtoken.entity.RefreshToken
+import com.ditto.domain.refreshtoken.repository.querydsl.RefreshTokenRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Modifying
-import org.springframework.data.jpa.repository.Query
-import org.springframework.transaction.annotation.Transactional
 
-interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
-
+interface RefreshTokenRepository : JpaRepository<RefreshToken, Long>, RefreshTokenRepositoryCustom {
     fun findByToken(token: String): RefreshToken?
-
-    @Transactional
-    @Modifying
-    @Query("DELETE FROM RefreshToken r WHERE r.memberId = :memberId")
-    fun deleteAllByMemberId(memberId: Long)
 }

--- a/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/querydsl/RefreshTokenRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/querydsl/RefreshTokenRepositoryCustom.kt
@@ -1,0 +1,5 @@
+package com.ditto.domain.refreshtoken.repository.querydsl
+
+interface RefreshTokenRepositoryCustom {
+    fun deleteAllByMemberId(memberId: Long)
+}

--- a/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/querydsl/RefreshTokenRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/querydsl/RefreshTokenRepositoryImpl.kt
@@ -2,7 +2,9 @@ package com.ditto.domain.refreshtoken.repository.querydsl
 
 import com.ditto.domain.refreshtoken.entity.QRefreshToken.refreshToken
 import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.transaction.annotation.Transactional
 
+@Transactional
 class RefreshTokenRepositoryImpl(
     private val queryFactory: JPAQueryFactory,
 ) : RefreshTokenRepositoryCustom {

--- a/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/querydsl/RefreshTokenRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/refreshtoken/repository/querydsl/RefreshTokenRepositoryImpl.kt
@@ -1,0 +1,16 @@
+package com.ditto.domain.refreshtoken.repository.querydsl
+
+import com.ditto.domain.refreshtoken.entity.QRefreshToken.refreshToken
+import com.querydsl.jpa.impl.JPAQueryFactory
+
+class RefreshTokenRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : RefreshTokenRepositoryCustom {
+
+    override fun deleteAllByMemberId(memberId: Long) {
+        queryFactory
+            .delete(refreshToken)
+            .where(refreshToken.memberId.eq(memberId))
+            .execute()
+    }
+}

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizSetRepositoryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizSetRepositoryTest.kt
@@ -1,0 +1,97 @@
+package com.ditto.domain.quiz.repository
+
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.entity.MatchingType
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import javax.sql.DataSource
+
+class QuizSetRepositoryTest(
+    private val quizSetRepository: QuizSetRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    val now = LocalDateTime.of(2026, 4, 10, 12, 0)
+
+    "findCurrentWeekActive" - {
+        "현재 시간이 startDate~endDate 범위 안이고 활성이면 조회된다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = true),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 1
+        }
+
+        "비활성 퀴즈 세트는 조회되지 않는다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = false),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 0
+        }
+
+        "현재 시간이 startDate 이전이면 조회되지 않는다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.plusDays(1), endDate = now.plusDays(7), isActive = true),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 0
+        }
+
+        "현재 시간이 endDate 이후이면 조회되지 않는다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(7), endDate = now.minusDays(1), isActive = true),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 0
+        }
+
+        "경계값 - startDate와 같은 시간이면 조회된다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now, endDate = now.plusDays(7), isActive = true),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 1
+        }
+
+        "경계값 - endDate와 같은 시간이면 조회된다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(7), endDate = now, isActive = true),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 1
+        }
+
+        "여러 활성 퀴즈 세트가 있으면 모두 조회된다" {
+            quizSetRepository.save(
+                QuizSetFixture.create(
+                    startDate = now.minusDays(1), endDate = now.plusDays(1),
+                    matchingType = MatchingType.ONE_TO_ONE, category = "성격",
+                ),
+            )
+            quizSetRepository.save(
+                QuizSetFixture.create(
+                    startDate = now.minusDays(1), endDate = now.plusDays(1),
+                    matchingType = MatchingType.GROUP, category = "취미",
+                ),
+            )
+
+            val result = quizSetRepository.findCurrentWeekActive(now)
+
+            result.size shouldBe 2
+        }
+    }
+})

--- a/domain/src/test/kotlin/com/ditto/domain/refreshtoken/repository/RefreshTokenRepositoryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/refreshtoken/repository/RefreshTokenRepositoryTest.kt
@@ -1,0 +1,41 @@
+package com.ditto.domain.refreshtoken.repository
+
+import com.ditto.domain.refreshtoken.RefreshTokenFixture
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+class RefreshTokenRepositoryTest(
+    private val refreshTokenRepository: RefreshTokenRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    "deleteAllByMemberId" - {
+        "해당 memberId의 토큰이 모두 삭제된다" {
+            refreshTokenRepository.save(RefreshTokenFixture.create(memberId = 1L, token = "token-1"))
+            refreshTokenRepository.save(RefreshTokenFixture.create(memberId = 1L, token = "token-2"))
+            refreshTokenRepository.save(RefreshTokenFixture.create(memberId = 1L, token = "token-3"))
+
+            refreshTokenRepository.deleteAllByMemberId(1L)
+
+            refreshTokenRepository.findAll().size shouldBe 0
+        }
+
+        "다른 memberId의 토큰은 삭제되지 않는다" {
+            refreshTokenRepository.save(RefreshTokenFixture.create(memberId = 1L, token = "token-1"))
+            refreshTokenRepository.save(RefreshTokenFixture.create(memberId = 2L, token = "token-2"))
+
+            refreshTokenRepository.deleteAllByMemberId(1L)
+
+            val remaining = refreshTokenRepository.findAll()
+            remaining.size shouldBe 1
+            remaining[0].memberId shouldBe 2L
+        }
+
+        "해당 memberId의 토큰이 없어도 예외가 발생하지 않는다" {
+            refreshTokenRepository.deleteAllByMemberId(99999L)
+
+            refreshTokenRepository.findAll().size shouldBe 0
+        }
+    }
+})


### PR DESCRIPTION
## Summary
- QueryDSL 설정 추가 (OpenFeign 7.1, `JPAQueryFactory` Bean 등록)
- 기존 `@Query` JPQL을 QueryDSL Custom Repository로 마이그레이션
- 미사용 Repository 메서드 삭제

## 구현 내용

### QueryDSL 설정
- `io.github.openfeign.querydsl:7.1` 적용 (원본 `com.querydsl` 5.1.0은 유지보수 중단)
- `domain/build.gradle.kts`: `kotlin("kapt")` + `querydsl-jpa` + `querydsl-apt` 의존성
- `DomainConfig`: `JPAQueryFactory` Bean 등록

### @Query → QueryDSL 마이그레이션

| 기존 | 변경 |
|---|---|
| `QuizSetRepository.findCurrentWeekActive` (`@Query` JPQL) | `QuizSetRepositoryImpl` (QueryDSL `selectFrom().where().fetch()`) |
| `RefreshTokenRepository.deleteAllByMemberId` (`@Query` + `@Modifying`) | `RefreshTokenRepositoryImpl` (QueryDSL `delete().where().execute()`) |

### 패키지 구조
```
{도메인}/repository/
├── XxxRepository.kt              ← JpaRepository + Custom 상속
└── querydsl/
    ├── XxxRepositoryCustom.kt    ← QueryDSL 메서드 인터페이스
    └── XxxRepositoryImpl.kt      ← QueryDSL 구현체
```

### 삭제
- `QuizSetRepository.findByYearAndMonthAndWeekAndIsActiveTrue` — `findCurrentWeekActive`로 대체되어 미사용

## Test plan
- [x] 전체 테스트 통과 (`domain` + `api` 모듈)
- [x] Q클래스 정상 생성 (QQuizSet, QQuiz, QQuizChoice, QMember, QSocialAccount, QRefreshToken, QBaseEntity)
- [x] QueryDSL 기반 현재 주차 퀴즈셋 조회 정상 동작
- [x] QueryDSL 기반 리프레시 토큰 삭제 정상 동작

Closes #34

🤖 Generated with [Claude Code](https://claude.com/claude-code)