### PR TITLE
feat. 퀴즈 답변 수정 차단 및 참여 요일 제한 로직 추가 (#38)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/config/quiz/QuizProperties.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/quiz/QuizProperties.kt
@@ -1,0 +1,9 @@
+package com.ditto.api.config.quiz
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+import java.time.DayOfWeek
+
+@ConfigurationProperties(prefix = "ditto.quiz")
+data class QuizProperties(
+    val availableDays: Set<DayOfWeek> = emptySet(),
+)

--- a/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
+++ b/api/src/main/kotlin/com/ditto/api/quiz/service/QuizProgressService.kt
@@ -1,5 +1,6 @@
 package com.ditto.api.quiz.service
 
+import com.ditto.api.config.quiz.QuizProperties
 import com.ditto.api.quiz.dto.QuizProgressResponse
 import com.ditto.api.quiz.dto.QuizSetWithProgressResponse
 import com.ditto.api.quiz.dto.QuizWithAnswerResponse
@@ -31,6 +32,7 @@ class QuizProgressService(
     private val quizRepository: QuizRepository,
     private val quizChoiceRepository: QuizChoiceRepository,
     private val quizSetRepository: QuizSetRepository,
+    private val quizProperties: QuizProperties,
 ) {
     @Transactional
     fun submitAnswer(
@@ -38,10 +40,13 @@ class QuizProgressService(
         request: SubmitAnswerRequest,
         now: LocalDateTime,
     ) {
+        validateAvailableDay(now)
+
         val quiz = findQuiz(request.quizId)
 
         validateActiveQuizSet(quiz.quizSetId, now)
         validateChoice(request.quizId, request.choiceId)
+        validateNotCompleted(memberId, quiz.quizSetId)
 
         val existingQuizAnswer = quizAnswerRepository.findByMemberIdAndQuizId(memberId, request.quizId)
 
@@ -116,7 +121,6 @@ class QuizProgressService(
         quizSetId: Long,
         now: LocalDateTime,
     ): QuizSetWithProgressResponse {
-
         validateActiveQuizSet(quizSetId, now)
 
         val quizzes = quizRepository.findByQuizSetIdInOrderByDisplayOrderAsc(listOf(quizSetId))
@@ -139,7 +143,10 @@ class QuizProgressService(
     }
 
     @Transactional
-    fun resetProgress(memberId: Long, now: LocalDateTime) {
+    fun resetProgress(
+        memberId: Long,
+        now: LocalDateTime,
+    ) {
         val quizSets = quizSetRepository.findCurrentWeekActive(now)
 
         if (quizSets.isEmpty()) {
@@ -172,6 +179,23 @@ class QuizProgressService(
 
         if (!quizSet.isActive || !isInPeriod) {
             throw ErrorException(ErrorCode.QUIZ_NOT_IN_ACTIVE_SET)
+        }
+    }
+
+    private fun validateAvailableDay(now: LocalDateTime) {
+        val availableDays = quizProperties.availableDays
+        if (availableDays.isNotEmpty() && now.dayOfWeek !in availableDays) {
+            throw ErrorException(ErrorCode.QUIZ_NOT_AVAILABLE_DAY)
+        }
+    }
+
+    private fun validateNotCompleted(
+        memberId: Long,
+        quizSetId: Long,
+    ) {
+        val progress = quizProgressRepository.findByMemberIdAndQuizSetId(memberId, quizSetId)
+        if (progress?.status == QuizProgressStatus.COMPLETED) {
+            throw ErrorException(ErrorCode.QUIZ_ALREADY_COMPLETED)
         }
     }
 

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -18,6 +18,11 @@ springdoc:
     url: /docs/openapi.yaml
 
 ditto:
+  quiz:
+    available-days:
+      - MONDAY
+      - TUESDAY
+      - WEDNESDAY
   security:
     api-key: ${API_KEY}
   jwt:

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -65,10 +65,10 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-04-15 16:05:52",
+                        "joinedAt" : "2026-04-15 16:19:51",
                         "role" : null,
-                        "createdAt" : "2026-04-15 16:05:52",
-                        "updatedAt" : "2026-04-15 16:05:52"
+                        "createdAt" : "2026-04-15 16:19:51",
+                        "updatedAt" : "2026-04-15 16:19:51"
                       },
                       "error" : null
                     }
@@ -194,8 +194,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-04-14 16:05:52",
-                          "endDate" : "2026-04-16 16:05:52",
+                          "startDate" : "2026-04-14 16:19:51",
+                          "endDate" : "2026-04-16 16:19:51",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -212,8 +212,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-04-15 16:05:52",
-                            "updatedAt" : "2026-04-15 16:05:52"
+                            "createdAt" : "2026-04-15 16:19:51",
+                            "updatedAt" : "2026-04-15 16:19:51"
                           } ]
                         } ]
                       },
@@ -259,8 +259,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-04-15 16:05:52",
-                        "updatedAt" : "2026-04-15 16:05:52"
+                        "createdAt" : "2026-04-15 16:19:51",
+                        "updatedAt" : "2026-04-15 16:19:51"
                       },
                       "error" : null
                     }
