### PR TITLE
feat. 1:1 매칭 API 구현 (#44)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/match/controller/PersonalMatchController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/PersonalMatchController.kt
@@ -1,0 +1,49 @@
+package com.ditto.api.match.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.match.dto.PersonalMatchListResponse
+import com.ditto.api.match.dto.PersonalMatchRequest
+import com.ditto.api.match.dto.PersonalMatchResponse
+import com.ditto.api.match.service.PersonalMatchService
+import com.ditto.common.response.ApiResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class PersonalMatchController(
+    private val personalMatchService: PersonalMatchService,
+) {
+
+    @GetMapping("/api/v1/matches/1on1")
+    fun getPersonalMatches(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestParam quizSetId: Long,
+    ): ApiResponse<PersonalMatchListResponse> =
+        ApiResponse.ok(personalMatchService.getPersonalMatches(principal.memberId, quizSetId))
+
+    @PostMapping("/api/v1/matches/request")
+    fun requestMatch(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestBody request: PersonalMatchRequest,
+    ): ApiResponse<PersonalMatchResponse> =
+        ApiResponse.ok(personalMatchService.requestMatch(principal.memberId, request))
+
+    @PostMapping("/api/v1/matches/request/{id}/accept")
+    fun acceptMatch(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @PathVariable id: Long,
+    ): ApiResponse<PersonalMatchResponse> =
+        ApiResponse.ok(personalMatchService.acceptMatch(principal.memberId, id))
+
+    @PostMapping("/api/v1/matches/request/{id}/reject")
+    fun rejectMatch(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @PathVariable id: Long,
+    ): ApiResponse<PersonalMatchResponse> =
+        ApiResponse.ok(personalMatchService.rejectMatch(principal.memberId, id))
+}

--- a/api/src/main/kotlin/com/ditto/api/match/dto/PersonalMatchListResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/PersonalMatchListResponse.kt
@@ -1,0 +1,6 @@
+package com.ditto.api.match.dto
+
+data class PersonalMatchListResponse(
+    val sent: List<PersonalMatchResponse>,
+    val received: List<PersonalMatchResponse>,
+)

--- a/api/src/main/kotlin/com/ditto/api/match/dto/PersonalMatchRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/PersonalMatchRequest.kt
@@ -1,0 +1,6 @@
+package com.ditto.api.match.dto
+
+data class PersonalMatchRequest(
+    val receiverId: Long,
+    val quizSetId: Long,
+)

--- a/api/src/main/kotlin/com/ditto/api/match/dto/PersonalMatchResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/PersonalMatchResponse.kt
@@ -1,0 +1,27 @@
+package com.ditto.api.match.dto
+
+import com.ditto.domain.match.entity.PersonalMatch
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import java.time.LocalDateTime
+
+data class PersonalMatchResponse(
+    val id: Long,
+    val quizSetId: Long,
+    val requesterId: Long,
+    val receiverId: Long,
+    val status: PersonalMatchStatus,
+    val createdAt: LocalDateTime,
+    val respondedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(match: PersonalMatch): PersonalMatchResponse = PersonalMatchResponse(
+            id = match.id,
+            quizSetId = match.quizSetId,
+            requesterId = match.requesterId,
+            receiverId = match.receiverId(),
+            status = match.status,
+            createdAt = match.createdAt,
+            respondedAt = match.respondedAt,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/match/service/PersonalMatchService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/PersonalMatchService.kt
@@ -1,0 +1,96 @@
+package com.ditto.api.match.service
+
+import com.ditto.api.match.dto.PersonalMatchListResponse
+import com.ditto.api.match.dto.PersonalMatchRequest
+import com.ditto.api.match.dto.PersonalMatchResponse
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.match.entity.PersonalMatch
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class PersonalMatchService(
+    private val personalMatchRepository: PersonalMatchRepository,
+) {
+
+    /** 보낸/받은 1:1 매칭 요청 목록 조회 */
+    fun getPersonalMatches(memberId: Long, quizSetId: Long): PersonalMatchListResponse {
+        val sent = personalMatchRepository.findByRequesterIdAndQuizSetId(memberId, quizSetId)
+        val received = findReceivedMatches(memberId, quizSetId)
+        return PersonalMatchListResponse(
+            sent = sent.map { PersonalMatchResponse.from(it) },
+            received = received.map { PersonalMatchResponse.from(it) },
+        )
+    }
+
+    /** 1:1 매칭 요청 생성 */
+    @Transactional
+    fun requestMatch(requesterId: Long, request: PersonalMatchRequest): PersonalMatchResponse {
+        val (receiverId, quizSetId) = request
+
+        if (requesterId == receiverId) {
+            throw WarnException(ErrorCode.CANNOT_REQUEST_SELF)
+        }
+
+        val memberId1 = minOf(requesterId, receiverId)
+        val memberId2 = maxOf(requesterId, receiverId)
+
+        if (personalMatchRepository.existsByMemberId1AndMemberId2AndQuizSetId(memberId1, memberId2, quizSetId)) {
+            val existing = personalMatchRepository.findByMemberId1AndMemberId2AndQuizSetIdAndStatus(
+                memberId1, memberId2, quizSetId, PersonalMatchStatus.ACCEPTED
+            )
+            if (existing != null) {
+                throw WarnException(ErrorCode.ALREADY_MATCHED)
+            }
+            throw WarnException(ErrorCode.MATCH_REQUEST_ALREADY_EXISTS)
+        }
+
+        val match = personalMatchRepository.save(
+            PersonalMatch.create(
+                requesterId = requesterId,
+                receiverId = receiverId,
+                quizSetId = quizSetId,
+            )
+        )
+        return PersonalMatchResponse.from(match)
+    }
+
+    /** 1:1 매칭 수락 */
+    @Transactional
+    fun acceptMatch(memberId: Long, matchId: Long): PersonalMatchResponse {
+        val match = findMatchOrThrow(matchId)
+        validateReceiver(match, memberId)
+        match.accept()
+        return PersonalMatchResponse.from(match)
+    }
+
+    /** 1:1 매칭 거절 */
+    @Transactional
+    fun rejectMatch(memberId: Long, matchId: Long): PersonalMatchResponse {
+        val match = findMatchOrThrow(matchId)
+        validateReceiver(match, memberId)
+        match.reject()
+        return PersonalMatchResponse.from(match)
+    }
+
+    private fun findMatchOrThrow(matchId: Long): PersonalMatch =
+        personalMatchRepository.findById(matchId).orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+
+    private fun validateReceiver(match: PersonalMatch, memberId: Long) {
+        if (match.receiverId() != memberId) {
+            throw WarnException(ErrorCode.FORBIDDEN)
+        }
+    }
+
+    private fun findReceivedMatches(memberId: Long, quizSetId: Long): List<PersonalMatch> {
+        val receivedAsMember1 = personalMatchRepository
+            .findByMemberId1AndQuizSetIdAndRequesterIdNot(memberId, quizSetId, memberId)
+        val receivedAsMember2 = personalMatchRepository
+            .findByMemberId2AndQuizSetIdAndRequesterIdNot(memberId, quizSetId, memberId)
+        return receivedAsMember1 + receivedAsMember2
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/PersonalMatchControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/PersonalMatchControllerTest.kt
@@ -1,97 +1,235 @@
 package com.ditto.api.match
 
-import com.ditto.api.support.RestDocsTest
-import com.ditto.domain.match.PersonalMatchFixture
-import com.ditto.domain.match.repository.PersonalMatchRepository
+import com.ditto.api.match.controller.PersonalMatchController
+import com.ditto.api.match.dto.PersonalMatchListResponse
+import com.ditto.api.match.dto.PersonalMatchRequest
+import com.ditto.api.match.dto.PersonalMatchResponse
+import com.ditto.api.match.service.PersonalMatchService
+import com.ditto.api.support.ControllerUnitTest
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.restdocs.request.RequestDocumentation.queryParameters
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
 
-class PersonalMatchControllerTest : RestDocsTest() {
+class PersonalMatchControllerTest : ControllerUnitTest() {
 
-    @Autowired
-    private lateinit var personalMatchRepository: PersonalMatchRepository
+    private val personalMatchService: PersonalMatchService = mockk()
+
+    override val controller = PersonalMatchController(personalMatchService)
+
+    private fun sampleResponse(
+        id: Long = 1L,
+        requesterId: Long = 1L,
+        receiverId: Long = 2L,
+        status: PersonalMatchStatus = PersonalMatchStatus.PENDING,
+    ) = PersonalMatchResponse(
+        id = id,
+        quizSetId = 10L,
+        requesterId = requesterId,
+        receiverId = receiverId,
+        status = status,
+        createdAt = LocalDateTime.of(2026, 5, 1, 12, 0),
+        respondedAt = null,
+    )
 
     @Test
     @DisplayName("보낸/받은 1:1 매칭 요청 목록을 조회한다")
     fun getPersonalMatches() {
-        val requesterId = 1L
-        val quizSetId = 10L
-        personalMatchRepository.save(
-            PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = quizSetId)
-        )
-        personalMatchRepository.save(
-            PersonalMatchFixture.create(requesterId = 3L, receiverId = requesterId, quizSetId = quizSetId)
+        every { personalMatchService.getPersonalMatches(any(), any()) } returns PersonalMatchListResponse(
+            sent = listOf(sampleResponse(requesterId = 1L, receiverId = 2L)),
+            received = listOf(sampleResponse(id = 2L, requesterId = 3L, receiverId = 1L)),
         )
 
         mockMvc.perform(
-            get("/api/v1/matches/1on1")
-                .param("quizSetId", quizSetId.toString())
-                .withApiKey()
-                .withBearerToken(),
+            get("/api/v1/matches/1on1").param("quizSetId", "10"),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.sent.length()").value(1))
             .andExpect(jsonPath("$.data.received.length()").value(1))
+            .andDo(
+                document(
+                    "personal-match-list",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("1:1 매칭 요청 목록 조회")
+                            .description("퀴즈셋에 대한 내가 보낸/받은 1:1 매칭 요청 목록을 조회합니다.")
+                            .queryParameters(
+                                parameterWithName("quizSetId").description("퀴즈 세트 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.sent[]").description("내가 보낸 요청 목록"),
+                                fieldWithPath("data.sent[].id").description("매칭 ID"),
+                                fieldWithPath("data.sent[].quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.sent[].requesterId").description("요청자 ID"),
+                                fieldWithPath("data.sent[].receiverId").description("수신자 ID"),
+                                fieldWithPath("data.sent[].status").description("상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)"),
+                                fieldWithPath("data.sent[].createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.sent[].respondedAt").description("응답 일시 (없으면 null)").optional(),
+                                fieldWithPath("data.received[]").description("내가 받은 요청 목록"),
+                                fieldWithPath("data.received[].id").description("매칭 ID"),
+                                fieldWithPath("data.received[].quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.received[].requesterId").description("요청자 ID"),
+                                fieldWithPath("data.received[].receiverId").description("수신자 ID"),
+                                fieldWithPath("data.received[].status").description("상태"),
+                                fieldWithPath("data.received[].createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.received[].respondedAt").description("응답 일시 (없으면 null)").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 
     @Test
     @DisplayName("1:1 매칭을 요청한다")
     fun requestMatch() {
-        val body = """{"receiverId": 2, "quizSetId": 10}"""
+        every { personalMatchService.requestMatch(any(), any()) } returns sampleResponse()
 
         mockMvc.perform(
             post("/api/v1/matches/request")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(body)
-                .withApiKey()
-                .withBearerToken(),
+                .content(objectMapper.writeValueAsString(PersonalMatchRequest(receiverId = 2L, quizSetId = 10L))),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.requesterId").value(1))
-            .andExpect(jsonPath("$.data.receiverId").value(2))
             .andExpect(jsonPath("$.data.status").value("PENDING"))
+            .andDo(
+                document(
+                    "personal-match-request",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("1:1 매칭 요청")
+                            .description("상대방에게 1:1 매칭을 요청합니다.")
+                            .requestFields(
+                                fieldWithPath("receiverId").description("요청 대상 회원 ID"),
+                                fieldWithPath("quizSetId").description("퀴즈 세트 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.id").description("생성된 매칭 ID"),
+                                fieldWithPath("data.quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.requesterId").description("요청자 ID"),
+                                fieldWithPath("data.receiverId").description("수신자 ID"),
+                                fieldWithPath("data.status").description("매칭 상태 (PENDING)"),
+                                fieldWithPath("data.createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.respondedAt").description("응답 일시 (최초 요청 시 null)").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 
     @Test
     @DisplayName("1:1 매칭 요청을 수락한다")
     fun acceptMatch() {
-        // JWT 토큰은 memberId=1 로 발급되므로 receiverId=1 로 설정
-        val match = personalMatchRepository.save(
-            PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
-        )
+        every { personalMatchService.acceptMatch(any(), any()) } returns
+            sampleResponse(status = PersonalMatchStatus.ACCEPTED)
 
-        mockMvc.perform(
-            post("/api/v1/matches/request/${match.id}/accept")
-                .withApiKey()
-                .withBearerToken(),
-        )
+        mockMvc.perform(post("/api/v1/matches/request/{id}/accept", 1L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+            .andDo(
+                document(
+                    "personal-match-accept",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("id").description("매칭 ID"),
+                    ),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("1:1 매칭 수락")
+                            .description("받은 매칭 요청을 수락합니다. 수신자만 호출 가능합니다.")
+                            .pathParameters(
+                                parameterWithName("id").description("매칭 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.id").description("매칭 ID"),
+                                fieldWithPath("data.quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.requesterId").description("요청자 ID"),
+                                fieldWithPath("data.receiverId").description("수신자 ID"),
+                                fieldWithPath("data.status").description("변경된 매칭 상태 (ACCEPTED)"),
+                                fieldWithPath("data.createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.respondedAt").description("응답 일시").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 
     @Test
     @DisplayName("1:1 매칭 요청을 거절한다")
     fun rejectMatch() {
-        val match = personalMatchRepository.save(
-            PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
-        )
+        every { personalMatchService.rejectMatch(any(), any()) } returns
+            sampleResponse(status = PersonalMatchStatus.REJECTED)
 
-        mockMvc.perform(
-            post("/api/v1/matches/request/${match.id}/reject")
-                .withApiKey()
-                .withBearerToken(),
-        )
+        mockMvc.perform(post("/api/v1/matches/request/{id}/reject", 1L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.status").value("REJECTED"))
+            .andDo(
+                document(
+                    "personal-match-reject",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(
+                        parameterWithName("id").description("매칭 ID"),
+                    ),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("1:1 매칭 거절")
+                            .description("받은 매칭 요청을 거절합니다. 수신자만 호출 가능합니다.")
+                            .pathParameters(
+                                parameterWithName("id").description("매칭 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.id").description("매칭 ID"),
+                                fieldWithPath("data.quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.requesterId").description("요청자 ID"),
+                                fieldWithPath("data.receiverId").description("수신자 ID"),
+                                fieldWithPath("data.status").description("변경된 매칭 상태 (REJECTED)"),
+                                fieldWithPath("data.createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.respondedAt").description("응답 일시").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 }

--- a/api/src/test/kotlin/com/ditto/api/match/PersonalMatchControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/PersonalMatchControllerTest.kt
@@ -1,0 +1,97 @@
+package com.ditto.api.match
+
+import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class PersonalMatchControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var personalMatchRepository: PersonalMatchRepository
+
+    @Test
+    @DisplayName("보낸/받은 1:1 매칭 요청 목록을 조회한다")
+    fun getPersonalMatches() {
+        val requesterId = 1L
+        val quizSetId = 10L
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = quizSetId)
+        )
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 3L, receiverId = requesterId, quizSetId = quizSetId)
+        )
+
+        mockMvc.perform(
+            get("/api/v1/matches/1on1")
+                .param("quizSetId", quizSetId.toString())
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.sent.length()").value(1))
+            .andExpect(jsonPath("$.data.received.length()").value(1))
+    }
+
+    @Test
+    @DisplayName("1:1 매칭을 요청한다")
+    fun requestMatch() {
+        val body = """{"receiverId": 2, "quizSetId": 10}"""
+
+        mockMvc.perform(
+            post("/api/v1/matches/request")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(body)
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.requesterId").value(1))
+            .andExpect(jsonPath("$.data.receiverId").value(2))
+            .andExpect(jsonPath("$.data.status").value("PENDING"))
+    }
+
+    @Test
+    @DisplayName("1:1 매칭 요청을 수락한다")
+    fun acceptMatch() {
+        // JWT 토큰은 memberId=1 로 발급되므로 receiverId=1 로 설정
+        val match = personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
+        )
+
+        mockMvc.perform(
+            post("/api/v1/matches/request/${match.id}/accept")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("ACCEPTED"))
+    }
+
+    @Test
+    @DisplayName("1:1 매칭 요청을 거절한다")
+    fun rejectMatch() {
+        val match = personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
+        )
+
+        mockMvc.perform(
+            post("/api/v1/matches/request/${match.id}/reject")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.status").value("REJECTED"))
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/PersonalMatchServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/PersonalMatchServiceTest.kt
@@ -1,0 +1,223 @@
+package com.ditto.api.match
+
+import com.ditto.api.match.service.PersonalMatchService
+import com.ditto.api.support.IntegrationTest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.api.match.dto.PersonalMatchRequest
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+class PersonalMatchServiceTest(
+    private val personalMatchService: PersonalMatchService,
+    private val personalMatchRepository: PersonalMatchRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    "1:1 매칭 요청 목록 조회" - {
+
+        "given: 보낸 요청과 받은 요청이 모두 존재할 때" - {
+            "when: 퀴즈셋 ID로 조회하면" - {
+                "then: 보낸 목록과 받은 목록을 분리하여 반환한다" {
+                    val requesterId = 1L
+                    val quizSetId = 10L
+
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = quizSetId)
+                    )
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = 3L, receiverId = requesterId, quizSetId = quizSetId)
+                    )
+
+                    val result = personalMatchService.getPersonalMatches(requesterId, quizSetId)
+
+                    result.sent.size shouldBe 1
+                    result.sent[0].requesterId shouldBe requesterId
+                    result.received.size shouldBe 1
+                    result.received[0].receiverId shouldBe requesterId
+                }
+            }
+        }
+
+        "given: 다른 퀴즈셋의 요청이 있을 때" - {
+            "when: 특정 퀴즈셋 ID로 조회하면" - {
+                "then: 해당 퀴즈셋의 요청만 반환한다" {
+                    val requesterId = 1L
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = 10L)
+                    )
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = requesterId, receiverId = 3L, quizSetId = 20L)
+                    )
+
+                    val result = personalMatchService.getPersonalMatches(requesterId, 10L)
+
+                    result.sent.size shouldBe 1
+                    result.sent[0].quizSetId shouldBe 10L
+                }
+            }
+        }
+    }
+
+    "1:1 매칭 요청 생성" - {
+
+        "given: 정상적인 두 사용자가" - {
+            "when: 매칭을 요청하면" - {
+                "then: PENDING 상태의 매칭이 생성된다" {
+                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
+
+                    val result = personalMatchService.requestMatch(requesterId = 1L, request = request)
+
+                    result.requesterId shouldBe 1L
+                    result.receiverId shouldBe 2L
+                    result.quizSetId shouldBe 10L
+                    result.status shouldBe PersonalMatchStatus.PENDING
+                }
+            }
+        }
+
+        "given: 본인에게 매칭을 요청하면" - {
+            "when: requesterId == receiverId 일 때" - {
+                "then: CANNOT_REQUEST_SELF 예외가 발생한다" {
+                    val request = PersonalMatchRequest(receiverId = 1L, quizSetId = 10L)
+
+                    shouldThrow<WarnException> {
+                        personalMatchService.requestMatch(requesterId = 1L, request = request)
+                    }.errorCode shouldBe ErrorCode.CANNOT_REQUEST_SELF
+                }
+            }
+        }
+
+        "given: 이미 PENDING 상태의 매칭 요청이 존재할 때" - {
+            "when: 동일한 두 사용자가 다시 요청하면" - {
+                "then: MATCH_REQUEST_ALREADY_EXISTS 예외가 발생한다" {
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+                    )
+                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
+
+                    shouldThrow<WarnException> {
+                        personalMatchService.requestMatch(requesterId = 1L, request = request)
+                    }.errorCode shouldBe ErrorCode.MATCH_REQUEST_ALREADY_EXISTS
+                }
+            }
+        }
+
+        "given: 역방향 요청이 이미 PENDING 상태로 존재할 때" - {
+            "when: B→A 요청이 있는 상태에서 A→B 요청하면" - {
+                "then: MATCH_REQUEST_ALREADY_EXISTS 예외가 발생한다" {
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
+                    )
+                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
+
+                    shouldThrow<WarnException> {
+                        personalMatchService.requestMatch(requesterId = 1L, request = request)
+                    }.errorCode shouldBe ErrorCode.MATCH_REQUEST_ALREADY_EXISTS
+                }
+            }
+        }
+
+        "given: 이미 ACCEPTED 상태의 매칭이 존재할 때" - {
+            "when: 동일한 두 사용자가 다시 요청하면" - {
+                "then: ALREADY_MATCHED 예외가 발생한다" {
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(
+                            requesterId = 1L,
+                            receiverId = 2L,
+                            quizSetId = 10L,
+                            status = PersonalMatchStatus.ACCEPTED,
+                        )
+                    )
+                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
+
+                    shouldThrow<WarnException> {
+                        personalMatchService.requestMatch(requesterId = 1L, request = request)
+                    }.errorCode shouldBe ErrorCode.ALREADY_MATCHED
+                }
+            }
+        }
+    }
+
+    "1:1 매칭 수락" - {
+
+        "given: PENDING 상태의 매칭이 존재하고 수신자가 요청할 때" - {
+            "when: 매칭을 수락하면" - {
+                "then: 상태가 ACCEPTED로 변경된다" {
+                    val match = personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+                    )
+
+                    val result = personalMatchService.acceptMatch(memberId = 2L, matchId = match.id)
+
+                    result.status shouldBe PersonalMatchStatus.ACCEPTED
+                    result.respondedAt shouldBe result.respondedAt  // not null
+                }
+            }
+        }
+
+        "given: 수신자가 아닌 사용자가" - {
+            "when: 매칭을 수락하려 하면" - {
+                "then: FORBIDDEN 예외가 발생한다" {
+                    val match = personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+                    )
+
+                    shouldThrow<WarnException> {
+                        personalMatchService.acceptMatch(memberId = 99L, matchId = match.id)
+                    }.errorCode shouldBe ErrorCode.FORBIDDEN
+                }
+            }
+        }
+
+        "given: 존재하지 않는 매칭 ID로" - {
+            "when: 수락을 요청하면" - {
+                "then: NOT_FOUND 예외가 발생한다" {
+                    shouldThrow<WarnException> {
+                        personalMatchService.acceptMatch(memberId = 1L, matchId = 9999L)
+                    }.errorCode shouldBe ErrorCode.NOT_FOUND
+                }
+            }
+        }
+    }
+
+    "1:1 매칭 거절" - {
+
+        "given: PENDING 상태의 매칭이 존재하고 수신자가 요청할 때" - {
+            "when: 매칭을 거절하면" - {
+                "then: 상태가 REJECTED로 변경된다" {
+                    val match = personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+                    )
+
+                    val result = personalMatchService.rejectMatch(memberId = 2L, matchId = match.id)
+
+                    result.status shouldBe PersonalMatchStatus.REJECTED
+                }
+            }
+        }
+
+        "given: ACCEPTED 상태의 매칭을" - {
+            "when: 거절하려 하면" - {
+                "then: INVALID_STATUS_TRANSITION 예외가 발생한다" {
+                    val match = personalMatchRepository.save(
+                        PersonalMatchFixture.create(
+                            requesterId = 1L,
+                            receiverId = 2L,
+                            quizSetId = 10L,
+                            status = PersonalMatchStatus.ACCEPTED,
+                        )
+                    )
+
+                    shouldThrow<WarnException> {
+                        personalMatchService.rejectMatch(memberId = 2L, matchId = match.id)
+                    }.errorCode shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+                }
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/ditto/api/match/PersonalMatchServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/PersonalMatchServiceTest.kt
@@ -1,15 +1,16 @@
 package com.ditto.api.match
 
+import com.ditto.api.match.dto.PersonalMatchRequest
 import com.ditto.api.match.service.PersonalMatchService
 import com.ditto.api.support.IntegrationTest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
-import com.ditto.api.match.dto.PersonalMatchRequest
 import com.ditto.domain.match.PersonalMatchFixture
 import com.ditto.domain.match.entity.PersonalMatchStatus
 import com.ditto.domain.match.repository.PersonalMatchRepository
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
 import javax.sql.DataSource
 
 class PersonalMatchServiceTest(
@@ -18,206 +19,169 @@ class PersonalMatchServiceTest(
     dataSource: DataSource,
 ) : IntegrationTest(dataSource, {
 
-    "1:1 매칭 요청 목록 조회" - {
+    "보낸/받은 요청이 모두 있을 때 퀴즈셋 기준으로 분리하여 반환한다" {
+        // given
+        val requesterId = 1L
+        val quizSetId = 10L
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = quizSetId)
+        )
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 3L, receiverId = requesterId, quizSetId = quizSetId)
+        )
 
-        "given: 보낸 요청과 받은 요청이 모두 존재할 때" - {
-            "when: 퀴즈셋 ID로 조회하면" - {
-                "then: 보낸 목록과 받은 목록을 분리하여 반환한다" {
-                    val requesterId = 1L
-                    val quizSetId = 10L
+        // when
+        val result = personalMatchService.getPersonalMatches(requesterId, quizSetId)
 
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = quizSetId)
-                    )
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = 3L, receiverId = requesterId, quizSetId = quizSetId)
-                    )
-
-                    val result = personalMatchService.getPersonalMatches(requesterId, quizSetId)
-
-                    result.sent.size shouldBe 1
-                    result.sent[0].requesterId shouldBe requesterId
-                    result.received.size shouldBe 1
-                    result.received[0].receiverId shouldBe requesterId
-                }
-            }
-        }
-
-        "given: 다른 퀴즈셋의 요청이 있을 때" - {
-            "when: 특정 퀴즈셋 ID로 조회하면" - {
-                "then: 해당 퀴즈셋의 요청만 반환한다" {
-                    val requesterId = 1L
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = 10L)
-                    )
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = requesterId, receiverId = 3L, quizSetId = 20L)
-                    )
-
-                    val result = personalMatchService.getPersonalMatches(requesterId, 10L)
-
-                    result.sent.size shouldBe 1
-                    result.sent[0].quizSetId shouldBe 10L
-                }
-            }
-        }
+        // then
+        result.sent.size shouldBe 1
+        result.sent[0].requesterId shouldBe requesterId
+        result.received.size shouldBe 1
+        result.received[0].receiverId shouldBe requesterId
     }
 
-    "1:1 매칭 요청 생성" - {
+    "다른 퀴즈셋의 요청은 조회 결과에 포함되지 않는다" {
+        // given
+        val requesterId = 1L
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = requesterId, receiverId = 2L, quizSetId = 10L)
+        )
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = requesterId, receiverId = 3L, quizSetId = 20L)
+        )
 
-        "given: 정상적인 두 사용자가" - {
-            "when: 매칭을 요청하면" - {
-                "then: PENDING 상태의 매칭이 생성된다" {
-                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
+        // when
+        val result = personalMatchService.getPersonalMatches(requesterId, 10L)
 
-                    val result = personalMatchService.requestMatch(requesterId = 1L, request = request)
-
-                    result.requesterId shouldBe 1L
-                    result.receiverId shouldBe 2L
-                    result.quizSetId shouldBe 10L
-                    result.status shouldBe PersonalMatchStatus.PENDING
-                }
-            }
-        }
-
-        "given: 본인에게 매칭을 요청하면" - {
-            "when: requesterId == receiverId 일 때" - {
-                "then: CANNOT_REQUEST_SELF 예외가 발생한다" {
-                    val request = PersonalMatchRequest(receiverId = 1L, quizSetId = 10L)
-
-                    shouldThrow<WarnException> {
-                        personalMatchService.requestMatch(requesterId = 1L, request = request)
-                    }.errorCode shouldBe ErrorCode.CANNOT_REQUEST_SELF
-                }
-            }
-        }
-
-        "given: 이미 PENDING 상태의 매칭 요청이 존재할 때" - {
-            "when: 동일한 두 사용자가 다시 요청하면" - {
-                "then: MATCH_REQUEST_ALREADY_EXISTS 예외가 발생한다" {
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
-                    )
-                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
-
-                    shouldThrow<WarnException> {
-                        personalMatchService.requestMatch(requesterId = 1L, request = request)
-                    }.errorCode shouldBe ErrorCode.MATCH_REQUEST_ALREADY_EXISTS
-                }
-            }
-        }
-
-        "given: 역방향 요청이 이미 PENDING 상태로 존재할 때" - {
-            "when: B→A 요청이 있는 상태에서 A→B 요청하면" - {
-                "then: MATCH_REQUEST_ALREADY_EXISTS 예외가 발생한다" {
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
-                    )
-                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
-
-                    shouldThrow<WarnException> {
-                        personalMatchService.requestMatch(requesterId = 1L, request = request)
-                    }.errorCode shouldBe ErrorCode.MATCH_REQUEST_ALREADY_EXISTS
-                }
-            }
-        }
-
-        "given: 이미 ACCEPTED 상태의 매칭이 존재할 때" - {
-            "when: 동일한 두 사용자가 다시 요청하면" - {
-                "then: ALREADY_MATCHED 예외가 발생한다" {
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(
-                            requesterId = 1L,
-                            receiverId = 2L,
-                            quizSetId = 10L,
-                            status = PersonalMatchStatus.ACCEPTED,
-                        )
-                    )
-                    val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
-
-                    shouldThrow<WarnException> {
-                        personalMatchService.requestMatch(requesterId = 1L, request = request)
-                    }.errorCode shouldBe ErrorCode.ALREADY_MATCHED
-                }
-            }
-        }
+        // then
+        result.sent.size shouldBe 1
+        result.sent[0].quizSetId shouldBe 10L
     }
 
-    "1:1 매칭 수락" - {
+    "정상적인 매칭 요청 시 PENDING 상태의 매칭이 생성된다" {
+        // given
+        val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
 
-        "given: PENDING 상태의 매칭이 존재하고 수신자가 요청할 때" - {
-            "when: 매칭을 수락하면" - {
-                "then: 상태가 ACCEPTED로 변경된다" {
-                    val match = personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
-                    )
+        // when
+        val result = personalMatchService.requestMatch(requesterId = 1L, request = request)
 
-                    val result = personalMatchService.acceptMatch(memberId = 2L, matchId = match.id)
-
-                    result.status shouldBe PersonalMatchStatus.ACCEPTED
-                    result.respondedAt shouldBe result.respondedAt  // not null
-                }
-            }
-        }
-
-        "given: 수신자가 아닌 사용자가" - {
-            "when: 매칭을 수락하려 하면" - {
-                "then: FORBIDDEN 예외가 발생한다" {
-                    val match = personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
-                    )
-
-                    shouldThrow<WarnException> {
-                        personalMatchService.acceptMatch(memberId = 99L, matchId = match.id)
-                    }.errorCode shouldBe ErrorCode.FORBIDDEN
-                }
-            }
-        }
-
-        "given: 존재하지 않는 매칭 ID로" - {
-            "when: 수락을 요청하면" - {
-                "then: NOT_FOUND 예외가 발생한다" {
-                    shouldThrow<WarnException> {
-                        personalMatchService.acceptMatch(memberId = 1L, matchId = 9999L)
-                    }.errorCode shouldBe ErrorCode.NOT_FOUND
-                }
-            }
-        }
+        // then
+        result.requesterId shouldBe 1L
+        result.receiverId shouldBe 2L
+        result.quizSetId shouldBe 10L
+        result.status shouldBe PersonalMatchStatus.PENDING
     }
 
