### PR TITLE
refactor. JWT에 memberId 포함 및 SocialAccount 조회 제거 (#37)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/controller/AuthController.kt
@@ -24,7 +24,7 @@ class AuthController(
 
     @PostMapping("/api/v1/users/auth/logout")
     fun logout(@AuthenticationPrincipal principal: MemberPrincipal): ApiResponse<Unit> {
-        authService.logout(principal.provider, principal.providerUserId)
+        authService.logout(principal.memberId)
         return ApiResponse(success = true)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
@@ -26,10 +26,7 @@ class OAuthFacade(
             return OAuthLoginResponse()
         }
 
-        val accessToken = jwtTokenProvider.generateAccessToken(
-            providerUserId = userInfo.id,
-            provider = provider,
-        )
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id)
         val refreshToken = authService.createRefreshToken(member.id)
         return OAuthLoginResponse(accessToken = accessToken, refreshToken = refreshToken.token)
     }

--- a/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
@@ -8,8 +8,6 @@ import com.ditto.common.exception.ErrorException
 import com.ditto.common.exception.WarnException
 import com.ditto.domain.refreshtoken.entity.RefreshToken
 import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
-import com.ditto.domain.socialaccount.entity.SocialProvider
-import com.ditto.domain.socialaccount.repository.SocialAccountRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
@@ -17,7 +15,6 @@ import org.springframework.transaction.annotation.Transactional
 class AuthService(
     private val jwtTokenProvider: JwtTokenProvider,
     private val refreshTokenRepository: RefreshTokenRepository,
-    private val socialAccountRepository: SocialAccountRepository,
 ) {
 
     @Transactional
@@ -33,10 +30,8 @@ class AuthService(
     }
 
     @Transactional
-    fun logout(provider: SocialProvider, providerUserId: String) {
-        val socialAccount = socialAccountRepository.findByProviderAndProviderUserId(provider, providerUserId)
-            ?: throw ErrorException(ErrorCode.UNAUTHORIZED_ERROR)
-        refreshTokenRepository.deleteAllByMemberId(socialAccount.memberId)
+    fun logout(memberId: Long) {
+        refreshTokenRepository.deleteAllByMemberId(memberId)
     }
 
     @Transactional
@@ -49,13 +44,7 @@ class AuthService(
 
         refreshTokenRepository.delete(refreshToken)
 
-        val socialAccount = socialAccountRepository.findByMemberId(refreshToken.memberId)
-            ?: throw ErrorException(ErrorCode.INTERNAL_ERROR)
-
-        val newAccessToken = jwtTokenProvider.generateAccessToken(
-            providerUserId = socialAccount.providerUserId,
-            provider = socialAccount.provider,
-        )
+        val newAccessToken = jwtTokenProvider.generateAccessToken(refreshToken.memberId)
         val newRefreshToken = createRefreshToken(refreshToken.memberId)
 
         return TokenRefreshResponse(

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
@@ -45,8 +45,7 @@ class JwtAuthenticationFilter(
     private fun setAuthentication(token: String) {
         val principal =
             MemberPrincipal(
-                providerUserId = jwtTokenProvider.getProviderUserId(token),
-                provider = jwtTokenProvider.getProvider(token),
+                memberId = jwtTokenProvider.getMemberId(token),
             )
 
         val authentication =

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtTokenProvider.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.config.auth
 
-import com.ditto.domain.socialaccount.entity.SocialProvider
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.stereotype.Component
@@ -21,21 +20,17 @@ class JwtTokenProvider(
         Jwts.parser().verifyWith(key).build()
     }
 
-    fun generateAccessToken(providerUserId: String, provider: SocialProvider, now: Date = Date()): String {
+    fun generateAccessToken(memberId: Long, now: Date = Date()): String {
         return Jwts.builder()
-            .subject(providerUserId)
-            .claim(CLAIM_PROVIDER, provider.name)
+            .subject(memberId.toString())
             .issuedAt(now)
             .expiration(Date(now.time + jwtProperties.expirationMs))
             .signWith(key)
             .compact()
     }
 
-    fun getProviderUserId(token: String): String =
-        parser.parseSignedClaims(token).payload.subject
-
-    fun getProvider(token: String): SocialProvider =
-        SocialProvider.valueOf(parser.parseSignedClaims(token).payload[CLAIM_PROVIDER, String::class.java])
+    fun getMemberId(token: String): Long =
+        parser.parseSignedClaims(token).payload.subject.toLong()
 
     fun isValid(token: String): Boolean =
         try {
@@ -49,8 +44,4 @@ class JwtTokenProvider(
 
     fun createRefreshTokenExpiresAt(now: LocalDateTime = LocalDateTime.now()): LocalDateTime =
         now.plusSeconds(jwtProperties.refreshExpirationMs / 1_000)
-
-    companion object {
-        private const val CLAIM_PROVIDER = "provider"
-    }
 }

--- a/api/src/main/kotlin/com/ditto/api/config/auth/MemberPrincipal.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/MemberPrincipal.kt
@@ -1,8 +1,5 @@
 package com.ditto.api.config.auth
 
-import com.ditto.domain.socialaccount.entity.SocialProvider
-
 data class MemberPrincipal(
-    val providerUserId: String,
-    val provider: SocialProvider,
+    val memberId: Long,
 )

--- a/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/controller/QuizProgressController.kt
@@ -23,7 +23,7 @@ class QuizProgressController(
         @AuthenticationPrincipal principal: MemberPrincipal,
         @RequestBody request: SubmitAnswerRequest,
     ): ApiResponse<Unit> {
-        quizProgressService.submitAnswer(principal, request, LocalDateTime.now())
+        quizProgressService.submitAnswer(principal.memberId, request, LocalDateTime.now())
         return ApiResponse(success = true)
     }
 
@@ -31,14 +31,14 @@ class QuizProgressController(
     fun getProgress(
         @AuthenticationPrincipal principal: MemberPrincipal,
     ): ApiResponse<QuizProgressResponse> {
-        return ApiResponse.ok(quizProgressService.getProgress(principal, LocalDateTime.now()))
+        return ApiResponse.ok(quizProgressService.getProgress(principal.memberId, LocalDateTime.now()))
     }
 
     @PostMapping("/api/v1/quiz-progress/reset")
     fun resetProgress(
         @AuthenticationPrincipal principal: MemberPrincipal,
     ): ApiResponse<Unit> {
-        quizProgressService.resetProgress(principal, LocalDateTime.now())
+        quizProgressService.resetProgress(principal.memberId, LocalDateTime.now())
         return ApiResponse(success = true)
     }
 
@@ -47,6 +47,6 @@ class QuizProgressController(
         @AuthenticationPrincipal principal: MemberPrincipal,
         @PathVariable id: Long,
     ): ApiResponse<QuizSetWithProgressResponse> {
-        return ApiResponse.ok(quizProgressService.getQuizSetWithProgress(principal, id, LocalDateTime.now()))
+        return ApiResponse.ok(quizProgressService.getQuizSetWithProgress(principal.memberId, id, LocalDateTime.now()))
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.quiz.service
 
-import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.api.quiz.dto.QuizProgressResponse
 import com.ditto.api.quiz.dto.QuizSetWithProgressResponse
 import com.ditto.api.quiz.dto.QuizWithAnswerResponse
@@ -35,11 +34,10 @@ class QuizProgressService(
 ) {
     @Transactional
     fun submitAnswer(
-        principal: MemberPrincipal,
+        memberId: Long,
         request: SubmitAnswerRequest,
         now: LocalDateTime,
     ) {
-        val memberId = principal.memberId
         val quiz = findQuiz(request.quizId)
 
         validateActiveQuizSet(quiz.quizSetId, now)
@@ -59,10 +57,9 @@ class QuizProgressService(
 
     @Transactional(readOnly = true)
     fun getProgress(
-        principal: MemberPrincipal,
+        memberId: Long,
         now: LocalDateTime,
     ): QuizProgressResponse {
-        val memberId = principal.memberId
         val quizSets = quizSetRepository.findCurrentWeekActive(now)
 
         if (quizSets.isEmpty()) {
@@ -115,11 +112,10 @@ class QuizProgressService(
 
     @Transactional(readOnly = true)
     fun getQuizSetWithProgress(
-        principal: MemberPrincipal,
+        memberId: Long,
         quizSetId: Long,
         now: LocalDateTime,
     ): QuizSetWithProgressResponse {
-        val memberId = principal.memberId
 
         validateActiveQuizSet(quizSetId, now)
 
@@ -143,8 +139,7 @@ class QuizProgressService(
     }
 
     @Transactional
-    fun resetProgress(principal: MemberPrincipal, now: LocalDateTime) {
-        val memberId = principal.memberId
+    fun resetProgress(memberId: Long, now: LocalDateTime) {
         val quizSets = quizSetRepository.findCurrentWeekActive(now)
 
         if (quizSets.isEmpty()) {

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -18,7 +18,6 @@ import com.ditto.domain.quiz.repository.QuizChoiceRepository
 import com.ditto.domain.quiz.repository.QuizProgressRepository
 import com.ditto.domain.quiz.repository.QuizRepository
 import com.ditto.domain.quiz.repository.QuizSetRepository
-import com.ditto.domain.socialaccount.repository.SocialAccountRepository
 import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
@@ -33,7 +32,6 @@ class QuizProgressService(
     private val quizRepository: QuizRepository,
     private val quizChoiceRepository: QuizChoiceRepository,
     private val quizSetRepository: QuizSetRepository,
-    private val socialAccountRepository: SocialAccountRepository,
 ) {
     @Transactional
     fun submitAnswer(
@@ -41,7 +39,7 @@ class QuizProgressService(
         request: SubmitAnswerRequest,
         now: LocalDateTime,
     ) {
-        val memberId = resolveMemberId(principal)
+        val memberId = principal.memberId
         val quiz = findQuiz(request.quizId)
 
         validateActiveQuizSet(quiz.quizSetId, now)
@@ -64,7 +62,7 @@ class QuizProgressService(
         principal: MemberPrincipal,
         now: LocalDateTime,
     ): QuizProgressResponse {
-        val memberId = resolveMemberId(principal)
+        val memberId = principal.memberId
         val quizSets = quizSetRepository.findCurrentWeekActive(now)
 
         if (quizSets.isEmpty()) {
@@ -121,7 +119,7 @@ class QuizProgressService(
         quizSetId: Long,
         now: LocalDateTime,
     ): QuizSetWithProgressResponse {
-        val memberId = resolveMemberId(principal)
+        val memberId = principal.memberId
 
         validateActiveQuizSet(quizSetId, now)
 
@@ -146,7 +144,7 @@ class QuizProgressService(
 
     @Transactional
     fun resetProgress(principal: MemberPrincipal, now: LocalDateTime) {
-        val memberId = resolveMemberId(principal)
+        val memberId = principal.memberId
         val quizSets = quizSetRepository.findCurrentWeekActive(now)
 
         if (quizSets.isEmpty()) {
@@ -159,14 +157,6 @@ class QuizProgressService(
 
         quizAnswerRepository.deleteByMemberIdAndQuizIds(memberId, quizIds)
         quizProgressRepository.deleteByMemberIdAndQuizSetIds(memberId, quizSetIds)
-    }
-
-    private fun resolveMemberId(principal: MemberPrincipal): Long {
-        val socialAccount =
-            socialAccountRepository
-                .findByProviderAndProviderUserId(principal.provider, principal.providerUserId)
-                ?: throw ErrorException(ErrorCode.UNAUTHORIZED_ERROR)
-        return socialAccount.memberId
     }
 
     private fun findQuiz(quizId: Long): Quiz =

--- a/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
@@ -37,7 +37,7 @@ class UserController(
         @PathVariable id: Long,
         @AuthenticationPrincipal principal: MemberPrincipal,
     ): ApiResponse<LeaveResponse> {
-        val result = userService.leaveUser(id, principal)
+        val result = userService.leaveUser(id, principal.memberId)
         return ApiResponse.ok(result)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
@@ -68,18 +68,14 @@ class UserService(
             WarnException(ErrorCode.NOT_FOUND)
         }
 
-        val socialAccount =
-            socialAccountRepository.findByProviderAndProviderUserId(principal.provider, principal.providerUserId)
-                ?: throw ErrorException(ErrorCode.UNAUTHORIZED_ERROR)
-
-        if (socialAccount.memberId != id) {
+        if (principal.memberId != id) {
             throw WarnException(ErrorCode.FORBIDDEN)
         }
 
         val response = member.toLeaveResponse()
 
         refreshTokenRepository.deleteAllByMemberId(id)
-        socialAccountRepository.delete(socialAccount)
+        socialAccountRepository.findByMemberId(id)?.let { socialAccountRepository.delete(it) }
         memberRepository.delete(member)
 
         return response

--- a/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.user.service
 
-import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.api.user.dto.CheckNicknameResponse
 import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.api.user.dto.LeaveResponse
@@ -63,12 +62,12 @@ class UserService(
     }
 
     @Transactional
-    fun leaveUser(id: Long, principal: MemberPrincipal): LeaveResponse {
+    fun leaveUser(id: Long, memberId: Long): LeaveResponse {
         val member = memberRepository.findById(id).orElseThrow {
             WarnException(ErrorCode.NOT_FOUND)
         }
 
-        if (principal.memberId != id) {
+        if (memberId != id) {
             throw WarnException(ErrorCode.FORBIDDEN)
         }
 

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -65,13 +65,275 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-04-10 19:24:28",
+                        "joinedAt" : "2026-04-15 13:30:35",
                         "role" : null,
-                        "createdAt" : "2026-04-10 19:24:28",
-                        "updatedAt" : "2026-04-10 19:24:28"
+                        "createdAt" : "2026-04-15 13:30:35",
+                        "updatedAt" : "2026-04-15 13:30:35"
                       },
                       "error" : null
                     }
+  /api/v1/quiz-progress/answers:
+    post:
+      tags:
+      - QuizProgress
+      summary: 퀴즈 답안 제출
+      description: 퀴즈에 대한 답안을 제출합니다. 이미 답변한 퀴즈에 재제출하면 선택지가 업데이트됩니다.
+      operationId: quiz-progress-submit-answer
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/api-v1-quiz-progress-answers-1062387050"
+            examples:
+              quiz-progress-submit-answer:
+                value: |-
+                  {
+                    "quizId" : 1,
+                    "choiceId" : 1
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-quiz-progress-reset-1831456372"
+              examples:
+                quiz-progress-submit-answer:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/quiz-progress/current:
+    get:
+      tags:
+      - QuizProgress
+      summary: 퀴즈 진행률 조회
+      description: 현재 주차의 퀴즈 진행 상태를 조회합니다.
+      operationId: quiz-progress-current
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-quiz-progress-current1012077415"
+              examples:
+                quiz-progress-current:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "status" : "COMPLETED",
+                        "quizSetId" : 1,
+                        "quizSetTitle" : "이번 주 1:1 매칭",
+                        "totalQuizzes" : 1,
+                        "answeredQuizzes" : 1,
+                        "participantCount" : 1
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/quiz-progress/reset:
+    post:
+      tags:
+      - QuizProgress
+      summary: 퀴즈 진행 초기화
+      description: 이번 주차의 퀴즈 답변과 진행 상태를 모두 초기화합니다.
+      operationId: quiz-progress-reset
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-quiz-progress-reset-1831456372"
+              examples:
+                quiz-progress-reset:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/quiz-sets/current-week:
+    get:
+      tags:
+      - QuizSet
+      summary: 이번 주차 퀴즈 세트 조회
+      description: 현재 활성화된 이번 주차의 퀴즈 세트를 퀴즈 목록과 함께 조회합니다.
+      operationId: quiz-set-current-week
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-quiz-sets-current-week-523790867"
+              examples:
+                quiz-set-current-week:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "year" : 2026,
+                        "month" : 4,
+                        "week" : 3,
+                        "quizSets" : [ {
+                          "id" : 1,
+                          "year" : 2026,
+                          "month" : 4,
+                          "week" : 2,
+                          "category" : "성격",
+                          "title" : "이번 주 1:1 매칭",
+                          "description" : "테스트 퀴즈 세트 설명",
+                          "startDate" : "2026-04-14 13:30:35",
+                          "endDate" : "2026-04-16 13:30:35",
+                          "isActive" : true,
+                          "matchingType" : "ONE_TO_ONE",
+                          "quizzes" : [ {
+                            "id" : 1,
+                            "question" : "짜장면 vs 짬뽕?",
+                            "quizSetId" : 1,
+                            "choices" : [ {
+                              "id" : 1,
+                              "content" : "짜장면",
+                              "order" : 1
+                            }, {
+                              "id" : 2,
+                              "content" : "짬뽕",
+                              "order" : 2
+                            } ],
+                            "order" : 1,
+                            "createdAt" : "2026-04-15 13:30:35",
+                            "updatedAt" : "2026-04-15 13:30:35"
+                          } ]
+                        } ]
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/quiz-sets/{id}:
+    get:
+      tags:
+      - QuizSet
+      summary: 퀴즈 세트 단건 조회
+      description: ID로 퀴즈 세트 메타데이터를 조회합니다.
+      operationId: quiz-set-get
+      parameters:
+      - name: id
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-quiz-sets-id1440540832"
+              examples:
+                quiz-set-get:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "year" : 2026,
+                        "month" : 4,
+                        "week" : 2,
+                        "category" : "성격",
+                        "title" : "이번 주 1:1 매칭",
+                        "description" : "테스트 퀴즈 세트 설명",
+                        "startDate" : "2026-04-06 00:00:00",
+                        "endDate" : "2026-04-12 23:59:59",
+                        "isActive" : true,
+                        "matchingType" : "ONE_TO_ONE",
+                        "createdAt" : "2026-04-15 13:30:35",
+                        "updatedAt" : "2026-04-15 13:30:35"
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/quiz-progress/quiz-sets/{id}:
+    get:
+      tags:
+      - QuizProgress
+      summary: 퀴즈셋 + 답변 조회
+      description: 퀴즈셋의 문제 목록과 사용자의 답변을 함께 조회합니다. 이어풀기에 사용됩니다.
+      operationId: quiz-progress-quiz-set-with-progress
+      parameters:
+      - name: id
+        in: path
+        description: ""
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-quiz-progress-quiz-sets-id-1569645469"
+              examples:
+                quiz-progress-quiz-set-with-progress:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "quizzes" : [ {
+                          "id" : 1,
+                          "question" : "첫번째",
+                          "quizSetId" : 1,
+                          "choices" : [ {
+                            "id" : 1,
+                            "content" : "A",
+                            "order" : 1
+                          }, {
+                            "id" : 2,
+                            "content" : "B",
+                            "order" : 2
+                          } ],
+                          "order" : 1,
+                          "createdAt" : "2026-04-15 13:30:35",
+                          "updatedAt" : "2026-04-15 13:30:35",
+                          "userAnswer" : 1
+                        }, {
+                          "id" : 2,
+                          "question" : "두번째",
+                          "quizSetId" : 1,
+                          "choices" : [ {
+                            "id" : 3,
+                            "content" : "C",
+                            "order" : 1
+                          }, {
+                            "id" : 4,
+                            "content" : "D",
+                            "order" : 2
+                          } ],
+                          "order" : 2,
+                          "createdAt" : "2026-04-15 13:30:35",
+                          "updatedAt" : "2026-04-15 13:30:35",
+                          "userAnswer" : null
+                        } ],
+                        "totalCount" : 2
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
   /api/v1/users/auth/logout:
     post:
       tags:
@@ -85,7 +347,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-auth-logout-1831456372"
+                $ref: "#/components/schemas/api-v1-quiz-progress-reset-1831456372"
               examples:
                 logout:
                   value: |-
@@ -112,7 +374,7 @@ paths:
               token-refresh:
                 value: |-
                   {
-                    "refreshToken" : "ffb7561c-4eb2-4336-bb28-99fa9fa4a08f"
+                    "refreshToken" : "c8e5d0e6-e3d5-416b-8fef-af3613ede3ee"
                   }
       responses:
         "200":
@@ -127,8 +389,8 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiJwcm92aWRlclVzZXJJZCIsInByb3ZpZGVyIjoiS0FLQU8iLCJpYXQiOjE3NzU4MTY2NjYsImV4cCI6MTc3NTgyMDI2Nn0.9fJXw-0ITY-dMtw7j5n7K-2vTZln6V3ZhXZ3qKNytPi-wO3Y-_2RzpZKnbLItQlEX5Iij4ECGSzP44OXoLLsSg",
-                        "refreshToken" : "894b0ecb-ae1a-4d45-861b-a2ec6c80cbb4"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzc2MjI3NDMyLCJleHAiOjE3NzYyMzEwMzJ9.3UqDxKWPH822V0ud7GJGGZdHnSp26kByclBBQUkx6FwW0BD4HF57YMu5jRBn72zCvbXW2gD2IFlFbZDTEpoeNA",
+                        "refreshToken" : "588f033f-2a03-4e4f-8e22-d7746714add1"
                       },
                       "error" : null
                     }
@@ -186,8 +448,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-04-10 19:24:28",
-                        "updatedAt" : "2026-04-10 19:24:28"
+                        "createdAt" : "2026-04-15 13:30:35",
+                        "updatedAt" : "2026-04-15 13:30:35"
                       },
                       "error" : null
                     }
@@ -230,7 +492,7 @@ paths:
       - OAuth
       summary: 소셜 로그인 콜백
       description: 신규 사용자는 토큰을 발급하지 않습니다. 회원가입이 필요합니다.
-      operationId: oauth-callback
+      operationId: oauth-callback-new-user
       parameters:
       - name: provider
         in: path
@@ -250,22 +512,15 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-social-login-provider-callback1685114549"
+                $ref: "#/components/schemas/api-v1-users-social-login-provider-callback1248644946"
               examples:
                 oauth-callback-new-user:
                   value: |-
                     {
                       "success" : true,
-                      "data" : { },
-                      "error" : null
-                    }
-                oauth-callback:
-                  value: |-
-                    {
-                      "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxMjM0NSIsInByb3ZpZGVyIjoiS0FLQU8iLCJpYXQiOjE3NzQ4MDEzMjAsImV4cCI6MTc3NDgwNDkyMH0.kqnh-Cde7IvgLPBqNMwnNINyD6JmXf5GRD0dcQKTNFyYwCjE6FdRqT_i8i04W67dDfexgPZvl6hk2U521gsCKA",
-                        "refreshToken" : "0282aea0-e052-43f2-b5d7-0ece67b91425"
+                        "accessToken" : null,
+                        "refreshToken" : null
                       },
                       "error" : null
                     }
@@ -292,26 +547,232 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-social-login-provider-callback1685114549:
+    api-v1-quiz-sets-current-week-523790867:
       required:
-      - data
       - error
       - success
       type: object
       properties:
         data:
           required:
-          - accessToken
-          - refreshToken
+          - month
+          - week
+          - year
           type: object
           properties:
-            accessToken:
+            week:
+              type: number
+              description: 주차
+            month:
+              type: number
+              description: 월
+            year:
+              type: number
+              description: 년도
+            quizSets:
+              type: array
+              items:
+                required:
+                - category
+                - description
+                - endDate
+                - id
+                - isActive
+                - matchingType
+                - month
+                - startDate
+                - title
+                - week
+                - year
+                type: object
+                properties:
+                  week:
+                    type: number
+                    description: 주차
+                  month:
+                    type: number
+                    description: 월
+                  endDate:
+                    type: string
+                    description: 종료일시
+                  year:
+                    type: number
+                    description: 년도
+                  description:
+                    type: string
+                    description: 퀴즈 세트 설명
+                  quizzes:
+                    type: array
+                    items:
+                      required:
+                      - createdAt
+                      - id
+                      - order
+                      - question
+                      - quizSetId
+                      - updatedAt
+                      type: object
+                      properties:
+                        createdAt:
+                          type: string
+                          description: 생성일시
+                        question:
+                          type: string
+                          description: 퀴즈 질문
+                        quizSetId:
+                          type: number
+                          description: 퀴즈 세트 ID
+                        id:
+                          type: number
+                          description: 퀴즈 ID
+                        choices:
+                          type: array
+                          items:
+                            required:
+                            - content
+                            - id
+                            - order
+                            type: object
+                            properties:
+                              id:
+                                type: number
+                                description: 선택지 ID
+                              content:
+                                type: string
+                                description: 선택지 내용
+                              order:
+                                type: number
+                                description: 선택지 순서
+                        updatedAt:
+                          type: string
+                          description: 수정일시
+                        order:
+                          type: number
+                          description: 퀴즈 순서
+                  id:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  isActive:
+                    type: boolean
+                    description: 활성화 여부
+                  title:
+                    type: string
+                    description: 퀴즈 세트 제목
+                  category:
+                    type: string
+                    description: 카테고리
+                  matchingType:
+                    type: string
+                    description: "매칭 타입 (ONE_TO_ONE, GROUP)"
+                  startDate:
+                    type: string
+                    description: 시작일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-quiz-sets-id-1569645469:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - totalCount
+          type: object
+          properties:
+            quizzes:
+              type: array
+              items:
+                required:
+                - createdAt
+                - id
+                - order
+                - question
+                - quizSetId
+                - updatedAt
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 생성일시
+                  userAnswer:
+                    type: number
+                    description: 사용자가 선택한 choiceId (미답변 시 null)
+                    nullable: true
+                  question:
+                    type: string
+                    description: 퀴즈 질문
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 퀴즈 ID
+                  choices:
+                    type: array
+                    items:
+                      required:
+                      - content
+                      - id
+                      - order
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                          description: 선택지 ID
+                        content:
+                          type: string
+                          description: 선택지 내용
+                        order:
+                          type: number
+                          description: 선택지 순서
+                  updatedAt:
+                    type: string
+                    description: 수정일시
+                  order:
+                    type: number
+                    description: 퀴즈 순서
+            totalCount:
+              type: number
+              description: 전체 퀴즈 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-current1012077415:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - participantCount
+          - status
+          type: object
+          properties:
+            answeredQuizzes:
+              type: number
+              description: 답변한 퀴즈 수
+              nullable: true
+            totalQuizzes:
+              type: number
+              description: 전체 퀴즈 수
+              nullable: true
+            quizSetId:
+              type: number
+              description: 참여 중인 퀴즈 세트 ID
+              nullable: true
+            participantCount:
+              type: number
+              description: 완료한 참여자 수
+            quizSetTitle:
               type: string
-              description: JWT 액세스 토큰
-            refreshToken:
+              description: 참여 중인 퀴즈 세트 제목
+              nullable: true
+            status:
               type: string
-              description: 리프레시 토큰
-          description: 빈 객체 (신규 사용자)
+              description: "진행 상태 (NOT_STARTED, IN_PROGRESS, COMPLETED)"
         success:
           type: boolean
           description: 성공 여부
@@ -364,7 +825,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-logout-1831456372:
+    api-v1-quiz-progress-reset-1831456372:
       required:
       - data
       - error
@@ -374,6 +835,18 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-quiz-progress-answers-1062387050:
+      required:
+      - choiceId
+      - quizId
+      type: object
+      properties:
+        choiceId:
+          type: number
+          description: 선택한 선택지 ID
+        quizId:
+          type: number
+          description: 퀴즈 ID
     api-v1-users-107230905:
       required:
       - error
@@ -423,6 +896,86 @@ components:
             updatedAt:
               type: string
               description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-sets-id1440540832:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - category
+          - createdAt
+          - description
+          - endDate
+          - id
+          - isActive
+          - matchingType
+          - month
+          - startDate
+          - title
+          - updatedAt
+          - week
+          - year
+          type: object
+          properties:
+            week:
+              type: number
+              description: 주차
+            endDate:
+              type: string
+              description: 종료일시
+            year:
+              type: number
+              description: 년도
+            description:
+              type: string
+              description: 퀴즈 세트 설명
+            isActive:
+              type: boolean
+              description: 활성화 여부
+            title:
+              type: string
+              description: 퀴즈 세트 제목
+            matchingType:
+              type: string
+              description: "매칭 타입 (ONE_TO_ONE, GROUP)"
+            createdAt:
+              type: string
+              description: 생성일시
+            month:
+              type: number
+              description: 월
+            id:
+              type: number
+              description: 퀴즈 세트 ID
+            category:
+              type: string
+              description: 카테고리
+            startDate:
+              type: string
+              description: 시작일시
+            updatedAt:
+              type: string
+              description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-social-login-provider-callback1248644946:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          - refreshToken
+          type: object
+          properties: {}
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/test/kotlin/com/ditto/api/auth/AuthServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/AuthServiceTest.kt
@@ -11,9 +11,6 @@ import com.ditto.domain.member.entity.Member
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.refreshtoken.entity.RefreshToken
 import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
-import com.ditto.domain.socialaccount.entity.SocialAccount
-import com.ditto.domain.socialaccount.entity.SocialProvider
-import com.ditto.domain.socialaccount.repository.SocialAccountRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -23,7 +20,6 @@ import javax.sql.DataSource
 class AuthServiceTest(
     private val authService: AuthService,
     private val jwtTokenProvider: JwtTokenProvider,
-    private val socialAccountRepository: SocialAccountRepository,
     private val memberRepository: MemberRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
     dataSource: DataSource,
@@ -34,14 +30,13 @@ class AuthServiceTest(
         "토큰 갱신" - {
             "유효한 리프레시 토큰으로 새 토큰 쌍을 발급한다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
                 val refreshToken = authService.createRefreshToken(member.id)
 
                 val result = authService.refresh(TokenRefreshRequest(refreshToken = refreshToken.token))
 
                 result.accessToken shouldNotBe null
                 jwtTokenProvider.isValid(result.accessToken) shouldBe true
-                jwtTokenProvider.getProviderUserId(result.accessToken) shouldBe "providerUserId"
+                jwtTokenProvider.getMemberId(result.accessToken) shouldBe member.id
                 result.refreshToken shouldNotBe refreshToken.token
             }
 
@@ -54,7 +49,6 @@ class AuthServiceTest(
 
             "만료된 리프레시 토큰이면 예외가 발생한다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
                 val expiredToken = RefreshToken.create(
                     memberId = member.id,
                     token = "expired-token",
@@ -68,19 +62,8 @@ class AuthServiceTest(
                 exception.errorCode shouldBe ErrorCode.REFRESH_TOKEN_EXPIRED
             }
 
-            "리프레시 토큰에 연결된 소셜 계정이 없으면 예외가 발생한다" {
-                val member = memberRepository.save(Member(nickname = "테스트유저"))
-                val refreshToken = authService.createRefreshToken(member.id)
-
-                val exception = shouldThrow<ErrorException> {
-                    authService.refresh(TokenRefreshRequest(refreshToken = refreshToken.token))
-                }
-                exception.errorCode shouldBe ErrorCode.INTERNAL_ERROR
-            }
-
             "갱신 후 이전 리프레시 토큰은 사용할 수 없다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
                 val refreshToken = authService.createRefreshToken(member.id)
                 val oldToken = refreshToken.token
 
@@ -96,41 +79,31 @@ class AuthServiceTest(
         "로그아웃" - {
             "로그아웃하면 해당 회원의 모든 토큰이 삭제된다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
                 val refreshToken = authService.createRefreshToken(member.id)
 
-                authService.logout(SocialProvider.KAKAO, "providerUserId")
+                authService.logout(member.id)
 
                 refreshTokenRepository.findByToken(refreshToken.token) shouldBe null
             }
 
             "로그아웃하면 해당 회원의 여러 토큰이 모두 삭제된다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
                 val token1 = authService.createRefreshToken(member.id)
                 val token2 = authService.createRefreshToken(member.id)
                 val token3 = authService.createRefreshToken(member.id)
 
-                authService.logout(SocialProvider.KAKAO, "providerUserId")
+                authService.logout(member.id)
 
                 refreshTokenRepository.findByToken(token1.token) shouldBe null
                 refreshTokenRepository.findByToken(token2.token) shouldBe null
                 refreshTokenRepository.findByToken(token3.token) shouldBe null
             }
 
-            "존재하지 않는 소셜 계정으로 로그아웃하면 예외가 발생한다" {
-                val exception = shouldThrow<ErrorException> {
-                    authService.logout(SocialProvider.KAKAO, "non-existent-user")
-                }
-                exception.errorCode shouldBe ErrorCode.UNAUTHORIZED_ERROR
-            }
-
             "로그아웃 후 같은 리프레시 토큰으로 갱신할 수 없다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
                 val refreshToken = authService.createRefreshToken(member.id)
 
-                authService.logout(SocialProvider.KAKAO, "providerUserId")
+                authService.logout(member.id)
 
                 val exception = shouldThrow<ErrorException> {
                     authService.refresh(TokenRefreshRequest(refreshToken = refreshToken.token))

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
@@ -91,7 +91,7 @@ class OAuthFacadeTest(
                 refreshTokenRepository.count() shouldBe 1
             }
 
-            "ACTIVE 사용자의 JWT에 providerUserId와 provider가 포함된다" {
+            "ACTIVE 사용자의 JWT에 memberId가 포함된다" {
                 val member =
                     memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
                 member.activate()
@@ -99,8 +99,7 @@ class OAuthFacadeTest(
 
                 val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                jwtTokenProvider.getProviderUserId(result.accessToken!!) shouldBe "12345"
-                jwtTokenProvider.getProvider(result.accessToken!!) shouldBe SocialProvider.KAKAO
+                jwtTokenProvider.getMemberId(result.accessToken!!) shouldBe member.id
             }
         }
     },

--- a/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
@@ -2,7 +2,6 @@ package com.ditto.api.config.auth
 
 import com.ditto.api.config.TestExceptionController
 import com.ditto.api.support.RestDocsTest
-import com.ditto.domain.socialaccount.entity.SocialProvider
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.context.annotation.Import
@@ -16,7 +15,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     @Test
     @DisplayName("유효한 Bearer 토큰이면 MemberPrincipal을 받을 수 있다")
     fun validBearerToken() {
-        val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+        val token = jwtTokenProvider.generateAccessToken(1L)
 
         mockMvc.perform(
             get("/api/test/me")
@@ -25,8 +24,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.providerUserId").value("kakao-123"))
-            .andExpect(jsonPath("$.data.provider").value("KAKAO"))
+            .andExpect(jsonPath("$.data.memberId").value(1))
     }
 
     @Test
@@ -59,7 +57,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     @Test
     @DisplayName("API Key 없이 Bearer 토큰만 보내면 401과 에러 정보를 반환한다")
     fun bearerTokenWithoutApiKey() {
-        val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+        val token = jwtTokenProvider.generateAccessToken(1L)
 
         mockMvc.perform(
             get("/api/test/me")

--- a/api/src/test/kotlin/com/ditto/api/config/auth/JwtTokenProviderTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/auth/JwtTokenProviderTest.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.config.auth
 
-import com.ditto.domain.socialaccount.entity.SocialProvider
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.string.shouldNotBeBlank
@@ -17,30 +16,24 @@ class JwtTokenProviderTest : FreeSpec(
 
         "토큰 생성" - {
             "유효한 JWT 문자열을 반환한다" {
-                val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+                val token = jwtTokenProvider.generateAccessToken(1L)
 
                 token.shouldNotBeBlank()
             }
 
             "생성된 토큰은 유효하다" {
-                val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+                val token = jwtTokenProvider.generateAccessToken(1L)
 
                 jwtTokenProvider.isValid(token) shouldBe true
             }
         }
 
         "토큰에서 claim 추출" - {
-            "올바른 providerUserId를 추출한다" {
-                val providerUserId = "kakao-456"
-                val token = jwtTokenProvider.generateAccessToken(providerUserId, SocialProvider.KAKAO)
+            "올바른 memberId를 추출한다" {
+                val memberId = 42L
+                val token = jwtTokenProvider.generateAccessToken(memberId)
 
-                jwtTokenProvider.getProviderUserId(token) shouldBe providerUserId
-            }
-
-            "올바른 provider를 추출한다" {
-                val token = jwtTokenProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
-
-                jwtTokenProvider.getProvider(token) shouldBe SocialProvider.KAKAO
+                jwtTokenProvider.getMemberId(token) shouldBe memberId
             }
         }
 
@@ -49,7 +42,7 @@ class JwtTokenProviderTest : FreeSpec(
                 val expiredProvider = JwtTokenProvider(
                     JwtProperties(secret = jwtProperties.secret, expirationMs = 0L, refreshExpirationMs = 1209600000L),
                 )
-                val token = expiredProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+                val token = expiredProvider.generateAccessToken(1L)
 
                 Thread.sleep(10)
                 jwtTokenProvider.isValid(token) shouldBe false
@@ -67,7 +60,7 @@ class JwtTokenProviderTest : FreeSpec(
                         refreshExpirationMs = 1209600000L,
                     ),
                 )
-                val token = otherProvider.generateAccessToken("kakao-123", SocialProvider.KAKAO)
+                val token = otherProvider.generateAccessToken(1L)
 
                 jwtTokenProvider.isValid(token) shouldBe false
             }

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressControllerTest.kt
@@ -14,6 +14,7 @@ import com.ditto.domain.quiz.repository.QuizSetRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.epages.restdocs.apispec.ResourceDocumentation.resource
 import com.epages.restdocs.apispec.ResourceSnippetParameters
@@ -115,7 +116,7 @@ class QuizProgressControllerTest : RestDocsTest() {
         val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
         quizProgressService.submitAnswer(
-            com.ditto.api.config.auth.MemberPrincipal("test-user", SocialProvider.KAKAO),
+            1L,
             SubmitAnswerRequest(quiz.id, choice.id),
             now,
         )
@@ -170,7 +171,7 @@ class QuizProgressControllerTest : RestDocsTest() {
         quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "D", displayOrder = 2))
 
         quizProgressService.submitAnswer(
-            com.ditto.api.config.auth.MemberPrincipal("test-user", SocialProvider.KAKAO),
+            1L,
             SubmitAnswerRequest(quiz1.id, choice1.id),
             now,
         )
@@ -273,7 +274,7 @@ class QuizProgressControllerTest : RestDocsTest() {
         val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
         quizProgressService.submitAnswer(
-            com.ditto.api.config.auth.MemberPrincipal("test-user", SocialProvider.KAKAO),
+            1L,
             SubmitAnswerRequest(quiz.id, choice.id),
             now,
         )

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.quiz
 
-import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.api.quiz.dto.SubmitAnswerRequest
 import com.ditto.api.quiz.service.QuizProgressService
 import com.ditto.api.support.IntegrationTest
@@ -17,9 +16,6 @@ import com.ditto.domain.quiz.repository.QuizChoiceRepository
 import com.ditto.domain.quiz.repository.QuizProgressRepository
 import com.ditto.domain.quiz.repository.QuizRepository
 import com.ditto.domain.quiz.repository.QuizSetRepository
-import com.ditto.domain.socialaccount.entity.SocialAccount
-import com.ditto.domain.socialaccount.entity.SocialProvider
-import com.ditto.domain.socialaccount.repository.SocialAccountRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
@@ -34,16 +30,14 @@ class QuizProgressServiceTest(
     private val quizAnswerRepository: QuizAnswerRepository,
     private val quizProgressRepository: QuizProgressRepository,
     private val memberRepository: MemberRepository,
-    private val socialAccountRepository: SocialAccountRepository,
     dataSource: DataSource,
 ) : IntegrationTest(dataSource, {
 
     val now = LocalDateTime.now()
 
-    fun setupMember(providerUserId: String = "test-user"): MemberPrincipal {
-        val member = memberRepository.save(Member(nickname = "테스트유저-$providerUserId"))
-        socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, providerUserId))
-        return MemberPrincipal(providerUserId = providerUserId, provider = SocialProvider.KAKAO)
+    fun setupMember(nickname: String = "테스트유저"): Long {
+        val member = memberRepository.save(Member(nickname = nickname))
+        return member.id
     }
 
     fun setupActiveQuizData(): Triple<Long, Long, Long> {
@@ -58,10 +52,10 @@ class QuizProgressServiceTest(
 
     "퀴즈 답안 제출" - {
         "정상적인 답안을 제출하면 QuizAnswer가 저장된다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val (quizId, choiceId, _) = setupActiveQuizData()
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, choiceId), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, choiceId), now)
 
             val answer = quizAnswerRepository.findByMemberIdAndQuizId(1L, quizId)
             answer shouldNotBe null
@@ -69,11 +63,11 @@ class QuizProgressServiceTest(
         }
 
         "같은 퀴즈에 다른 선택지로 재제출하면 choiceId가 업데이트된다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val (quizId, choiceId1, choiceId2) = setupActiveQuizData()
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, choiceId1), now)
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, choiceId2), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, choiceId1), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, choiceId2), now)
 
             val answers = quizAnswerRepository.findAll()
             answers.size shouldBe 1
@@ -81,7 +75,7 @@ class QuizProgressServiceTest(
         }
 
         "비활성 퀴즈 세트의 퀴즈에 답안을 제출하면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = false),
             )
@@ -89,13 +83,13 @@ class QuizProgressServiceTest(
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+                quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice.id), now)
             }
             exception.errorCode shouldBe ErrorCode.QUIZ_NOT_IN_ACTIVE_SET
         }
 
         "기간이 지난 퀴즈 세트의 퀴즈에 답안을 제출하면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(7), endDate = now.minusDays(1)),
             )
@@ -103,56 +97,47 @@ class QuizProgressServiceTest(
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+                quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice.id), now)
             }
             exception.errorCode shouldBe ErrorCode.QUIZ_NOT_IN_ACTIVE_SET
         }
 
         "존재하지 않는 quizId로 제출하면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(99999L, 1L), now)
+                quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(99999L, 1L), now)
             }
             exception.errorCode shouldBe ErrorCode.NOT_FOUND
         }
 
         "해당 퀴즈에 속하지 않는 choiceId로 제출하면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val (quizId, _, _) = setupActiveQuizData()
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quizId, 99999L), now)
+                quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, 99999L), now)
             }
             exception.errorCode shouldBe ErrorCode.INVALID_CHOICE
         }
 
-        "소셜 계정이 없는 principal로 제출하면 예외가 발생한다" {
-            val (quizId, choiceId, _) = setupActiveQuizData()
-            val unknownPrincipal = MemberPrincipal(providerUserId = "unknown", provider = SocialProvider.KAKAO)
-
-            val exception = shouldThrow<ErrorException> {
-                quizProgressService.submitAnswer(unknownPrincipal, SubmitAnswerRequest(quizId, choiceId), now)
-            }
-            exception.errorCode shouldBe ErrorCode.UNAUTHORIZED_ERROR
-        }
     }
 
     "퀴즈 진행률 조회" - {
         "퀴즈를 풀지 않았으면 NOT_STARTED를 반환한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
 
-            val result = quizProgressService.getProgress(principal, now)
+            val result = quizProgressService.getProgress(memberId, now)
 
             result.status shouldBe QuizProgressStatus.NOT_STARTED
             result.quizSetId shouldBe null
         }
 
         "퀴즈를 일부 풀었으면 IN_PROGRESS를 반환한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
@@ -160,9 +145,9 @@ class QuizProgressServiceTest(
             quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "두번째", displayOrder = 2))
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id))
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz1.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz1.id, choice.id), now)
 
-            val result = quizProgressService.getProgress(principal, now)
+            val result = quizProgressService.getProgress(memberId, now)
 
             result.status shouldBe QuizProgressStatus.IN_PROGRESS
             result.quizSetId shouldBe quizSet.id
@@ -171,16 +156,16 @@ class QuizProgressServiceTest(
         }
 
         "퀴즈를 모두 풀었으면 COMPLETED를 반환한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
             val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice.id), now)
 
-            val result = quizProgressService.getProgress(principal, now)
+            val result = quizProgressService.getProgress(memberId, now)
 
             result.status shouldBe QuizProgressStatus.COMPLETED
             result.quizSetId shouldBe quizSet.id
@@ -189,9 +174,9 @@ class QuizProgressServiceTest(
         }
 
         "participantCount가 정확하게 계산된다" {
-            val principal1 = setupMember("user-1")
-            val principal2 = setupMember("user-2")
-            setupMember("user-3")
+            val memberId1 = setupMember("유저1")
+            val memberId2 = setupMember("유저2")
+            setupMember("유저3")
 
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
@@ -199,19 +184,19 @@ class QuizProgressServiceTest(
             val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
-            quizProgressService.submitAnswer(principal1, SubmitAnswerRequest(quiz.id, choice.id), now)
-            quizProgressService.submitAnswer(principal2, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId1, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId2, SubmitAnswerRequest(quiz.id, choice.id), now)
 
-            val result = quizProgressService.getProgress(principal1, now)
+            val result = quizProgressService.getProgress(memberId1, now)
 
             result.participantCount shouldBe 2
         }
 
         "활성 퀴즈셋이 없으면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.getProgress(principal, now)
+                quizProgressService.getProgress(memberId, now)
             }
             exception.errorCode shouldBe ErrorCode.NOT_FOUND
         }
@@ -219,7 +204,7 @@ class QuizProgressServiceTest(
 
     "퀴즈셋 + 답변 조회" - {
         "퀴즈와 답변을 함께 조회한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
@@ -230,9 +215,9 @@ class QuizProgressServiceTest(
             quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "C", displayOrder = 1))
             quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz2.id, content = "D", displayOrder = 2))
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz1.id, choice1.id), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz1.id, choice1.id), now)
 
-            val result = quizProgressService.getQuizSetWithProgress(principal, quizSet.id, now)
+            val result = quizProgressService.getQuizSetWithProgress(memberId, quizSet.id, now)
 
             result.totalCount shouldBe 2
             result.quizzes[0].userAnswer shouldBe choice1.id
@@ -240,22 +225,22 @@ class QuizProgressServiceTest(
         }
 
         "비활성 퀴즈셋을 조회하면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1), isActive = false),
             )
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.getQuizSetWithProgress(principal, quizSet.id, now)
+                quizProgressService.getQuizSetWithProgress(memberId, quizSet.id, now)
             }
             exception.errorCode shouldBe ErrorCode.QUIZ_NOT_IN_ACTIVE_SET
         }
 
         "존재하지 않는 퀴즈셋을 조회하면 예외가 발생한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
 
             val exception = shouldThrow<ErrorException> {
-                quizProgressService.getQuizSetWithProgress(principal, 99999L, now)
+                quizProgressService.getQuizSetWithProgress(memberId, 99999L, now)
             }
             exception.errorCode shouldBe ErrorCode.NOT_FOUND
         }