@@ -307,8 +307,8 @@ paths:
                             "order" : 2
                           } ],
                           "order" : 1,
-                          "createdAt" : "2026-04-15 16:05:52",
-                          "updatedAt" : "2026-04-15 16:05:52",
+                          "createdAt" : "2026-04-15 16:19:51",
+                          "updatedAt" : "2026-04-15 16:19:51",
                           "userAnswer" : 1
                         }, {
                           "id" : 2,
@@ -324,8 +324,8 @@ paths:
                             "order" : 2
                           } ],
                           "order" : 2,
-                          "createdAt" : "2026-04-15 16:05:52",
-                          "updatedAt" : "2026-04-15 16:05:52",
+                          "createdAt" : "2026-04-15 16:19:51",
+                          "updatedAt" : "2026-04-15 16:19:51",
                           "userAnswer" : null
                         } ],
                         "totalCount" : 2
@@ -374,7 +374,7 @@ paths:
               token-refresh:
                 value: |-
                   {
-                    "refreshToken" : "0d31b4bb-3a09-49ad-9e39-be0ad8b260d3"
+                    "refreshToken" : "d6187db7-d9ff-45d0-adcf-e2cb0432c985"
                   }
       responses:
         "200":
@@ -389,8 +389,8 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzc2MjM2NzQ5LCJleHAiOjE3NzYyNDAzNDl9.m8gsv-XGgXLyvJ9C0LyuGU0LSd3beYaFNNdZV0OnigQDSAjC14UD87MNH_JrhFx_BxGaYKlx2y7Wf8rCmAkkAg",
-                        "refreshToken" : "a88d57a7-26ab-4553-98e3-9e211181667e"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzc2MjM3NTg5LCJleHAiOjE3NzYyNDExODl9.asRYG6r2h0wYDluU6JPrQviKjTzwPsrN6sqRMcNt6A7otKsWLBcZTyjGLJHGwgK8RRIrQ35ut7Kix9Ay1YRjTQ",
+                        "refreshToken" : "bbab6ca6-dfd2-4b3e-8584-7ba7229f540a"
                       },
                       "error" : null
                     }
@@ -448,8 +448,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-04-15 16:05:52",
-                        "updatedAt" : "2026-04-15 16:05:52"
+                        "createdAt" : "2026-04-15 16:19:51",
+                        "updatedAt" : "2026-04-15 16:19:51"
                       },
                       "error" : null
                     }
@@ -964,6 +964,29 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users-auth-refresh1056639717:
+      required:
+      - refreshToken
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
+    api-v1-users-social-login-provider-callback1248644946:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          - refreshToken
+          type: object
+          properties: {}
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-users-id-leave-1444522536:
       required:
       - error
@@ -1001,29 +1024,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-social-login-provider-callback1248644946:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          - refreshToken
-          type: object
-          properties: {}
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-auth-refresh1056639717:
-      required:
-      - refreshToken
-      type: object
-      properties:
-        refreshToken:
-          type: string
-          description: 리프레시 토큰
   securitySchemes:
     ApiKey:
       type: apiKey

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -65,10 +65,10 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-04-15 13:30:35",
+                        "joinedAt" : "2026-04-15 16:05:52",
                         "role" : null,
-                        "createdAt" : "2026-04-15 13:30:35",
-                        "updatedAt" : "2026-04-15 13:30:35"
+                        "createdAt" : "2026-04-15 16:05:52",
+                        "updatedAt" : "2026-04-15 16:05:52"
                       },
                       "error" : null
                     }
@@ -194,8 +194,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-04-14 13:30:35",
-                          "endDate" : "2026-04-16 13:30:35",
+                          "startDate" : "2026-04-14 16:05:52",
+                          "endDate" : "2026-04-16 16:05:52",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -212,8 +212,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-04-15 13:30:35",
-                            "updatedAt" : "2026-04-15 13:30:35"
+                            "createdAt" : "2026-04-15 16:05:52",
+                            "updatedAt" : "2026-04-15 16:05:52"
                           } ]
                         } ]
                       },
@@ -259,8 +259,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-04-15 13:30:35",
-                        "updatedAt" : "2026-04-15 13:30:35"
+                        "createdAt" : "2026-04-15 16:05:52",
+                        "updatedAt" : "2026-04-15 16:05:52"
                       },
                       "error" : null
                     }
