### PR TITLE
feat. 퀴즈 진행률 조회 API 구현 (#26)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/auth/dto/OAuthLoginResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/dto/OAuthLoginResponse.kt
@@ -1,8 +1,5 @@
 package com.ditto.api.auth.dto
 
-import com.fasterxml.jackson.annotation.JsonInclude
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class OAuthLoginResponse(
     val accessToken: String? = null,
     val refreshToken: String? = null,

--- a/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
@@ -1,10 +1,14 @@
 package com.ditto.api.quiz.controller
 
 import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.quiz.dto.QuizProgressResponse
+import com.ditto.api.quiz.dto.QuizSetWithProgressResponse
 import com.ditto.api.quiz.dto.SubmitAnswerRequest
 import com.ditto.api.quiz.service.QuizProgressService
 import com.ditto.common.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
@@ -21,5 +25,20 @@ class QuizProgressController(
     ): ApiResponse<Unit> {
         quizProgressService.submitAnswer(principal, request, LocalDateTime.now())
         return ApiResponse(success = true)
+    }
+
+    @GetMapping("/api/v1/quiz-progress/current")
+    fun getProgress(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<QuizProgressResponse> {
+        return ApiResponse.ok(quizProgressService.getProgress(principal, LocalDateTime.now()))
+    }
+
+    @GetMapping("/api/v1/quiz-progress/quiz-sets/{id}")
+    fun getQuizSetWithProgress(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @PathVariable id: Long,
+    ): ApiResponse<QuizSetWithProgressResponse> {
+        return ApiResponse.ok(quizProgressService.getQuizSetWithProgress(principal, id, LocalDateTime.now()))
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
@@ -34,6 +34,14 @@ class QuizProgressController(
         return ApiResponse.ok(quizProgressService.getProgress(principal, LocalDateTime.now()))
     }
 
+    @PostMapping("/api/v1/quiz-progress/reset")
+    fun resetProgress(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<Unit> {
+        quizProgressService.resetProgress(principal, LocalDateTime.now())
+        return ApiResponse(success = true)
+    }
+
     @GetMapping("/api/v1/quiz-progress/quiz-sets/{id}")
     fun getQuizSetWithProgress(
         @AuthenticationPrincipal principal: MemberPrincipal,

--- a/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizProgressResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizProgressResponse.kt
@@ -1,0 +1,25 @@
+package com.ditto.api.quiz.dto
+
+import com.ditto.domain.quiz.entity.QuizProgressStatus
+import com.fasterxml.jackson.annotation.JsonInclude
+
+@JsonInclude(JsonInclude.Include.NON_NULL)
+data class QuizProgressResponse(
+    val status: QuizProgressStatus,
+    val quizSetId: Long?,
+    val quizSetTitle: String?,
+    val totalQuizzes: Int?,
+    val answeredQuizzes: Int?,
+    val participantCount: Long,
+) {
+    companion object {
+        fun notStarted(participantCount: Long) = QuizProgressResponse(
+            status = QuizProgressStatus.NOT_STARTED,
+            quizSetId = null,
+            quizSetTitle = null,
+            totalQuizzes = null,
+            answeredQuizzes = null,
+            participantCount = participantCount,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizProgressResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizProgressResponse.kt
@@ -1,6 +1,7 @@
 package com.ditto.api.quiz.dto
 
 import com.ditto.domain.quiz.entity.QuizProgressStatus
+
 data class QuizProgressResponse(
     val status: QuizProgressStatus,
     val quizSetId: Long?,
@@ -10,13 +11,14 @@ data class QuizProgressResponse(
     val participantCount: Long,
 ) {
     companion object {
-        fun notStarted(participantCount: Long) = QuizProgressResponse(
-            status = QuizProgressStatus.NOT_STARTED,
-            quizSetId = null,
-            quizSetTitle = null,
-            totalQuizzes = null,
-            answeredQuizzes = null,
-            participantCount = participantCount,
-        )
+        fun notStarted(participantCount: Long) =
+            QuizProgressResponse(
+                status = QuizProgressStatus.NOT_STARTED,
+                quizSetId = null,
+                quizSetTitle = null,
+                totalQuizzes = null,
+                answeredQuizzes = null,
+                participantCount = participantCount,
+            )
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizProgressResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizProgressResponse.kt
@@ -1,9 +1,6 @@
 package com.ditto.api.quiz.dto
 
 import com.ditto.domain.quiz.entity.QuizProgressStatus
-import com.fasterxml.jackson.annotation.JsonInclude
-
-@JsonInclude(JsonInclude.Include.NON_NULL)
 data class QuizProgressResponse(
     val status: QuizProgressStatus,
     val quizSetId: Long?,

--- a/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizSetWithProgressResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/dto/QuizSetWithProgressResponse.kt
@@ -1,0 +1,34 @@
+package com.ditto.api.quiz.dto
+
+import com.ditto.domain.quiz.entity.Quiz
+import com.ditto.domain.quiz.entity.QuizChoice
+import java.time.LocalDateTime
+
+data class QuizSetWithProgressResponse(
+    val quizzes: List<QuizWithAnswerResponse>,
+    val totalCount: Int,
+)
+
+data class QuizWithAnswerResponse(
+    val id: Long,
+    val question: String,
+    val quizSetId: Long,
+    val choices: List<QuizChoiceResponse>,
+    val order: Int,
+    val createdAt: LocalDateTime,
+    val updatedAt: LocalDateTime,
+    val userAnswer: Long?,
+) {
+    companion object {
+        fun from(quiz: Quiz, choices: List<QuizChoice>, userAnswer: Long?) = QuizWithAnswerResponse(
+            id = quiz.id,
+            question = quiz.question,
+            quizSetId = quiz.quizSetId,
+            choices = choices.map { QuizChoiceResponse.from(it) },
+            order = quiz.displayOrder,
+            createdAt = quiz.createdAt,
+            updatedAt = quiz.updatedAt,
+            userAnswer = userAnswer,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -4,10 +4,12 @@ import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.api.quiz.dto.SubmitAnswerRequest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
-import com.ditto.common.exception.WarnException
+import com.ditto.domain.quiz.entity.Quiz
 import com.ditto.domain.quiz.entity.QuizAnswer
+import com.ditto.domain.quiz.entity.QuizProgress
 import com.ditto.domain.quiz.repository.QuizAnswerRepository
 import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizProgressRepository
 import com.ditto.domain.quiz.repository.QuizRepository
 import com.ditto.domain.quiz.repository.QuizSetRepository
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
@@ -18,6 +20,7 @@ import java.time.LocalDateTime
 @Service
 class QuizProgressService(
     private val quizAnswerRepository: QuizAnswerRepository,
+    private val quizProgressRepository: QuizProgressRepository,
     private val quizRepository: QuizRepository,
     private val quizChoiceRepository: QuizChoiceRepository,
     private val quizSetRepository: QuizSetRepository,
@@ -30,11 +33,21 @@ class QuizProgressService(
         now: LocalDateTime,
     ) {
         val memberId = resolveMemberId(principal)
+        val quiz = findQuiz(request.quizId)
 
-        validateQuizInActiveSet(request.quizId, now)
+        validateActiveQuizSet(quiz.quizSetId, now)
         validateChoice(request.quizId, request.choiceId)
 
-        upsertAnswer(memberId, request.quizId, request.choiceId)
+        val existingQuizAnswer = quizAnswerRepository.findByMemberIdAndQuizId(memberId, request.quizId)
+
+        if (existingQuizAnswer != null) {
+            existingQuizAnswer.changeChoice(request.choiceId)
+            quizAnswerRepository.save(existingQuizAnswer)
+            return
+        }
+
+        quizAnswerRepository.save(QuizAnswer.create(memberId, request.quizId, request.choiceId))
+        updateProgress(memberId, quiz.quizSetId)
     }
 
     private fun resolveMemberId(principal: MemberPrincipal): Long {
@@ -45,20 +58,22 @@ class QuizProgressService(
         return socialAccount.memberId
     }
 
-    private fun validateQuizInActiveSet(
-        quizId: Long,
+    private fun findQuiz(quizId: Long): Quiz =
+        quizRepository
+            .findById(quizId)
+            .orElseThrow { ErrorException(ErrorCode.NOT_FOUND) }
+
+    private fun validateActiveQuizSet(
+        quizSetId: Long,
         now: LocalDateTime,
     ) {
-        val quiz =
-            quizRepository
-                .findById(quizId)
-                .orElseThrow { ErrorException(ErrorCode.NOT_FOUND) }
         val quizSet =
             quizSetRepository
-                .findById(quiz.quizSetId)
+                .findById(quizSetId)
                 .orElseThrow { ErrorException(ErrorCode.NOT_FOUND) }
 
         val isInPeriod = now >= quizSet.startDate && now <= quizSet.endDate
+
         if (!quizSet.isActive || !isInPeriod) {
             throw ErrorException(ErrorCode.QUIZ_NOT_IN_ACTIVE_SET)
         }
@@ -69,25 +84,25 @@ class QuizProgressService(
         choiceId: Long,
     ) {
         val choices = quizChoiceRepository.findByQuizIdInOrderByDisplayOrderAsc(listOf(quizId))
-        val valid = choices.any { it.id == choiceId }
-        if (!valid) {
+        if (choices.none { it.id == choiceId }) {
             throw ErrorException(ErrorCode.INVALID_CHOICE)
         }
     }
 
-    private fun upsertAnswer(
+    private fun updateProgress(
         memberId: Long,
-        quizId: Long,
-        choiceId: Long,
+        quizSetId: Long,
     ) {
-        val existing = quizAnswerRepository.findByMemberIdAndQuizId(memberId, quizId)
-
-        if (existing != null) {
-            existing.changeChoice(choiceId)
+        val progress = quizProgressRepository.findByMemberIdAndQuizSetId(memberId, quizSetId)
+        if (progress != null) {
+            progress.recordAnswer()
             return
         }
 
-        val newQuizAnswer = QuizAnswer.create(memberId, quizId, choiceId)
-        quizAnswerRepository.save(newQuizAnswer)
+        val totalCount = quizRepository.countByQuizSetId(quizSetId).toInt()
+        val newProgress = QuizProgress.create(memberId, quizSetId, totalCount)
+
+        newProgress.recordAnswer()
+        quizProgressRepository.save(newProgress)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -144,6 +144,23 @@ class QuizProgressService(
         )
     }
 
+    @Transactional
+    fun resetProgress(principal: MemberPrincipal, now: LocalDateTime) {
+        val memberId = resolveMemberId(principal)
+        val quizSets = quizSetRepository.findCurrentWeekActive(now)
+
+        if (quizSets.isEmpty()) {
+            log.warn { "초기화 요청 시 활성 퀴즈셋 없음: memberId=$memberId" }
+            return
+        }
+
+        val quizSetIds = quizSets.map { it.id }
+        val quizIds = quizRepository.findByQuizSetIdInOrderByDisplayOrderAsc(quizSetIds).map { it.id }
+
+        quizAnswerRepository.deleteByMemberIdAndQuizIds(memberId, quizIds)
+        quizProgressRepository.deleteByMemberIdAndQuizSetIds(memberId, quizSetIds)
+    }
+
     private fun resolveMemberId(principal: MemberPrincipal): Long {
         val socialAccount =
             socialAccountRepository

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -1,21 +1,30 @@
 package com.ditto.api.quiz.service
 
 import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.quiz.dto.QuizProgressResponse
+import com.ditto.api.quiz.dto.QuizSetWithProgressResponse
+import com.ditto.api.quiz.dto.QuizWithAnswerResponse
 import com.ditto.api.quiz.dto.SubmitAnswerRequest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
 import com.ditto.domain.quiz.entity.Quiz
 import com.ditto.domain.quiz.entity.QuizAnswer
+import com.ditto.domain.quiz.entity.QuizChoice
 import com.ditto.domain.quiz.entity.QuizProgress
+import com.ditto.domain.quiz.entity.QuizProgressStatus
+import com.ditto.domain.quiz.entity.QuizSet
 import com.ditto.domain.quiz.repository.QuizAnswerRepository
 import com.ditto.domain.quiz.repository.QuizChoiceRepository
 import com.ditto.domain.quiz.repository.QuizProgressRepository
 import com.ditto.domain.quiz.repository.QuizRepository
 import com.ditto.domain.quiz.repository.QuizSetRepository
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+
+private val log = KotlinLogging.logger {}
 
 @Service
 class QuizProgressService(
@@ -48,6 +57,91 @@ class QuizProgressService(
 
         quizAnswerRepository.save(QuizAnswer.create(memberId, request.quizId, request.choiceId))
         updateProgress(memberId, quiz.quizSetId)
+    }
+
+    @Transactional(readOnly = true)
+    fun getProgress(
+        principal: MemberPrincipal,
+        now: LocalDateTime,
+    ): QuizProgressResponse {
+        val memberId = resolveMemberId(principal)
+        val quizSets = quizSetRepository.findCurrentWeekActive(now)
+
+        if (quizSets.isEmpty()) {
+            throw ErrorException(ErrorCode.NOT_FOUND)
+        }
+
+        val progress = findActiveProgress(memberId, quizSets)
+
+        val participantCount =
+            quizProgressRepository.countByQuizSetIdInAndStatus(
+                quizSetIds = quizSets.map { it.id },
+                status = QuizProgressStatus.COMPLETED,
+            )
+
+        if (progress == null) {
+            return QuizProgressResponse.notStarted(participantCount)
+        }
+
+        val selectedQuizSet =
+            quizSets
+                .find { it.id == progress.quizSetId }
+                ?: throw ErrorException(ErrorCode.INTERNAL_ERROR)
+
+        return QuizProgressResponse(
+            status = progress.status,
+            quizSetId = progress.quizSetId,
+            quizSetTitle = selectedQuizSet.title,
+            totalQuizzes = progress.totalCount,
+            answeredQuizzes = progress.answeredCount,
+            participantCount = participantCount,
+        )
+    }
+
+    private fun findActiveProgress(
+        memberId: Long,
+        quizSets: List<QuizSet>,
+    ): QuizProgress? {
+        val progresses =
+            quizSets
+                .map { it.id }
+                .let { quizSetIds -> quizProgressRepository.findByMemberIdAndQuizSetIdIn(memberId, quizSetIds) }
+
+        if (progresses.size > 1) {
+            log.error { "한 주에 여러 퀴즈셋에 참여한 사용자 발견: memberId=$memberId, quizSetIds=quizSetIds" }
+            throw ErrorException(ErrorCode.INTERNAL_ERROR)
+        }
+
+        return progresses.singleOrNull()
+    }
+
+    @Transactional(readOnly = true)
+    fun getQuizSetWithProgress(
+        principal: MemberPrincipal,
+        quizSetId: Long,
+        now: LocalDateTime,
+    ): QuizSetWithProgressResponse {
+        val memberId = resolveMemberId(principal)
+
+        validateActiveQuizSet(quizSetId, now)
+
+        val quizzes = quizRepository.findByQuizSetIdInOrderByDisplayOrderAsc(listOf(quizSetId))
+        val quizIds = quizzes.map { it.id }
+
+        val choicesByQuizId = findChoicesByQuizId(quizIds)
+        val answersByQuizId = findAnswersByQuizId(memberId, quizIds)
+
+        return QuizSetWithProgressResponse(
+            quizzes =
+                quizzes.map { quiz ->
+                    QuizWithAnswerResponse.from(
+                        quiz = quiz,
+                        choices = choicesByQuizId[quiz.id] ?: emptyList(),
+                        userAnswer = answersByQuizId[quiz.id]?.choiceId,
+                    )
+                },
+            totalCount = quizzes.size,
+        )
     }
 
     private fun resolveMemberId(principal: MemberPrincipal): Long {
@@ -104,5 +198,24 @@ class QuizProgressService(
 
         newProgress.recordAnswer()
         quizProgressRepository.save(newProgress)
+    }
+
+    private fun findChoicesByQuizId(quizIds: List<Long>): Map<Long, List<QuizChoice>> {
+        if (quizIds.isEmpty()) return emptyMap()
+
+        return quizChoiceRepository
+            .findByQuizIdInOrderByDisplayOrderAsc(quizIds)
+            .groupBy { it.quizId }
+    }
+
+    private fun findAnswersByQuizId(
+        memberId: Long,
+        quizIds: List<Long>,
+    ): Map<Long, QuizAnswer> {
+        if (quizIds.isEmpty()) return emptyMap()
+
+        return quizAnswerRepository
+            .findByMemberIdAndQuizIdIn(memberId, quizIds)
+            .associateBy { it.quizId }
     }
 }

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthControllerTest.kt
@@ -58,8 +58,8 @@ class OAuthControllerTest : RestDocsTest() {
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.accessToken").doesNotExist())
-            .andExpect(jsonPath("$.data.refreshToken").doesNotExist())
+            .andExpect(jsonPath("$.data.accessToken").isEmpty)
+            .andExpect(jsonPath("$.data.refreshToken").isEmpty)
             .andDo(
                 document(
                     "oauth-callback-new-user",
@@ -78,7 +78,8 @@ class OAuthControllerTest : RestDocsTest() {
                             )
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),
-                                fieldWithPath("data").description("빈 객체 (신규 사용자)"),
+                                fieldWithPath("data.accessToken").description("JWT 액세스 토큰 (신규 사용자는 null)"),
+                                fieldWithPath("data.refreshToken").description("리프레시 토큰 (신규 사용자는 null)"),
                                 fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
@@ -1,5 +1,7 @@
 package com.ditto.api.quiz
 
+import com.ditto.api.quiz.dto.SubmitAnswerRequest
+import com.ditto.api.quiz.service.QuizProgressService
 import com.ditto.api.support.RestDocsTest
 import com.ditto.domain.member.entity.Member
 import com.ditto.domain.member.repository.MemberRepository
@@ -23,12 +25,16 @@ import org.springframework.restdocs.operation.preprocess.Preprocessors.preproces
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
 import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import java.time.LocalDateTime
 
 class QuizProgressControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var quizProgressService: QuizProgressService
 
     @Autowired
     private lateinit var quizSetRepository: QuizSetRepository
@@ -90,6 +96,118 @@ class QuizProgressControllerTest : RestDocsTest() {
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),
                                 fieldWithPath("data").description("데이터 (답안 제출 시 null)"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("퀴즈 진행률을 조회한다")
+    fun getProgress() {
+        setupAuthenticatedMember()
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+        )
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+        val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+        quizProgressService.submitAnswer(
+            com.ditto.api.config.auth.MemberPrincipal("test-user", SocialProvider.KAKAO),
+            SubmitAnswerRequest(quiz.id, choice.id),
+            now,
+        )
+
+        mockMvc.perform(
+            get("/api/v1/quiz-progress/current")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("COMPLETED"))
+            .andExpect(jsonPath("$.data.participantCount").value(1))
+            .andDo(
+                document(
+                    "quiz-progress-current",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("QuizProgress")
+                            .summary("퀴즈 진행률 조회")
+                            .description("현재 주차의 퀴즈 진행 상태를 조회합니다.")
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.status").description("진행 상태 (NOT_STARTED, IN_PROGRESS, COMPLETED)"),
+                                fieldWithPath("data.quizSetId").description("참여 중인 퀴즈 세트 ID").optional(),
+                                fieldWithPath("data.quizSetTitle").description("참여 중인 퀴즈 세트 제목").optional(),
+                                fieldWithPath("data.totalQuizzes").description("전체 퀴즈 수").optional(),
+                                fieldWithPath("data.answeredQuizzes").description("답변한 퀴즈 수").optional(),
+                                fieldWithPath("data.participantCount").description("완료한 참여자 수"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("퀴즈셋의 문제와 답변을 조회한다")
+    fun getQuizSetWithProgress() {
+        setupAuthenticatedMember()
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+        )
+        val quiz1 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "첫번째", displayOrder = 1))
+        val quiz2 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "두번째", displayOrder = 2))
+        val choice1 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id, content = "A", displayOrder = 1))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id, content = "B", displayOrder = 2))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "C", displayOrder = 1))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "D", displayOrder = 2))
+
+        quizProgressService.submitAnswer(
+            com.ditto.api.config.auth.MemberPrincipal("test-user", SocialProvider.KAKAO),
+            SubmitAnswerRequest(quiz1.id, choice1.id),
+            now,
+        )
+
+        mockMvc.perform(
+            get("/api/v1/quiz-progress/quiz-sets/{id}", quizSet.id)
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.totalCount").value(2))
+            .andExpect(jsonPath("$.data.quizzes[0].userAnswer").value(choice1.id.toInt()))
+            .andExpect(jsonPath("$.data.quizzes[1].userAnswer").isEmpty)
+            .andDo(
+                document(
+                    "quiz-progress-quiz-set-with-progress",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("QuizProgress")
+                            .summary("퀴즈셋 + 답변 조회")
+                            .description("퀴즈셋의 문제 목록과 사용자의 답변을 함께 조회합니다. 이어풀기에 사용됩니다.")
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.totalCount").description("전체 퀴즈 수"),
+                                fieldWithPath("data.quizzes[].id").description("퀴즈 ID"),
+                                fieldWithPath("data.quizzes[].question").description("퀴즈 질문"),
+                                fieldWithPath("data.quizzes[].quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.quizzes[].order").description("퀴즈 순서"),
+                                fieldWithPath("data.quizzes[].createdAt").description("생성일시"),
+                                fieldWithPath("data.quizzes[].updatedAt").description("수정일시"),
+                                fieldWithPath("data.quizzes[].choices[].id").description("선택지 ID"),
+                                fieldWithPath("data.quizzes[].choices[].content").description("선택지 내용"),
+                                fieldWithPath("data.quizzes[].choices[].order").description("선택지 순서"),
+                                fieldWithPath("data.quizzes[].userAnswer").description("사용자가 선택한 choiceId (미답변 시 null)").optional(),
                                 fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
@@ -261,4 +261,48 @@ class QuizProgressControllerTest : RestDocsTest() {
             .andExpect(jsonPath("$.success").value(false))
             .andExpect(jsonPath("$.error.code").value("4002"))
     }
+
+    @Test
+    @DisplayName("퀴즈 진행을 초기화한다")
+    fun resetProgress() {
+        setupAuthenticatedMember()
+        val quizSet = quizSetRepository.save(
+            QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+        )
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+        val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+        quizProgressService.submitAnswer(
+            com.ditto.api.config.auth.MemberPrincipal("test-user", SocialProvider.KAKAO),
+            SubmitAnswerRequest(quiz.id, choice.id),
+            now,
+        )
+
+        mockMvc.perform(
+            post("/api/v1/quiz-progress/reset")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andDo(
+                document(
+                    "quiz-progress-reset",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("QuizProgress")
+                            .summary("퀴즈 진행 초기화")
+                            .description("이번 주차의 퀴즈 답변과 진행 상태를 모두 초기화합니다.")
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data").description("데이터 (초기화 시 null)"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
 }

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
@@ -14,6 +14,7 @@ import com.ditto.domain.quiz.QuizSetFixture
 import com.ditto.domain.quiz.entity.QuizProgressStatus
 import com.ditto.domain.quiz.repository.QuizAnswerRepository
 import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizProgressRepository
 import com.ditto.domain.quiz.repository.QuizRepository
 import com.ditto.domain.quiz.repository.QuizSetRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
@@ -31,6 +32,7 @@ class QuizProgressServiceTest(
     private val quizRepository: QuizRepository,
     private val quizChoiceRepository: QuizChoiceRepository,
     private val quizAnswerRepository: QuizAnswerRepository,
+    private val quizProgressRepository: QuizProgressRepository,
     private val memberRepository: MemberRepository,
     private val socialAccountRepository: SocialAccountRepository,
     dataSource: DataSource,
@@ -256,6 +258,75 @@ class QuizProgressServiceTest(
                 quizProgressService.getQuizSetWithProgress(principal, 99999L, now)
             }
             exception.errorCode shouldBe ErrorCode.NOT_FOUND
+        }
+    }
+
+    "퀴즈 진행 초기화" - {
+        "초기화하면 답변과 진행 상태가 모두 삭제된다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+
+            quizAnswerRepository.findAll().size shouldBe 1
+            quizProgressRepository.findAll().size shouldBe 1
+
+            quizProgressService.resetProgress(principal, now)
+
+            quizAnswerRepository.findAll().size shouldBe 0
+            quizProgressRepository.findAll().size shouldBe 0
+        }
+
+        "초기화 후 진행률 조회하면 NOT_STARTED를 반환한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.resetProgress(principal, now)
+
+            val result = quizProgressService.getProgress(principal, now)
+            result.status shouldBe QuizProgressStatus.NOT_STARTED
+        }
+
+        "답변이 없어도 초기화 호출 시 예외가 발생하지 않는다" {
+            val principal = setupMember()
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+
+            quizProgressService.resetProgress(principal, now)
+        }
+
+        "활성 퀴즈셋이 없어도 초기화 호출 시 예외가 발생하지 않는다" {
+            val principal = setupMember()
+
+            quizProgressService.resetProgress(principal, now)
+        }
+
+        "다른 사용자의 답변은 초기화되지 않는다" {
+            val principal1 = setupMember("user-1")
+            val principal2 = setupMember("user-2")
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            quizProgressService.submitAnswer(principal1, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(principal2, SubmitAnswerRequest(quiz.id, choice.id), now)
+
+            quizProgressService.resetProgress(principal1, now)
+
+            quizAnswerRepository.findAll().size shouldBe 1
+            quizProgressRepository.findAll().size shouldBe 1
         }
     }
 })

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
@@ -6,12 +6,12 @@ import com.ditto.api.quiz.service.QuizProgressService
 import com.ditto.api.support.IntegrationTest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
-import com.ditto.common.exception.WarnException
 import com.ditto.domain.member.entity.Member
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.quiz.QuizChoiceFixture
 import com.ditto.domain.quiz.QuizFixture
 import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.entity.QuizProgressStatus
 import com.ditto.domain.quiz.repository.QuizAnswerRepository
 import com.ditto.domain.quiz.repository.QuizChoiceRepository
 import com.ditto.domain.quiz.repository.QuizRepository
@@ -38,10 +38,10 @@ class QuizProgressServiceTest(
 
     val now = LocalDateTime.now()
 
-    fun setupMember(): MemberPrincipal {
-        val member = memberRepository.save(Member(nickname = "테스트유저"))
-        socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "test-user"))
-        return MemberPrincipal(providerUserId = "test-user", provider = SocialProvider.KAKAO)
+    fun setupMember(providerUserId: String = "test-user"): MemberPrincipal {
+        val member = memberRepository.save(Member(nickname = "테스트유저-$providerUserId"))
+        socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, providerUserId))
+        return MemberPrincipal(providerUserId = providerUserId, provider = SocialProvider.KAKAO)
     }
 
     fun setupActiveQuizData(): Triple<Long, Long, Long> {
@@ -133,6 +133,129 @@ class QuizProgressServiceTest(
                 quizProgressService.submitAnswer(unknownPrincipal, SubmitAnswerRequest(quizId, choiceId), now)
             }
             exception.errorCode shouldBe ErrorCode.UNAUTHORIZED_ERROR
+        }
+    }
+
+    "퀴즈 진행률 조회" - {
+        "퀴즈를 풀지 않았으면 NOT_STARTED를 반환한다" {
+            val principal = setupMember()
+            quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+
+            val result = quizProgressService.getProgress(principal, now)
+
+            result.status shouldBe QuizProgressStatus.NOT_STARTED
+            result.quizSetId shouldBe null
+        }
+
+        "퀴즈를 일부 풀었으면 IN_PROGRESS를 반환한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz1 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, displayOrder = 1))
+            quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "두번째", displayOrder = 2))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id))
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz1.id, choice.id), now)
+
+            val result = quizProgressService.getProgress(principal, now)
+
+            result.status shouldBe QuizProgressStatus.IN_PROGRESS
+            result.quizSetId shouldBe quizSet.id
+            result.totalQuizzes shouldBe 2
+            result.answeredQuizzes shouldBe 1
+        }
+
+        "퀴즈를 모두 풀었으면 COMPLETED를 반환한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+
+            val result = quizProgressService.getProgress(principal, now)
+
+            result.status shouldBe QuizProgressStatus.COMPLETED
+            result.quizSetId shouldBe quizSet.id
+            result.totalQuizzes shouldBe 1
+            result.answeredQuizzes shouldBe 1
+        }
+
+        "participantCount가 정확하게 계산된다" {
+            val principal1 = setupMember("user-1")
+            val principal2 = setupMember("user-2")
+            setupMember("user-3")
+
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            quizProgressService.submitAnswer(principal1, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(principal2, SubmitAnswerRequest(quiz.id, choice.id), now)
+
+            val result = quizProgressService.getProgress(principal1, now)
+
+            result.participantCount shouldBe 2
+        }
+
+        "활성 퀴즈셋이 없으면 예외가 발생한다" {
+            val principal = setupMember()
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.getProgress(principal, now)
+            }
+            exception.errorCode shouldBe ErrorCode.NOT_FOUND
+        }
+    }
+
+    "퀴즈셋 + 답변 조회" - {
+        "퀴즈와 답변을 함께 조회한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz1 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "첫번째", displayOrder = 1))
+            val quiz2 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "두번째", displayOrder = 2))
+            val choice1 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id, content = "A", displayOrder = 1))
+            quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id, content = "B", displayOrder = 2))
+            quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "C", displayOrder = 1))
+            quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "D", displayOrder = 2))
+
+            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz1.id, choice1.id), now)
+
+            val result = quizProgressService.getQuizSetWithProgress(principal, quizSet.id, now)
+
+            result.totalCount shouldBe 2
+            result.quizzes[0].userAnswer shouldBe choice1.id
+            result.quizzes[1].userAnswer shouldBe null
+        }
+
+        "비활성 퀴즈셋을 조회하면 예외가 발생한다" {
+            val principal = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = false),
+            )
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.getQuizSetWithProgress(principal, quizSet.id, now)
+            }
+            exception.errorCode shouldBe ErrorCode.QUIZ_NOT_IN_ACTIVE_SET
+        }
+
+        "존재하지 않는 퀴즈셋을 조회하면 예외가 발생한다" {
+            val principal = setupMember()
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.getQuizSetWithProgress(principal, 99999L, now)
+            }
+            exception.errorCode shouldBe ErrorCode.NOT_FOUND
         }
     }
 })

