### PR TITLE
feat. 매칭 상태 조회 API 구현 (#42)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/match/controller/MatchingStatusController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/MatchingStatusController.kt
@@ -1,0 +1,23 @@
+package com.ditto.api.match.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.match.dto.MatchingStatusResponse
+import com.ditto.api.match.service.MatchingStatusService
+import com.ditto.common.response.ApiResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MatchingStatusController(
+    private val matchingStatusService: MatchingStatusService,
+) {
+
+    @GetMapping("/api/v1/matching/status/{quizSetId}")
+    fun getMatchingStatus(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @PathVariable quizSetId: Long,
+    ): ApiResponse<MatchingStatusResponse> =
+        ApiResponse.ok(matchingStatusService.getMatchingStatus(principal.memberId, quizSetId))
+}

--- a/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchStatus.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchStatus.kt
@@ -1,0 +1,7 @@
+package com.ditto.api.match.dto
+
+enum class GroupMatchStatus {
+    NONE,
+    JOINED,
+    DECLINED,
+}

--- a/api/src/main/kotlin/com/ditto/api/match/dto/MatchingStatusResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/MatchingStatusResponse.kt
@@ -1,0 +1,35 @@
+package com.ditto.api.match.dto
+
+import com.ditto.domain.match.entity.PersonalMatch
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import java.time.LocalDateTime
+
+data class MatchingStatusResponse(
+    val quizSetId: Long,
+    /** ACCEPTED > PENDING 순으로 우선 노출. 매칭이 없으면 null */
+    val personalMatch: PersonalMatchSummary?,
+    /** NONE / JOINED / DECLINED */
+    val groupMatchStatus: GroupMatchStatus,
+    /** groupMatchStatus == JOINED 일 때 설정 */
+    val groupMatchRoomId: Long?,
+)
+
+data class PersonalMatchSummary(
+    val id: Long,
+    val requesterId: Long,
+    val receiverId: Long,
+    val status: PersonalMatchStatus,
+    val createdAt: LocalDateTime,
+    val respondedAt: LocalDateTime?,
+) {
+    companion object {
+        fun from(match: PersonalMatch): PersonalMatchSummary = PersonalMatchSummary(
+            id = match.id,
+            requesterId = match.requesterId,
+            receiverId = match.receiverId(),
+            status = match.status,
+            createdAt = match.createdAt,
+            respondedAt = match.respondedAt,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/match/service/MatchingStatusService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/MatchingStatusService.kt
@@ -1,0 +1,60 @@
+package com.ditto.api.match.service
+
+import com.ditto.api.match.dto.GroupMatchStatus
+import com.ditto.api.match.dto.MatchingStatusResponse
+import com.ditto.api.match.dto.PersonalMatchSummary
+import com.ditto.domain.match.entity.PersonalMatch
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.GroupMatchDeclineRepository
+import com.ditto.domain.match.repository.GroupMatchMemberRepository
+import com.ditto.domain.match.repository.GroupMatchRepository
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MatchingStatusService(
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val groupMatchRepository: GroupMatchRepository,
+    private val groupMatchMemberRepository: GroupMatchMemberRepository,
+    private val groupMatchDeclineRepository: GroupMatchDeclineRepository,
+) {
+
+    fun getMatchingStatus(memberId: Long, quizSetId: Long): MatchingStatusResponse {
+        val personalMatch = resolvePersonalMatch(memberId, quizSetId)
+        val (groupMatchStatus, groupMatchRoomId) = resolveGroupMatchStatus(memberId, quizSetId)
+
+        return MatchingStatusResponse(
+            quizSetId = quizSetId,
+            personalMatch = personalMatch?.let { PersonalMatchSummary.from(it) },
+            groupMatchStatus = groupMatchStatus,
+            groupMatchRoomId = groupMatchRoomId,
+        )
+    }
+
+    /** ACCEPTED 매칭 우선, 없으면 PENDING 반환 */
+    private fun resolvePersonalMatch(memberId: Long, quizSetId: Long): PersonalMatch? {
+        return personalMatchRepository.findMatchByQuizSetIdAndStatusAndMemberId(
+            quizSetId, PersonalMatchStatus.ACCEPTED, memberId,
+        ) ?: personalMatchRepository.findMatchByQuizSetIdAndStatusAndMemberId(
+            quizSetId, PersonalMatchStatus.PENDING, memberId,
+        )
+    }
+
+    /** 그룹 매칭 상태: DECLINED > JOINED > NONE 순으로 판단 */
+    private fun resolveGroupMatchStatus(memberId: Long, quizSetId: Long): Pair<GroupMatchStatus, Long?> {
+        if (groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId)) {
+            return Pair(GroupMatchStatus.DECLINED, null)
+        }
+
+        val memberships = groupMatchMemberRepository.findByMemberIdAndQuizSetId(memberId, quizSetId)
+        if (memberships.isNotEmpty()) {
+            // 여러 방에 참여했을 경우 가장 최근 방 반환
+            val latestMembership = memberships.maxByOrNull { it.createdAt }!!
+            return Pair(GroupMatchStatus.JOINED, latestMembership.roomId)
+        }
+
+        return Pair(GroupMatchStatus.NONE, null)
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingStatusControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingStatusControllerTest.kt
@@ -1,0 +1,92 @@
+package com.ditto.api.match
+
+import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.match.GroupMatchFixture
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.GroupMatchDecline
+import com.ditto.domain.match.entity.GroupMatchMember
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.GroupMatchDeclineRepository
+import com.ditto.domain.match.repository.GroupMatchMemberRepository
+import com.ditto.domain.match.repository.GroupMatchRepository
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class MatchingStatusControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var personalMatchRepository: PersonalMatchRepository
+
+    @Autowired
+    private lateinit var groupMatchRepository: GroupMatchRepository
+
+    @Autowired
+    private lateinit var groupMatchMemberRepository: GroupMatchMemberRepository
+
+    @Autowired
+    private lateinit var groupMatchDeclineRepository: GroupMatchDeclineRepository
+
+    // JWT 토큰은 memberId=1 로 발급
+    private val memberId = 1L
+    private val quizSetId = 10L
+
+    @Test
+    @DisplayName("1:1 ACCEPTED 매칭이 있고 그룹 매칭에 참여한 상태를 조회한다")
+    fun getMatchingStatus_withAllStatuses() {
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = memberId, receiverId = 2L, quizSetId = quizSetId,
+                status = PersonalMatchStatus.ACCEPTED,
+            )
+        )
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+        groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+
+        mockMvc.perform(
+            get("/api/v1/matching/status/$quizSetId")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.quizSetId").value(quizSetId))
+            .andExpect(jsonPath("$.data.personalMatch.status").value("ACCEPTED"))
+            .andExpect(jsonPath("$.data.groupMatchStatus").value("JOINED"))
+            .andExpect(jsonPath("$.data.groupMatchRoomId").value(room.id))
+    }
+
+    @Test
+    @DisplayName("아무 매칭도 없을 때 NONE 상태를 반환한다")
+    fun getMatchingStatus_noMatches() {
+        mockMvc.perform(
+            get("/api/v1/matching/status/$quizSetId")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.personalMatch").doesNotExist())
+            .andExpect(jsonPath("$.data.groupMatchStatus").value("NONE"))
+            .andExpect(jsonPath("$.data.groupMatchRoomId").doesNotExist())
+    }
+
+    @Test
+    @DisplayName("그룹 매칭을 거절한 상태를 조회한다")
+    fun getMatchingStatus_declined() {
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+        mockMvc.perform(
+            get("/api/v1/matching/status/$quizSetId")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.groupMatchStatus").value("DECLINED"))
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingStatusControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingStatusControllerTest.kt
@@ -1,73 +1,107 @@
 package com.ditto.api.match
 
-import com.ditto.api.support.RestDocsTest
-import com.ditto.domain.match.GroupMatchFixture
-import com.ditto.domain.match.PersonalMatchFixture
-import com.ditto.domain.match.entity.GroupMatchDecline
-import com.ditto.domain.match.entity.GroupMatchMember
+import com.ditto.api.match.controller.MatchingStatusController
+import com.ditto.api.match.dto.GroupMatchStatus
+import com.ditto.api.match.dto.MatchingStatusResponse
+import com.ditto.api.match.dto.PersonalMatchSummary
+import com.ditto.api.match.service.MatchingStatusService
+import com.ditto.api.support.ControllerUnitTest
 import com.ditto.domain.match.entity.PersonalMatchStatus
-import com.ditto.domain.match.repository.GroupMatchDeclineRepository
-import com.ditto.domain.match.repository.GroupMatchMemberRepository
-import com.ditto.domain.match.repository.GroupMatchRepository
-import com.ditto.domain.match.repository.PersonalMatchRepository
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import java.time.LocalDateTime
 
-class MatchingStatusControllerTest : RestDocsTest() {
+class MatchingStatusControllerTest : ControllerUnitTest() {
 
-    @Autowired
-    private lateinit var personalMatchRepository: PersonalMatchRepository
+    private val matchingStatusService: MatchingStatusService = mockk()
 
-    @Autowired
-    private lateinit var groupMatchRepository: GroupMatchRepository
-
-    @Autowired
-    private lateinit var groupMatchMemberRepository: GroupMatchMemberRepository
-
-    @Autowired
-    private lateinit var groupMatchDeclineRepository: GroupMatchDeclineRepository
-
-    // JWT 토큰은 memberId=1 로 발급
-    private val memberId = 1L
-    private val quizSetId = 10L
+    override val controller = MatchingStatusController(matchingStatusService)
 
     @Test
-    @DisplayName("1:1 ACCEPTED 매칭이 있고 그룹 매칭에 참여한 상태를 조회한다")
+    @DisplayName("매칭 상태를 조회한다 — 1:1 ACCEPTED, 그룹 JOINED")
     fun getMatchingStatus_withAllStatuses() {
-        personalMatchRepository.save(
-            PersonalMatchFixture.create(
-                requesterId = memberId, receiverId = 2L, quizSetId = quizSetId,
+        every { matchingStatusService.getMatchingStatus(any(), any()) } returns MatchingStatusResponse(
+            quizSetId = 10L,
+            personalMatch = PersonalMatchSummary(
+                id = 1L,
+                requesterId = 1L,
+                receiverId = 2L,
                 status = PersonalMatchStatus.ACCEPTED,
-            )
+                createdAt = LocalDateTime.of(2026, 5, 1, 12, 0),
+                respondedAt = LocalDateTime.of(2026, 5, 1, 12, 30),
+            ),
+            groupMatchStatus = GroupMatchStatus.JOINED,
+            groupMatchRoomId = 5L,
         )
-        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
-        groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
 
-        mockMvc.perform(
-            get("/api/v1/matching/status/$quizSetId")
-                .withApiKey()
-                .withBearerToken(),
-        )
+        mockMvc.perform(get("/api/v1/matching/status/{quizSetId}", 10L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.quizSetId").value(quizSetId))
+            .andExpect(jsonPath("$.data.quizSetId").value(10))
             .andExpect(jsonPath("$.data.personalMatch.status").value("ACCEPTED"))
             .andExpect(jsonPath("$.data.groupMatchStatus").value("JOINED"))
-            .andExpect(jsonPath("$.data.groupMatchRoomId").value(room.id))
+            .andExpect(jsonPath("$.data.groupMatchRoomId").value(5))
+            .andDo(
+                document(
+                    "matching-status",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("매칭 상태 조회")
+                            .description(
+                                "퀴즈셋에 대한 나의 매칭 현황을 조회합니다.\n\n" +
+                                    "- **personalMatch**: ACCEPTED > PENDING 우선 반환. 없으면 null\n" +
+                                    "- **groupMatchStatus**: DECLINED > JOINED > NONE 순으로 판단",
+                            )
+                            .pathParameters(
+                                parameterWithName("quizSetId").description("퀴즈 세트 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.personalMatch").description("1:1 매칭 정보 (없으면 null)").optional(),
+                                fieldWithPath("data.personalMatch.id").description("매칭 ID").optional(),
+                                fieldWithPath("data.personalMatch.requesterId").description("요청자 ID").optional(),
+                                fieldWithPath("data.personalMatch.receiverId").description("수신자 ID").optional(),
+                                fieldWithPath("data.personalMatch.status").description("매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)").optional(),
+                                fieldWithPath("data.personalMatch.createdAt").description("요청 생성일시").optional(),
+                                fieldWithPath("data.personalMatch.respondedAt").description("응답 일시 (없으면 null)").optional(),
+                                fieldWithPath("data.groupMatchStatus").description("그룹 매칭 상태 (NONE / JOINED / DECLINED)"),
+                                fieldWithPath("data.groupMatchRoomId").description("참여 중인 그룹 방 ID (JOINED 일 때만 존재)").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 
     @Test
-    @DisplayName("아무 매칭도 없을 때 NONE 상태를 반환한다")
+    @DisplayName("매칭이 없으면 personalMatch=null, groupMatchStatus=NONE 을 반환한다")
     fun getMatchingStatus_noMatches() {
-        mockMvc.perform(
-            get("/api/v1/matching/status/$quizSetId")
-                .withApiKey()
-                .withBearerToken(),
+        every { matchingStatusService.getMatchingStatus(any(), any()) } returns MatchingStatusResponse(
+            quizSetId = 10L,
+            personalMatch = null,
+            groupMatchStatus = GroupMatchStatus.NONE,
+            groupMatchRoomId = null,
         )
+
+        mockMvc.perform(get("/api/v1/matching/status/{quizSetId}", 10L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.personalMatch").doesNotExist())
@@ -76,15 +110,16 @@ class MatchingStatusControllerTest : RestDocsTest() {
     }
 
     @Test
-    @DisplayName("그룹 매칭을 거절한 상태를 조회한다")
+    @DisplayName("그룹 매칭을 거절한 경우 DECLINED 를 반환한다")
     fun getMatchingStatus_declined() {
-        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
-
-        mockMvc.perform(
-            get("/api/v1/matching/status/$quizSetId")
-                .withApiKey()
-                .withBearerToken(),
+        every { matchingStatusService.getMatchingStatus(any(), any()) } returns MatchingStatusResponse(
+            quizSetId = 10L,
+            personalMatch = null,
+            groupMatchStatus = GroupMatchStatus.DECLINED,
+            groupMatchRoomId = null,
         )
+
+        mockMvc.perform(get("/api/v1/matching/status/{quizSetId}", 10L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.groupMatchStatus").value("DECLINED"))

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingStatusServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingStatusServiceTest.kt
@@ -28,129 +28,113 @@ class MatchingStatusServiceTest(
     val memberId = 1L
     val quizSetId = 10L
 
-    "매칭 상태 조회 — 1:1 매칭" - {
+    "아무 매칭도 없으면 personalMatch 가 null 로 반환된다" {
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        "given: 아무 매칭도 없을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: personalMatch 가 null 로 반환된다" {
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
-
-                    result.personalMatch shouldBe null
-                    result.quizSetId shouldBe quizSetId
-                }
-            }
-        }
-
-        "given: PENDING 상태의 1:1 매칭이 있을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: PENDING 매칭이 반환된다" {
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(requesterId = memberId, receiverId = 2L, quizSetId = quizSetId)
-                    )
-
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
-
-                    result.personalMatch shouldNotBe null
-                    result.personalMatch!!.status shouldBe PersonalMatchStatus.PENDING
-                }
-            }
-        }
-
-        "given: PENDING 과 ACCEPTED 매칭이 모두 있을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: ACCEPTED 매칭이 우선 반환된다" {
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(
-                            requesterId = memberId, receiverId = 2L, quizSetId = quizSetId,
-                            status = PersonalMatchStatus.PENDING,
-                        )
-                    )
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(
-                            requesterId = memberId, receiverId = 3L, quizSetId = quizSetId,
-                            status = PersonalMatchStatus.ACCEPTED,
-                        )
-                    )
-
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
-
-                    result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
-                }
-            }
-        }
-
-        "given: 내가 받은 ACCEPTED 매칭이 있을 때" - {
-            "when: 수신자 입장으로 상태를 조회하면" - {
-                "then: 해당 ACCEPTED 매칭이 반환된다" {
-                    personalMatchRepository.save(
-                        PersonalMatchFixture.create(
-                            requesterId = 2L, receiverId = memberId, quizSetId = quizSetId,
-                            status = PersonalMatchStatus.ACCEPTED,
-                        )
-                    )
-
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
-
-                    result.personalMatch shouldNotBe null
-                    result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
-                    result.personalMatch!!.receiverId shouldBe memberId
-                }
-            }
-        }
+        // then
+        result.personalMatch shouldBe null
+        result.quizSetId shouldBe quizSetId
     }
 
-    "매칭 상태 조회 — 그룹 매칭" - {
+    "PENDING 1:1 매칭이 있으면 해당 매칭을 반환한다" {
+        // given
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = memberId, receiverId = 2L, quizSetId = quizSetId)
+        )
 
-        "given: 그룹 매칭 이력이 없을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: groupMatchStatus 가 NONE 으로 반환된다" {
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-                    result.groupMatchStatus shouldBe GroupMatchStatus.NONE
-                    result.groupMatchRoomId shouldBe null
-                }
-            }
-        }
+        // then
+        result.personalMatch shouldNotBe null
+        result.personalMatch!!.status shouldBe PersonalMatchStatus.PENDING
+    }
 
-        "given: 그룹 매칭을 거절했을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: groupMatchStatus 가 DECLINED 으로 반환된다" {
-                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+    "PENDING 과 ACCEPTED 매칭이 모두 있을 때 ACCEPTED 가 우선 반환된다" {
+        // given
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = memberId, receiverId = 2L, quizSetId = quizSetId,
+                status = PersonalMatchStatus.PENDING,
+            )
+        )
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = memberId, receiverId = 3L, quizSetId = quizSetId,
+                status = PersonalMatchStatus.ACCEPTED,
+            )
+        )
 
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-                    result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
-                    result.groupMatchRoomId shouldBe null
-                }
-            }
-        }
+        // then
+        result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
+    }
 
-        "given: 그룹 방에 참여했을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: groupMatchStatus 가 JOINED 이고 roomId 가 반환된다" {
-                    val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
-                    groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+    "수신자 입장에서도 ACCEPTED 매칭이 반환된다" {
+        // given
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = 2L, receiverId = memberId, quizSetId = quizSetId,
+                status = PersonalMatchStatus.ACCEPTED,
+            )
+        )
 
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-                    result.groupMatchStatus shouldBe GroupMatchStatus.JOINED
-                    result.groupMatchRoomId shouldBe room.id
-                }
-            }
-        }
+        // then
+        result.personalMatch shouldNotBe null
+        result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
+        result.personalMatch!!.receiverId shouldBe memberId
+    }
 
-        "given: 거절 이력과 참여 이력이 모두 있을 때" - {
-            "when: 상태를 조회하면" - {
-                "then: DECLINED 가 JOINED 보다 우선 반환된다" {
-                    val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
-                    groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
-                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+    "그룹 매칭 이력이 없으면 NONE 이 반환된다" {
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+        // then
+        result.groupMatchStatus shouldBe GroupMatchStatus.NONE
+        result.groupMatchRoomId shouldBe null
+    }
 
-                    result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
-                }
-            }
-        }
+    "그룹 매칭을 거절하면 DECLINED 가 반환된다" {
+        // given
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+        // then
+        result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
+        result.groupMatchRoomId shouldBe null
+    }
+
+    "그룹 방에 참여하면 JOINED 와 roomId 가 반환된다" {
+        // given
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+        groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+        // then
+        result.groupMatchStatus shouldBe GroupMatchStatus.JOINED
+        result.groupMatchRoomId shouldBe room.id
+    }
+
+    "거절 이력과 참여 이력이 모두 있으면 DECLINED 가 우선 반환된다" {
+        // given
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+        groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+        // when
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+        // then
+        result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
     }
 })

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingStatusServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingStatusServiceTest.kt
@@ -1,0 +1,156 @@
+package com.ditto.api.match
+
+import com.ditto.api.match.dto.GroupMatchStatus
+import com.ditto.api.match.service.MatchingStatusService
+import com.ditto.api.support.IntegrationTest
+import com.ditto.domain.match.GroupMatchFixture
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.GroupMatchDecline
+import com.ditto.domain.match.entity.GroupMatchMember
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.GroupMatchDeclineRepository
+import com.ditto.domain.match.repository.GroupMatchMemberRepository
+import com.ditto.domain.match.repository.GroupMatchRepository
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import javax.sql.DataSource
+
+class MatchingStatusServiceTest(
+    private val matchingStatusService: MatchingStatusService,
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val groupMatchRepository: GroupMatchRepository,
+    private val groupMatchMemberRepository: GroupMatchMemberRepository,
+    private val groupMatchDeclineRepository: GroupMatchDeclineRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    val memberId = 1L
+    val quizSetId = 10L
+
+    "매칭 상태 조회 — 1:1 매칭" - {
+
+        "given: 아무 매칭도 없을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: personalMatch 가 null 로 반환된다" {
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.personalMatch shouldBe null
+                    result.quizSetId shouldBe quizSetId
+                }
+            }
+        }
+
+        "given: PENDING 상태의 1:1 매칭이 있을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: PENDING 매칭이 반환된다" {
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(requesterId = memberId, receiverId = 2L, quizSetId = quizSetId)
+                    )
+
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.personalMatch shouldNotBe null
+                    result.personalMatch!!.status shouldBe PersonalMatchStatus.PENDING
+                }
+            }
+        }
+
+        "given: PENDING 과 ACCEPTED 매칭이 모두 있을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: ACCEPTED 매칭이 우선 반환된다" {
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(
+                            requesterId = memberId, receiverId = 2L, quizSetId = quizSetId,
+                            status = PersonalMatchStatus.PENDING,
+                        )
+                    )
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(
+                            requesterId = memberId, receiverId = 3L, quizSetId = quizSetId,
+                            status = PersonalMatchStatus.ACCEPTED,
+                        )
+                    )
+
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
+                }
+            }
+        }
+
+        "given: 내가 받은 ACCEPTED 매칭이 있을 때" - {
+            "when: 수신자 입장으로 상태를 조회하면" - {
+                "then: 해당 ACCEPTED 매칭이 반환된다" {
+                    personalMatchRepository.save(
+                        PersonalMatchFixture.create(
+                            requesterId = 2L, receiverId = memberId, quizSetId = quizSetId,
+                            status = PersonalMatchStatus.ACCEPTED,
+                        )
+                    )
+
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.personalMatch shouldNotBe null
+                    result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
+                    result.personalMatch!!.receiverId shouldBe memberId
+                }
+            }
+        }
+    }
+
+    "매칭 상태 조회 — 그룹 매칭" - {
+
+        "given: 그룹 매칭 이력이 없을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: groupMatchStatus 가 NONE 으로 반환된다" {
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.groupMatchStatus shouldBe GroupMatchStatus.NONE
+                    result.groupMatchRoomId shouldBe null
+                }
+            }
+        }
+
+        "given: 그룹 매칭을 거절했을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: groupMatchStatus 가 DECLINED 으로 반환된다" {
+                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
+                    result.groupMatchRoomId shouldBe null
+                }
+            }
+        }
+
+        "given: 그룹 방에 참여했을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: groupMatchStatus 가 JOINED 이고 roomId 가 반환된다" {
+                    val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+                    groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.groupMatchStatus shouldBe GroupMatchStatus.JOINED
+                    result.groupMatchRoomId shouldBe room.id
+                }
+            }
+        }
+
+        "given: 거절 이력과 참여 이력이 모두 있을 때" - {
+            "when: 상태를 조회하면" - {
+                "then: DECLINED 가 JOINED 보다 우선 반환된다" {
+                    val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+                    groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+                    val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+                    result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
+                }
+            }
+        }
+    }
+})

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/GroupMatchMemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/GroupMatchMemberRepository.kt
@@ -2,10 +2,25 @@ package com.ditto.domain.match.repository
 
 import com.ditto.domain.match.entity.GroupMatchMember
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface GroupMatchMemberRepository : JpaRepository<GroupMatchMember, Long> {
 
     fun existsByRoomIdAndMemberId(roomId: Long, memberId: Long): Boolean
 
     fun findByRoomId(roomId: Long): List<GroupMatchMember>
+
+    /** 특정 퀴즈셋의 그룹 방에 참여한 멤버 레코드 조회 (GroupMatch JOIN) */
+    @Query(
+        """
+        SELECT gmm FROM GroupMatchMember gmm
+        JOIN GroupMatch gm ON gmm.roomId = gm.id
+        WHERE gmm.memberId = :memberId AND gm.quizSetId = :quizSetId
+        """,
+    )
+    fun findByMemberIdAndQuizSetId(
+        @Param("memberId") memberId: Long,
+        @Param("quizSetId") quizSetId: Long,
+    ): List<GroupMatchMember>
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryCustom.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.match.repository.querydsl
 
+import com.ditto.domain.match.entity.PersonalMatch
 import com.ditto.domain.match.entity.PersonalMatchStatus
 
 interface PersonalMatchRepositoryCustom {
@@ -9,4 +10,11 @@ interface PersonalMatchRepositoryCustom {
         status: PersonalMatchStatus,
         memberId: Long,
     ): Boolean
+
+    /** 특정 퀴즈셋에서 memberId가 포함된 특정 상태의 매칭 조회 (방향 무관) */
+    fun findMatchByQuizSetIdAndStatusAndMemberId(
+        quizSetId: Long,
+        status: PersonalMatchStatus,
+        memberId: Long,
+    ): PersonalMatch?
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryImpl.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.match.repository.querydsl
 
+import com.ditto.domain.match.entity.PersonalMatch
 import com.ditto.domain.match.entity.PersonalMatchStatus
 import com.ditto.domain.match.entity.QPersonalMatch.personalMatch
 import com.querydsl.jpa.impl.JPAQueryFactory
@@ -23,4 +24,17 @@ class PersonalMatchRepositoryImpl(
             personalMatch.memberId1.eq(memberId).or(personalMatch.memberId2.eq(memberId)),
         )
         .fetchFirst() != null
+
+    override fun findMatchByQuizSetIdAndStatusAndMemberId(
+        quizSetId: Long,
+        status: PersonalMatchStatus,
+        memberId: Long,
+    ): PersonalMatch? = queryFactory
+        .selectFrom(personalMatch)
+        .where(
+            personalMatch.quizSetId.eq(quizSetId),
+            personalMatch.status.eq(status),
+            personalMatch.memberId1.eq(memberId).or(personalMatch.memberId2.eq(memberId)),
+        )
+        .fetchFirst()
 }


### PR DESCRIPTION
## Summary
- `GET /api/v1/matching/status/{quizSetId}` — 퀴즈셋별 1:1·그룹 매칭 현황 통합 반환
- 1:1 매칭: ACCEPTED > PENDING 우선순위로 가장 관련 있는 매칭 반환
- 그룹 매칭 상태: DECLINED > JOINED > NONE 순으로 판단
- QueryDSL `findMatchByQuizSetIdAndStatusAndMemberId` 메서드 추가
- `GroupMatchMemberRepository`에 JPQL 퀴즈셋 기반 참여 조회 메서드 추가

## Test plan
- [ ] 서비스 테스트 8개 통과 확인
- [ ] 컨트롤러 테스트 3개 통과 확인
- [ ] ACCEPTED/PENDING 공존 시 ACCEPTED 우선 반환 확인
- [ ] DECLINED/JOINED 공존 시 DECLINED 우선 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)