@@ -307,8 +307,8 @@ paths:
                             "order" : 2
                           } ],
                           "order" : 1,
-                          "createdAt" : "2026-04-15 13:30:35",
-                          "updatedAt" : "2026-04-15 13:30:35",
+                          "createdAt" : "2026-04-15 16:05:52",
+                          "updatedAt" : "2026-04-15 16:05:52",
                           "userAnswer" : 1
                         }, {
                           "id" : 2,
@@ -324,8 +324,8 @@ paths:
                             "order" : 2
                           } ],
                           "order" : 2,
-                          "createdAt" : "2026-04-15 13:30:35",
-                          "updatedAt" : "2026-04-15 13:30:35",
+                          "createdAt" : "2026-04-15 16:05:52",
+                          "updatedAt" : "2026-04-15 16:05:52",
                           "userAnswer" : null
                         } ],
                         "totalCount" : 2
@@ -374,7 +374,7 @@ paths:
               token-refresh:
                 value: |-
                   {
-                    "refreshToken" : "c8e5d0e6-e3d5-416b-8fef-af3613ede3ee"
+                    "refreshToken" : "0d31b4bb-3a09-49ad-9e39-be0ad8b260d3"
                   }
       responses:
         "200":
@@ -389,8 +389,8 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzc2MjI3NDMyLCJleHAiOjE3NzYyMzEwMzJ9.3UqDxKWPH822V0ud7GJGGZdHnSp26kByclBBQUkx6FwW0BD4HF57YMu5jRBn72zCvbXW2gD2IFlFbZDTEpoeNA",
-                        "refreshToken" : "588f033f-2a03-4e4f-8e22-d7746714add1"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzc2MjM2NzQ5LCJleHAiOjE3NzYyNDAzNDl9.m8gsv-XGgXLyvJ9C0LyuGU0LSd3beYaFNNdZV0OnigQDSAjC14UD87MNH_JrhFx_BxGaYKlx2y7Wf8rCmAkkAg",
+                        "refreshToken" : "a88d57a7-26ab-4553-98e3-9e211181667e"
                       },
                       "error" : null
                     }
@@ -448,8 +448,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-04-15 13:30:35",
-                        "updatedAt" : "2026-04-15 13:30:35"
+                        "createdAt" : "2026-04-15 16:05:52",
+                        "updatedAt" : "2026-04-15 16:05:52"
                       },
                       "error" : null
                     }
@@ -964,29 +964,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-social-login-provider-callback1248644946:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          - refreshToken
-          type: object
-          properties: {}
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-auth-refresh1056639717:
-      required:
-      - refreshToken
-      type: object
-      properties:
-        refreshToken:
-          type: string
-          description: 리프레시 토큰
     api-v1-users-id-leave-1444522536:
       required:
       - error
@@ -1024,6 +1001,29 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users-social-login-provider-callback1248644946:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          - refreshToken
+          type: object
+          properties: {}
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-refresh1056639717:
+      required:
+      - refreshToken
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
   securitySchemes:
     ApiKey:
       type: apiKey

--- a/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/quiz/QuizProgressServiceTest.kt
@@ -19,7 +19,9 @@ import com.ditto.domain.quiz.repository.QuizSetRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import java.time.DayOfWeek
 import java.time.LocalDateTime
+import java.time.temporal.TemporalAdjusters
 import javax.sql.DataSource
 
 class QuizProgressServiceTest(
@@ -33,7 +35,7 @@ class QuizProgressServiceTest(
     dataSource: DataSource,
 ) : IntegrationTest(dataSource, {
 
-    val now = LocalDateTime.now()
+    val now = LocalDateTime.now().with(TemporalAdjusters.nextOrSame(DayOfWeek.MONDAY))
 
     fun setupMember(nickname: String = "테스트유저"): Long {
         val member = memberRepository.save(Member(nickname = nickname))
@@ -64,14 +66,20 @@ class QuizProgressServiceTest(
 
         "같은 퀴즈에 다른 선택지로 재제출하면 choiceId가 업데이트된다" {
             val memberId = setupMember()
-            val (quizId, choiceId1, choiceId2) = setupActiveQuizData()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(1)),
+            )
+            val quiz1 = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, displayOrder = 1))
+            quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, question = "두번째", displayOrder = 2))
+            val choice1 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id, content = "A", displayOrder = 1))
+            val choice2 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz1.id, content = "B", displayOrder = 2))
 
-            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, choiceId1), now)
-            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, choiceId2), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz1.id, choice1.id), now)
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz1.id, choice2.id), now)
 
             val answers = quizAnswerRepository.findAll()
             answers.size shouldBe 1