--- a/common/src/main/kotlin/com/ditto/common/serialization/ObjectMapperFactory.kt
+++ b/common/src/main/kotlin/com/ditto/common/serialization/ObjectMapperFactory.kt
@@ -40,7 +40,7 @@ object ObjectMapperFactory {
             registerModule(javaTimeModule)
             disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            setSerializationInclusion(JsonInclude.Include.ALWAYS)
+            setSerializationInclusion(JsonInclude.Include.NON_NULL)
         }
     }
 }

--- a/common/src/main/kotlin/com/ditto/common/serialization/ObjectMapperFactory.kt
+++ b/common/src/main/kotlin/com/ditto/common/serialization/ObjectMapperFactory.kt
@@ -40,7 +40,7 @@ object ObjectMapperFactory {
             registerModule(javaTimeModule)
             disable(SerializationFeature.WRITE_DATES_AS_TIMESTAMPS)
             disable(DeserializationFeature.FAIL_ON_UNKNOWN_PROPERTIES)
-            setSerializationInclusion(JsonInclude.Include.NON_NULL)
+            setSerializationInclusion(JsonInclude.Include.ALWAYS)
         }
     }
 }

--- a/domain/db/V20260413212142_퀴즈 진행 테이블 추가.sql
+++ b/domain/db/V20260413212142_퀴즈 진행 테이블 추가.sql
@@ -1,0 +1,14 @@
+CREATE TABLE quiz_progress
+(
+    id             BIGINT      NOT NULL AUTO_INCREMENT COMMENT '퀴즈 진행 ID',
+    member_id      BIGINT      NOT NULL COMMENT '회원 ID',
+    quiz_set_id    BIGINT      NOT NULL COMMENT '퀴즈 세트 ID',
+    status         VARCHAR(20) NOT NULL COMMENT '진행 상태 (NOT_STARTED, IN_PROGRESS, COMPLETED)',
+    answered_count INT         NOT NULL DEFAULT 0 COMMENT '답변한 퀴즈 수',
+    total_count    INT         NOT NULL COMMENT '전체 퀴즈 수',
+    created_at     DATETIME(6) NOT NULL COMMENT '생성 일시',
+    updated_at     DATETIME(6) NOT NULL COMMENT '수정 일시',
+    PRIMARY KEY (id),
+    UNIQUE KEY quiz_progress_uk_1 (member_id, quiz_set_id),
+    INDEX quiz_progress_index_1 (quiz_set_id, status)
+) COMMENT ='퀴즈 진행';

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizProgress.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizProgress.kt
@@ -1,0 +1,74 @@
+package com.ditto.domain.quiz.entity
+
+import com.ditto.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.EnumType
+import jakarta.persistence.Enumerated
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.Comment
+
+@Entity
+@Table(
+    name = "quiz_progress",
+    uniqueConstraints = [
+        UniqueConstraint(name = "quiz_progress_uk_1", columnNames = ["member_id", "quiz_set_id"]),
+    ],
+    indexes = [
+        Index(name = "quiz_progress_index_1", columnList = "quiz_set_id, status"),
+    ],
+)
+class QuizProgress private constructor(
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+    @Comment("회원 ID")
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+    @Comment("퀴즈 세트 ID")
+    @Column(name = "quiz_set_id", nullable = false)
+    val quizSetId: Long,
+    @Comment("전체 퀴즈 수")
+    @Column(name = "total_count", nullable = false)
+    val totalCount: Int,
+    status: QuizProgressStatus = QuizProgressStatus.NOT_STARTED,
+    answeredCount: Int = 0,
+) : BaseEntity() {
+
+    @Comment("진행 상태")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var status: QuizProgressStatus = status
+        protected set
+
+    @Comment("답변한 퀴즈 수")
+    @Column(name = "answered_count", nullable = false)
+    var answeredCount: Int = answeredCount
+        protected set
+
+    fun recordAnswer() {
+        answeredCount++
+        if (answeredCount >= totalCount) {
+            status = QuizProgressStatus.COMPLETED
+            return
+        }
+        status = QuizProgressStatus.IN_PROGRESS
+    }
+
+    companion object {
+        fun create(
+            memberId: Long,
+            quizSetId: Long,
+            totalCount: Int,
+        ): QuizProgress = QuizProgress(
+            memberId = memberId,
+            quizSetId = quizSetId,
+            totalCount = totalCount,
+        )
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizProgressStatus.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizProgressStatus.kt
@@ -1,0 +1,7 @@
+package com.ditto.domain.quiz.entity
+
+enum class QuizProgressStatus {
+    NOT_STARTED,
+    IN_PROGRESS,
+    COMPLETED,
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long> {
     fun findByMemberIdAndQuizId(memberId: Long, quizId: Long): QuizAnswer?
+    fun findByMemberIdAndQuizIdIn(memberId: Long, quizIds: List<Long>): List<QuizAnswer>
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
@@ -1,9 +1,10 @@
 package com.ditto.domain.quiz.repository
 
 import com.ditto.domain.quiz.entity.QuizAnswer
+import com.ditto.domain.quiz.repository.querydsl.QuizAnswerRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long> {
+interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long>, QuizAnswerRepositoryCustom {
     fun findByMemberIdAndQuizId(memberId: Long, quizId: Long): QuizAnswer?
     fun findByMemberIdAndQuizIdIn(memberId: Long, quizIds: List<Long>): List<QuizAnswer>
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
@@ -5,6 +5,18 @@ import com.ditto.domain.quiz.entity.QuizProgressStatus
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface QuizProgressRepository : JpaRepository<QuizProgress, Long> {
-    fun findByMemberIdAndQuizSetId(memberId: Long, quizSetId: Long): QuizProgress?
-    fun countByQuizSetIdInAndStatus(quizSetIds: List<Long>, status: QuizProgressStatus): Long
+    fun findByMemberIdAndQuizSetId(
+        memberId: Long,
+        quizSetId: Long,
+    ): QuizProgress?
+
+    fun findByMemberIdAndQuizSetIdIn(
+        memberId: Long,
+        quizSetIds: List<Long>,
+    ): List<QuizProgress>
+
+    fun countByQuizSetIdInAndStatus(
+        quizSetIds: List<Long>,
+        status: QuizProgressStatus,
+    ): Long
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
@@ -2,9 +2,10 @@ package com.ditto.domain.quiz.repository
 
 import com.ditto.domain.quiz.entity.QuizProgress
 import com.ditto.domain.quiz.entity.QuizProgressStatus
+import com.ditto.domain.quiz.repository.querydsl.QuizProgressRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
 
-interface QuizProgressRepository : JpaRepository<QuizProgress, Long> {
+interface QuizProgressRepository : JpaRepository<QuizProgress, Long>, QuizProgressRepositoryCustom {
     fun findByMemberIdAndQuizSetId(
         memberId: Long,
         quizSetId: Long,
@@ -19,4 +20,5 @@ interface QuizProgressRepository : JpaRepository<QuizProgress, Long> {
         quizSetIds: List<Long>,
         status: QuizProgressStatus,
     ): Long
+
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
@@ -1,0 +1,10 @@
+package com.ditto.domain.quiz.repository
+
+import com.ditto.domain.quiz.entity.QuizProgress
+import com.ditto.domain.quiz.entity.QuizProgressStatus
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface QuizProgressRepository : JpaRepository<QuizProgress, Long> {
+    fun findByMemberIdAndQuizSetId(memberId: Long, quizSetId: Long): QuizProgress?
+    fun countByQuizSetIdInAndStatus(quizSetIds: List<Long>, status: QuizProgressStatus): Long
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizRepository.kt
@@ -5,4 +5,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface QuizRepository : JpaRepository<Quiz, Long> {
     fun findByQuizSetIdInOrderByDisplayOrderAsc(quizSetIds: List<Long>): List<Quiz>
+    fun countByQuizSetId(quizSetId: Long): Long
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizAnswerRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizAnswerRepositoryCustom.kt
@@ -1,0 +1,5 @@
+package com.ditto.domain.quiz.repository.querydsl
+
+interface QuizAnswerRepositoryCustom {
+    fun deleteByMemberIdAndQuizIds(memberId: Long, quizIds: List<Long>)
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizAnswerRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizAnswerRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.ditto.domain.quiz.repository.querydsl
+
+import com.ditto.domain.quiz.entity.QQuizAnswer.quizAnswer
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class QuizAnswerRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : QuizAnswerRepositoryCustom {
+
+    override fun deleteByMemberIdAndQuizIds(memberId: Long, quizIds: List<Long>) {
+        if (quizIds.isEmpty()) return
+        queryFactory
+            .delete(quizAnswer)
+            .where(
+                quizAnswer.memberId.eq(memberId),
+                quizAnswer.quizId.`in`(quizIds),
+            )
+            .execute()
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizProgressRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizProgressRepositoryCustom.kt
@@ -1,0 +1,5 @@
+package com.ditto.domain.quiz.repository.querydsl
+
+interface QuizProgressRepositoryCustom {
+    fun deleteByMemberIdAndQuizSetIds(memberId: Long, quizSetIds: List<Long>)
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizProgressRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizProgressRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.ditto.domain.quiz.repository.querydsl
+
+import com.ditto.domain.quiz.entity.QQuizProgress.quizProgress
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional
+class QuizProgressRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : QuizProgressRepositoryCustom {
+
+    override fun deleteByMemberIdAndQuizSetIds(memberId: Long, quizSetIds: List<Long>) {
+        if (quizSetIds.isEmpty()) return
+        queryFactory
+            .delete(quizProgress)
+            .where(
+                quizProgress.memberId.eq(memberId),
+                quizProgress.quizSetId.`in`(quizSetIds),
+            )
+            .execute()
+    }
+}

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/entity/QuizProgressTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/entity/QuizProgressTest.kt
@@ -1,0 +1,108 @@
+package com.ditto.domain.quiz.entity
+
+import com.ditto.domain.quiz.QuizProgressFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.repository.QuizProgressRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import javax.sql.DataSource
+
+class QuizProgressTest(
+    private val quizSetRepository: QuizSetRepository,
+    private val quizProgressRepository: QuizProgressRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    "QuizProgress 생성" - {
+        "QuizProgress를 생성하고 저장할 수 있다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val progress = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id, totalCount = 5),
+            )
+
+            progress.id shouldNotBe 0L
+            progress.memberId shouldBe 1L
+            progress.quizSetId shouldBe quizSet.id
+            progress.totalCount shouldBe 5
+            progress.answeredCount shouldBe 0
+            progress.status shouldBe QuizProgressStatus.NOT_STARTED
+        }
+
+        "같은 memberId, quizSetId로 중복 저장하면 예외가 발생한다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id),
+            )
+
+            shouldThrow<Exception> {
+                quizProgressRepository.saveAndFlush(
+                    QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id),
+                )
+            }
+        }
+    }
+
+    "QuizProgress 상태 전이" - {
+        "recordAnswer() 호출 시 IN_PROGRESS로 변경된다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val progress = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id, totalCount = 3),
+            )
+
+            progress.recordAnswer()
+            quizProgressRepository.saveAndFlush(progress)
+
+            val found = quizProgressRepository.findByMemberIdAndQuizSetId(1L, quizSet.id)
+            found shouldNotBe null
+            found!!.answeredCount shouldBe 1
+            found.status shouldBe QuizProgressStatus.IN_PROGRESS
+        }
+
+        "모든 퀴즈에 답변하면 COMPLETED로 변경된다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val progress = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id, totalCount = 2),
+            )
+
+            progress.recordAnswer()
+            progress.recordAnswer()
+            quizProgressRepository.saveAndFlush(progress)
+
+            val found = quizProgressRepository.findByMemberIdAndQuizSetId(1L, quizSet.id)
+            found shouldNotBe null
+            found!!.answeredCount shouldBe 2
+            found.status shouldBe QuizProgressStatus.COMPLETED
+        }
+    }
+
+    "QuizProgressRepository" - {
+        "countByQuizSetIdInAndStatus로 완료한 사용자 수를 조회할 수 있다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+
+            val progress1 = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id, totalCount = 1),
+            )
+            progress1.recordAnswer()
+            quizProgressRepository.saveAndFlush(progress1)
+
+            val progress2 = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 2L, quizSetId = quizSet.id, totalCount = 1),
+            )
+            progress2.recordAnswer()
+            quizProgressRepository.saveAndFlush(progress2)
+
+            quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 3L, quizSetId = quizSet.id, totalCount = 2),
+            )
+
+            val count = quizProgressRepository.countByQuizSetIdInAndStatus(
+                listOf(quizSet.id),
+                QuizProgressStatus.COMPLETED,
+            )
+            count shouldBe 2
+        }
+    }
+})

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepositoryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepositoryTest.kt
@@ -1,0 +1,56 @@
+package com.ditto.domain.quiz.repository
+
+import com.ditto.domain.quiz.QuizAnswerFixture
+import com.ditto.domain.quiz.QuizChoiceFixture
+import com.ditto.domain.quiz.QuizFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+class QuizAnswerRepositoryTest(
+    private val quizSetRepository: QuizSetRepository,
+    private val quizRepository: QuizRepository,
+    private val quizChoiceRepository: QuizChoiceRepository,
+    private val quizAnswerRepository: QuizAnswerRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    "deleteByMemberIdAndQuizIds" - {
+        "해당 memberId와 quizIds의 답변이 벌크 삭제된다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val quiz1 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, displayOrder = 1))
+            val quiz2 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "두번째", displayOrder = 2))
+            val choice1 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id))
+            val choice2 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id))
+
+            quizAnswerRepository.save(QuizAnswerFixture.create(memberId = 1L, quizId = quiz1.id, choiceId = choice1.id))
+            quizAnswerRepository.save(QuizAnswerFixture.create(memberId = 1L, quizId = quiz2.id, choiceId = choice2.id))
+
+            quizAnswerRepository.deleteByMemberIdAndQuizIds(1L, listOf(quiz1.id, quiz2.id))
+
+            quizAnswerRepository.findAll().size shouldBe 0
+        }
+
+        "다른 memberId의 답변은 삭제되지 않는다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+
+            quizAnswerRepository.save(QuizAnswerFixture.create(memberId = 1L, quizId = quiz.id, choiceId = choice.id))
+            quizAnswerRepository.save(QuizAnswerFixture.create(memberId = 2L, quizId = quiz.id, choiceId = choice.id))
+
+            quizAnswerRepository.deleteByMemberIdAndQuizIds(1L, listOf(quiz.id))
+
+            val remaining = quizAnswerRepository.findAll()
+            remaining.size shouldBe 1
+            remaining[0].memberId shouldBe 2L
+        }
+
+        "빈 quizIds로 호출해도 예외가 발생하지 않는다" {
+            quizAnswerRepository.deleteByMemberIdAndQuizIds(1L, emptyList())
+
+            quizAnswerRepository.findAll().size shouldBe 0
+        }
+    }
+})

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepositoryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepositoryTest.kt
@@ -1,0 +1,47 @@
+package com.ditto.domain.quiz.repository
+
+import com.ditto.domain.quiz.QuizProgressFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+class QuizProgressRepositoryTest(
+    private val quizSetRepository: QuizSetRepository,
+    private val quizProgressRepository: QuizProgressRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    "deleteByMemberIdAndQuizSetIds" - {
+        "해당 memberId와 quizSetIds의 진행 상태가 벌크 삭제된다" {
+            val quizSet1 = quizSetRepository.save(QuizSetFixture.create(category = "성격"))
+            val quizSet2 = quizSetRepository.save(QuizSetFixture.create(category = "취미"))
+
+            quizProgressRepository.save(QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet1.id))
+            quizProgressRepository.save(QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet2.id))
+
+            quizProgressRepository.deleteByMemberIdAndQuizSetIds(1L, listOf(quizSet1.id, quizSet2.id))
+
+            quizProgressRepository.findAll().size shouldBe 0
+        }
+
+        "다른 memberId의 진행 상태는 삭제되지 않는다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+
+            quizProgressRepository.save(QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id))
+            quizProgressRepository.save(QuizProgressFixture.create(memberId = 2L, quizSetId = quizSet.id))
+
+            quizProgressRepository.deleteByMemberIdAndQuizSetIds(1L, listOf(quizSet.id))
+
+            val remaining = quizProgressRepository.findAll()
+            remaining.size shouldBe 1
+            remaining[0].memberId shouldBe 2L
+        }
+
+        "빈 quizSetIds로 호출해도 예외가 발생하지 않는다" {
+            quizProgressRepository.deleteByMemberIdAndQuizSetIds(1L, emptyList())
+
+            quizProgressRepository.findAll().size shouldBe 0
+        }
+    }
+})