-    "1:1 매칭 거절" - {
+    "자기 자신에게 매칭 요청하면 CANNOT_REQUEST_SELF 예외가 발생한다" {
+        // given
+        val request = PersonalMatchRequest(receiverId = 1L, quizSetId = 10L)
 
-        "given: PENDING 상태의 매칭이 존재하고 수신자가 요청할 때" - {
-            "when: 매칭을 거절하면" - {
-                "then: 상태가 REJECTED로 변경된다" {
-                    val match = personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
-                    )
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.requestMatch(requesterId = 1L, request = request)
+        }.errorCode shouldBe ErrorCode.CANNOT_REQUEST_SELF
+    }
 
-                    val result = personalMatchService.rejectMatch(memberId = 2L, matchId = match.id)
+    "이미 PENDING 요청이 있는 동일 페어가 다시 요청하면 MATCH_REQUEST_ALREADY_EXISTS 예외가 발생한다" {
+        // given
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+        )
+        val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
 
-                    result.status shouldBe PersonalMatchStatus.REJECTED
-                }
-            }
-        }
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.requestMatch(requesterId = 1L, request = request)
+        }.errorCode shouldBe ErrorCode.MATCH_REQUEST_ALREADY_EXISTS
+    }
 
-        "given: ACCEPTED 상태의 매칭을" - {
-            "when: 거절하려 하면" - {
-                "then: INVALID_STATUS_TRANSITION 예외가 발생한다" {
-                    val match = personalMatchRepository.save(
-                        PersonalMatchFixture.create(
-                            requesterId = 1L,
-                            receiverId = 2L,
-                            quizSetId = 10L,
-                            status = PersonalMatchStatus.ACCEPTED,
-                        )
-                    )
+    "역방향 PENDING 요청이 있을 때 반대 방향으로 요청해도 MATCH_REQUEST_ALREADY_EXISTS 예외가 발생한다" {
+        // given
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 2L, receiverId = 1L, quizSetId = 10L)
+        )
+        val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
 
-                    shouldThrow<WarnException> {
-                        personalMatchService.rejectMatch(memberId = 2L, matchId = match.id)
-                    }.errorCode shouldBe ErrorCode.INVALID_STATUS_TRANSITION
-                }
-            }
-        }
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.requestMatch(requesterId = 1L, request = request)
+        }.errorCode shouldBe ErrorCode.MATCH_REQUEST_ALREADY_EXISTS
+    }
+
+    "이미 ACCEPTED 매칭이 있는 페어가 다시 요청하면 ALREADY_MATCHED 예외가 발생한다" {
+        // given
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = 1L, receiverId = 2L, quizSetId = 10L,
+                status = PersonalMatchStatus.ACCEPTED,
+            )
+        )
+        val request = PersonalMatchRequest(receiverId = 2L, quizSetId = 10L)
+
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.requestMatch(requesterId = 1L, request = request)
+        }.errorCode shouldBe ErrorCode.ALREADY_MATCHED
+    }
+
+    "수신자가 수락하면 상태가 ACCEPTED 로 변경되고 respondedAt 이 기록된다" {
+        // given
+        val match = personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+        )
+
+        // when
+        val result = personalMatchService.acceptMatch(memberId = 2L, matchId = match.id)
+
+        // then
+        result.status shouldBe PersonalMatchStatus.ACCEPTED
+        result.respondedAt shouldNotBe null
+    }
+
+    "수신자가 아닌 사용자가 수락을 시도하면 FORBIDDEN 예외가 발생한다" {
+        // given
+        val match = personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+        )
+
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.acceptMatch(memberId = 99L, matchId = match.id)
+        }.errorCode shouldBe ErrorCode.FORBIDDEN
+    }
+
+    "존재하지 않는 매칭 ID로 수락하면 NOT_FOUND 예외가 발생한다" {
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.acceptMatch(memberId = 1L, matchId = 9999L)
+        }.errorCode shouldBe ErrorCode.NOT_FOUND
+    }
+
+    "수신자가 거절하면 상태가 REJECTED 로 변경된다" {
+        // given
+        val match = personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 1L, receiverId = 2L, quizSetId = 10L)
+        )
+
+        // when
+        val result = personalMatchService.rejectMatch(memberId = 2L, matchId = match.id)
+
+        // then
+        result.status shouldBe PersonalMatchStatus.REJECTED
+    }
+
+    "ACCEPTED 상태의 매칭을 거절하려 하면 INVALID_STATUS_TRANSITION 예외가 발생한다" {
+        // given
+        val match = personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = 1L, receiverId = 2L, quizSetId = 10L,
+                status = PersonalMatchStatus.ACCEPTED,
+            )
+        )
+
+        // when & then
+        shouldThrow<WarnException> {
+            personalMatchService.rejectMatch(memberId = 2L, matchId = match.id)
+        }.errorCode shouldBe ErrorCode.INVALID_STATUS_TRANSITION
     }
 })


### PR DESCRIPTION
## Summary
- `GET /api/v1/matches/1on1?quizSetId=` — 보낸/받은 요청 목록 분리 반환
- `POST /api/v1/matches/request` — 매칭 요청 생성 (자기 자신·중복·ACCEPTED 중복 검증)
- `POST /api/v1/matches/request/{id}/accept` — 수신자만 수락 가능
- `POST /api/v1/matches/request/{id}/reject` — 수신자만 거절 가능

## Test plan
- [ ] 서비스 테스트 12개 통과 확인
- [ ] 컨트롤러 테스트 4개 통과 확인
- [ ] 자기 자신에게 요청 시 5001 에러 반환 확인
- [ ] 중복 요청 시 5002, 이미 매칭된 경우 5003 에러 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)