-            answers[0].choiceId shouldBe choiceId2
+            answers[0].choiceId shouldBe choice2.id
         }
 
         "비활성 퀴즈 세트의 퀴즈에 답안을 제출하면 예외가 발생한다" {
@@ -109,6 +117,43 @@ class QuizProgressServiceTest(
                 quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(99999L, 1L), now)
             }
             exception.errorCode shouldBe ErrorCode.NOT_FOUND
+        }
+
+        "참여 불가 요일에 제출하면 예외가 발생한다" {
+            val memberId = setupMember()
+            val thursday = now.with(TemporalAdjusters.nextOrSame(DayOfWeek.THURSDAY))
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = thursday.minusDays(1), endDate = thursday.plusDays(1)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id))
+            val quizId = quiz.id
+            val choiceId = choice.id
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quizId, choiceId), thursday)
+            }
+            exception.errorCode shouldBe ErrorCode.QUIZ_NOT_AVAILABLE_DAY
+        }
+
+        "COMPLETED 상태에서 답변을 수정하면 예외가 발생한다" {
+            val memberId = setupMember()
+            val quizSet = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(1), endDate = now.plusDays(7)),
+            )
+            val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id))
+            val choice1 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "A", displayOrder = 1))
+            val choice2 = quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "B", displayOrder = 2))
+
+            quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice1.id), now)
+
+            val progress = quizProgressRepository.findByMemberIdAndQuizSetId(memberId, quizSet.id)
+            progress!!.status shouldBe QuizProgressStatus.COMPLETED
+
+            val exception = shouldThrow<ErrorException> {
+                quizProgressService.submitAnswer(memberId, SubmitAnswerRequest(quiz.id, choice2.id), now)
+            }
+            exception.errorCode shouldBe ErrorCode.QUIZ_ALREADY_COMPLETED
         }
 
         "해당 퀴즈에 속하지 않는 choiceId로 제출하면 예외가 발생한다" {

--- a/api/src/test/resources/application-test.yml
+++ b/api/src/test/resources/application-test.yml
@@ -1,0 +1,6 @@
+ditto:
+  quiz:
+    available-days:
+      - MONDAY
+      - TUESDAY
+      - WEDNESDAY

--- a/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
+++ b/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
@@ -16,5 +16,7 @@ enum class ErrorCode(
     NICKNAME_ALREADY_EXISTS(409, "3003", "이미 사용 중인 닉네임입니다."),
     QUIZ_NOT_IN_ACTIVE_SET(400, "4001", "현재 활성화된 퀴즈 세트에 속한 퀴즈가 아닙니다."),
     INVALID_CHOICE(400, "4002", "해당 퀴즈의 유효한 선택지가 아닙니다."),
+    QUIZ_ALREADY_COMPLETED(400, "4003", "이미 완료된 퀴즈는 수정할 수 없습니다."),
+    QUIZ_NOT_AVAILABLE_DAY(400, "4004", "퀴즈 참여 가능한 요일이 아닙니다."),
     INTERNAL_ERROR(500, "9999", "알 수 없는 에러가 발생했습니다."),
 }

--- a/domain/src/test/resources/application-test.yml
+++ b/domain/src/test/resources/application-test.yml
@@ -1,3 +1,10 @@
+ditto:
+  quiz:
+    available-days:
+      - MONDAY
+      - TUESDAY
+      - WEDNESDAY
+
 spring:
   datasource:
     url: jdbc:h2:mem:ditto;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE

--- a/domain/src/test/resources/application-test.yml
+++ b/domain/src/test/resources/application-test.yml
@@ -1,10 +1,3 @@
-ditto:
-  quiz:
-    available-days:
-      - MONDAY
-      - TUESDAY
-      - WEDNESDAY
-
 spring:
   datasource:
     url: jdbc:h2:mem:ditto;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE


### PR DESCRIPTION
## Summary
- COMPLETED 상태의 퀴즈셋에 답변 수정 시도 시 `QUIZ_ALREADY_COMPLETED` 에러 반환
- 참여 불가 요일(목/금/토/일) 답변 제출 시 `QUIZ_NOT_AVAILABLE_DAY` 에러 반환
- 참여 가능 요일을 `application.yml`에서 설정 가능하도록 `QuizProperties` 추가
  - prod: 월/화/수만 허용
  - local: 설정 없음 (모든 요일 허용)

## Test plan
- [x] 참여 불가 요일에 답변 제출 시 예외 발생 테스트
- [x] COMPLETED 상태에서 답변 수정 시 예외 발생 테스트
- [x] 전체 테스트 통과 확인

Closes #38

🤖 Generated with [Claude Code](https://claude.com/claude-code)