--- a/domain/src/testFixtures/kotlin/com/ditto/domain/quiz/QuizProgressFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/ditto/domain/quiz/QuizProgressFixture.kt
@@ -1,0 +1,18 @@
+package com.ditto.domain.quiz
+
+import com.ditto.domain.quiz.entity.QuizProgress
+import com.ditto.domain.withId
+
+object QuizProgressFixture {
+
+    fun create(
+        memberId: Long = 1L,
+        quizSetId: Long = 1L,
+        totalCount: Int = 5,
+        id: Long = 0L,
+    ): QuizProgress = QuizProgress.create(
+        memberId = memberId,
+        quizSetId = quizSetId,
+        totalCount = totalCount,
+    ).withId(id)
+}


### PR DESCRIPTION
## Summary
- 퀴즈 진행률 조회 API 2개 구현 (`GET /api/v1/quiz-progress/current`, `GET /api/v1/quiz-progress/quiz-sets/{id}`)
- 퀴즈 진행 초기화 API 구현 (`POST /api/v1/quiz-progress/reset`)
- `QuizProgress` 엔티티 추가 — 쓰기 시점에 상태를 갱신하고 읽기는 단순 조회
- `submitAnswer`에 quiz_progress 연동 추가
- QueryDSL 벌크 DELETE Repository 추가