@@ -263,67 +248,67 @@ class QuizProgressServiceTest(
 
     "퀴즈 진행 초기화" - {
         "초기화하면 답변과 진행 상태가 모두 삭제된다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
             val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice.id), now)
 
             quizAnswerRepository.findAll().size shouldBe 1
             quizProgressRepository.findAll().size shouldBe 1
 
-            quizProgressService.resetProgress(principal, now)
+            quizProgressService.resetProgress(memberId, now)
 
             quizAnswerRepository.findAll().size shouldBe 0
             quizProgressRepository.findAll().size shouldBe 0
         }
 
         "초기화 후 진행률 조회하면 NOT_STARTED를 반환한다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
             val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
-            quizProgressService.submitAnswer(principal, SubmitAnswerRequest(quiz.id, choice.id), now)
-            quizProgressService.resetProgress(principal, now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.resetProgress(memberId, now)
 
-            val result = quizProgressService.getProgress(principal, now)
+            val result = quizProgressService.getProgress(memberId, now)
             result.status shouldBe QuizProgressStatus.NOT_STARTED
         }
 
         "답변이 없어도 초기화 호출 시 예외가 발생하지 않는다" {
-            val principal = setupMember()
+            val memberId = setupMember()
             quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
 
-            quizProgressService.resetProgress(principal, now)
+            quizProgressService.resetProgress(memberId, now)
         }
 
         "활성 퀴즈셋이 없어도 초기화 호출 시 예외가 발생하지 않는다" {
-            val principal = setupMember()
+            val memberId = setupMember()
 
-            quizProgressService.resetProgress(principal, now)
+            quizProgressService.resetProgress(memberId, now)
         }
 
         "다른 사용자의 답변은 초기화되지 않는다" {
-            val principal1 = setupMember("user-1")
-            val principal2 = setupMember("user-2")
+            val memberId1 = setupMember("유저1")
+            val memberId2 = setupMember("유저2")
             val quizSet = quizSetRepository.save(
                 QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
             )
             val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
             val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
 
-            quizProgressService.submitAnswer(principal1, SubmitAnswerRequest(quiz.id, choice.id), now)
-            quizProgressService.submitAnswer(principal2, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId1, SubmitAnswerRequest(quiz.id, choice.id), now)
+            quizProgressService.submitAnswer(memberId2, SubmitAnswerRequest(quiz.id, choice.id), now)
 
-            quizProgressService.resetProgress(principal1, now)
+            quizProgressService.resetProgress(memberId1, now)
 
             quizAnswerRepository.findAll().size shouldBe 1
             quizProgressRepository.findAll().size shouldBe 1

--- a/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
@@ -2,7 +2,6 @@ package com.ditto.api.support
 
 import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.common.serialization.ObjectMapperFactory
-import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -33,7 +32,7 @@ abstract class RestDocsTest {
     }
 
     protected fun MockHttpServletRequestBuilder.withBearerToken(): MockHttpServletRequestBuilder {
-        val token = jwtTokenProvider.generateAccessToken("test-user", SocialProvider.KAKAO)
+        val token = jwtTokenProvider.generateAccessToken(1L)
         return this.header("Authorization", "Bearer $token")
     }
 

--- a/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
@@ -1,7 +1,6 @@
 package com.ditto.api.user
 
 import com.ditto.api.auth.service.AuthService
-import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.api.support.IntegrationTest
 import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.api.user.service.UserService
@@ -135,7 +134,7 @@ class UserServiceTest(
 
                 val result = userService.leaveUser(
                     id = member.id,
-                    principal = MemberPrincipal(providerUserId = "leave-user", provider = SocialProvider.KAKAO),
+                    memberId = member.id,
                 )
 
                 result.id shouldBe member.id
@@ -150,7 +149,7 @@ class UserServiceTest(
 
                 userService.leaveUser(
                     id = member.id,
-                    principal = MemberPrincipal(providerUserId = "leave-user-2", provider = SocialProvider.KAKAO),
+                    memberId = member.id,
                 )
 
                 refreshTokenRepository.findByToken(token1.token) shouldBe null
@@ -161,7 +160,7 @@ class UserServiceTest(
                 val exception = shouldThrow<WarnException> {
                     userService.leaveUser(
                         id = 99999L,
-                        principal = MemberPrincipal(providerUserId = "any", provider = SocialProvider.KAKAO),
+                        memberId = 1L,
                     )
                 }
                 exception.errorCode shouldBe ErrorCode.NOT_FOUND
@@ -169,28 +168,15 @@ class UserServiceTest(
 
             "다른 회원의 ID로 탈퇴 요청하면 예외가 발생한다" {
                 val memberA = memberRepository.save(Member(nickname = "멤버A"))
-                socialAccountRepository.save(SocialAccount.create(memberA.id, SocialProvider.KAKAO, "user-a"))
                 val memberB = memberRepository.save(Member(nickname = "멤버B"))
 
                 val exception = shouldThrow<WarnException> {
                     userService.leaveUser(
                         id = memberB.id,
-                        principal = MemberPrincipal(providerUserId = "user-a", provider = SocialProvider.KAKAO),
+                        memberId = memberA.id,
                     )
                 }
                 exception.errorCode shouldBe ErrorCode.FORBIDDEN
-            }
-
-            "소셜 계정이 없으면 예외가 발생한다" {
-                val member = memberRepository.save(Member(nickname = "소셜없는유저"))
-
-                val exception = shouldThrow<ErrorException> {
-                    userService.leaveUser(
-                        id = member.id,
-                        principal = MemberPrincipal(providerUserId = "ghost-user", provider = SocialProvider.KAKAO),
-                    )
-                }
-                exception.errorCode shouldBe ErrorCode.UNAUTHORIZED_ERROR
             }
         }
     },


### PR DESCRIPTION
## Summary
- JWT 토큰의 subject를 `providerUserId` → `memberId`로 변경
- `MemberPrincipal(providerUserId, provider)` → `MemberPrincipal(memberId)`로 단순화
- 인증이 필요한 모든 API에서 발생하던 `SocialAccountRepository` DB 조회 제거
- Service 메서드에서 `MemberPrincipal` 대신 `memberId: Long` 직접 사용하도록 변경
- `AuthService.refresh()`에서 SocialAccount 조회 없이 `refreshToken.memberId`로 바로 토큰 생성
- `AuthService.logout()`을 `(provider, providerUserId)` → `(memberId)` 시그니처로 변경

## Test plan
- [x] 전체 테스트 통과 확인 (`./gradlew test` BUILD SUCCESSFUL)
- [ ] JWT 토큰 발급/갱신 정상 동작 확인
- [ ] 기존 토큰 사용자 재로그인 필요 여부 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)