## 구현 내용

### 도메인 (`domain`)
- `QuizProgress` 엔티티 (memberId, quizSetId, status, answeredCount, totalCount)
- `QuizProgressStatus` enum (NOT_STARTED, IN_PROGRESS, COMPLETED)
- `QuizProgressRepository` (findByMemberIdAndQuizSetId, findByMemberIdAndQuizSetIdIn, countByQuizSetIdInAndStatus)
- `QuizAnswerRepository` — `findByMemberIdAndQuizIdIn` 추가
- `QuizRepository` — `countByQuizSetId` 추가
- QueryDSL 벌크 DELETE: `QuizAnswerRepositoryImpl.deleteByMemberIdAndQuizIds`, `QuizProgressRepositoryImpl.deleteByMemberIdAndQuizSetIds`
- DDL: `V20260413_퀴즈 진행 테이블 추가.sql`

### API (`api`)
- `GET /api/v1/quiz-progress/current` — 홈 화면용 진행률 (status + participantCount)
  - NOT_STARTED: nullable 필드는 JSON에서 제외 (`@JsonInclude(NON_NULL)`)
  - IN_PROGRESS/COMPLETED: quizSetId, quizSetTitle, totalQuizzes, answeredQuizzes 포함
- `GET /api/v1/quiz-progress/quiz-sets/{id}` — 퀴즈셋 + 내 답변 (이어풀기용)
  - 활성 퀴즈셋 검증 (`validateActiveQuizSet` 재사용)
  - `userAnswer: Long?` (선택한 choiceId 또는 null)
- `POST /api/v1/quiz-progress/reset` — 이번 주 퀴즈 진행 초기화
  - QuizAnswer + QuizProgress 벌크 삭제
  - idempotent (활성 퀴즈셋/답변 없어도 정상 응답)
- `submitAnswer` 수정: 새 답변 시 `QuizProgress` 생성/갱신 (`recordAnswer()`)

### 설계 결정
- **quiz_progress 테이블 도입**: 매 요청마다 QuizAnswer 집계 대신, 쓰기 시점에 상태 갱신 → 읽기 성능 최적화
- **participantCount**: `COUNT WHERE status = COMPLETED` 인덱스 쿼리로 처리
- **한 주 하나의 퀴즈셋**: `singleOrNull()` + 위반 시 에러 로그 + INTERNAL_ERROR
- **userAnswer 심플화**: `QuizAnswerResponse` 객체 대신 `choiceId: Long?` 만 반환
- **벌크 DELETE**: QueryDSL로 N+1 DELETE 방지

### 테스트
- 도메인 테스트: QuizProgress 생성, 상태 전이, participantCount 조회, 벌크 DELETE
- 통합 테스트: 진행률 상태별 검증, participantCount, 퀴즈셋+답변 조회, 초기화 후 NOT_STARTED 확인, idempotent 검증
- 문서화 테스트: 4개 엔드포인트 RestDocs

## Test plan
- [x] NOT_STARTED — 퀴즈 안 풀었을 때 status 확인
- [x] IN_PROGRESS — 일부만 풀었을 때 status + answeredQuizzes 확인
- [x] COMPLETED — 모두 풀었을 때 status 확인
- [x] participantCount — 여러 사용자 중 완료자 수 정확성
- [x] 활성 퀴즈셋 없을 때 예외 (NOT_FOUND)
- [x] 퀴즈셋+답변 조회 — userAnswer 있는/없는 quiz
- [x] 비활성 퀴즈셋 조회 시 예외 (QUIZ_NOT_IN_ACTIVE_SET)
- [x] submitAnswer 후 progress 자동 갱신 확인
- [x] 초기화 시 답변 + progress 모두 삭제
- [x] 초기화 후 getProgress → NOT_STARTED
- [x] 초기화 idempotent (답변/퀴즈셋 없어도 정상)
- [x] 다른 사용자 답변 보존
- [x] 벌크 DELETE 정상 동작 (QuizAnswer, QuizProgress)

Closes #26
Closes #27

🤖 Generated with [Claude Code](https://claude.com/claude-code)