### PR TITLE
feat. 그룹 매칭 API 구현 (#43)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/match/controller/GroupMatchController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/GroupMatchController.kt
@@ -1,0 +1,34 @@
+package com.ditto.api.match.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.match.dto.GroupMatchDeclineRequest
+import com.ditto.api.match.dto.GroupMatchJoinRequest
+import com.ditto.api.match.dto.GroupMatchJoinResponse
+import com.ditto.api.match.service.GroupMatchService
+import com.ditto.common.response.ApiResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class GroupMatchController(
+    private val groupMatchService: GroupMatchService,
+) {
+
+    @PostMapping("/api/v1/matches/group/join")
+    fun joinGroupMatch(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestBody request: GroupMatchJoinRequest,
+    ): ApiResponse<GroupMatchJoinResponse> =
+        ApiResponse.ok(groupMatchService.joinGroupMatch(principal.memberId, request))
+
+    @PostMapping("/api/v1/matches/group/decline")
+    fun declineGroupMatch(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        @RequestBody request: GroupMatchDeclineRequest,
+    ): ApiResponse<Unit> {
+        groupMatchService.declineGroupMatch(principal.memberId, request)
+        return ApiResponse(success = true)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchDeclineRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchDeclineRequest.kt
@@ -1,0 +1,5 @@
+package com.ditto.api.match.dto
+
+data class GroupMatchDeclineRequest(
+    val quizSetId: Long,
+)

--- a/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchJoinRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchJoinRequest.kt
@@ -1,0 +1,5 @@
+package com.ditto.api.match.dto
+
+data class GroupMatchJoinRequest(
+    val quizSetId: Long,
+)

--- a/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchJoinResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchJoinResponse.kt
@@ -1,0 +1,19 @@
+package com.ditto.api.match.dto
+
+import com.ditto.domain.match.entity.GroupMatch
+
+data class GroupMatchJoinResponse(
+    val roomId: Long,
+    val quizSetId: Long,
+    val participantCount: Int,
+    val isActive: Boolean,
+) {
+    companion object {
+        fun from(room: GroupMatch): GroupMatchJoinResponse = GroupMatchJoinResponse(
+            roomId = room.id,
+            quizSetId = room.quizSetId,
+            participantCount = room.participantCount,
+            isActive = room.isActive,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/match/service/GroupMatchService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/GroupMatchService.kt
@@ -1,0 +1,64 @@
+package com.ditto.api.match.service
+
+import com.ditto.api.match.dto.GroupMatchDeclineRequest
+import com.ditto.api.match.dto.GroupMatchJoinRequest
+import com.ditto.api.match.dto.GroupMatchJoinResponse
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.match.entity.GroupMatch
+import com.ditto.domain.match.entity.GroupMatchDecline
+import com.ditto.domain.match.entity.GroupMatchMember
+import com.ditto.domain.match.repository.GroupMatchDeclineRepository
+import com.ditto.domain.match.repository.GroupMatchMemberRepository
+import com.ditto.domain.match.repository.GroupMatchRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class GroupMatchService(
+    private val groupMatchRepository: GroupMatchRepository,
+    private val groupMatchMemberRepository: GroupMatchMemberRepository,
+    private val groupMatchDeclineRepository: GroupMatchDeclineRepository,
+) {
+
+    /** 그룹 매칭 참여 */
+    @Transactional
+    fun joinGroupMatch(memberId: Long, request: GroupMatchJoinRequest): GroupMatchJoinResponse {
+        val quizSetId = request.quizSetId
+
+        if (groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId)) {
+            throw WarnException(ErrorCode.ALREADY_DECLINED_GROUP)
+        }
+
+        if (groupMatchMemberRepository.existsByMemberIdAndQuizSetId(memberId, quizSetId)) {
+            throw WarnException(ErrorCode.ALREADY_JOINED_GROUP)
+        }
+
+        val room = findOrCreateRoom(quizSetId)
+        room.addParticipant()
+        groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+
+        return GroupMatchJoinResponse.from(room)
+    }
+
+    /** 그룹 매칭 거절 */
+    @Transactional
+    fun declineGroupMatch(memberId: Long, request: GroupMatchDeclineRequest) {
+        val quizSetId = request.quizSetId
+
+        if (groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId)) {
+            throw WarnException(ErrorCode.ALREADY_DECLINED_GROUP)
+        }
+
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+    }
+
+    /** 참여 가능한 방이 있으면 반환, 없으면 새 방 생성 */
+    private fun findOrCreateRoom(quizSetId: Long): GroupMatch {
+        val existingRoom = groupMatchRepository
+            .findFirstByQuizSetIdAndIsActiveFalseOrderByCreatedAtAsc(quizSetId)
+
+        return existingRoom ?: groupMatchRepository.save(GroupMatch.create(quizSetId))
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/GroupMatchControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/GroupMatchControllerTest.kt
@@ -1,65 +1,96 @@
 package com.ditto.api.match
 
-import com.ditto.api.support.RestDocsTest
-import com.ditto.domain.match.entity.GroupMatchDecline
-import com.ditto.domain.match.repository.GroupMatchDeclineRepository
-import com.ditto.domain.match.repository.GroupMatchRepository
+import com.ditto.api.match.controller.GroupMatchController
+import com.ditto.api.match.dto.GroupMatchDeclineRequest
+import com.ditto.api.match.dto.GroupMatchJoinRequest
+import com.ditto.api.match.dto.GroupMatchJoinResponse
+import com.ditto.api.match.service.GroupMatchService
+import com.ditto.api.support.ControllerUnitTest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import io.mockk.every
+import io.mockk.mockk
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
-import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.MediaType
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
-class GroupMatchControllerTest : RestDocsTest() {
+class GroupMatchControllerTest : ControllerUnitTest() {
 
-    @Autowired
-    private lateinit var groupMatchRepository: GroupMatchRepository
+    private val groupMatchService: GroupMatchService = mockk()
 
-    @Autowired
-    private lateinit var groupMatchDeclineRepository: GroupMatchDeclineRepository
-
-    // JWT 토큰은 memberId=1 로 발급
-    private val memberId = 1L
-    private val quizSetId = 10L
+    override val controller = GroupMatchController(groupMatchService)
 
     @Test
     @DisplayName("그룹 매칭에 참여한다")
     fun joinGroupMatch() {
+        every { groupMatchService.joinGroupMatch(any(), any()) } returns GroupMatchJoinResponse(
+            roomId = 1L,
+            quizSetId = 10L,
+            participantCount = 1,
+            isActive = false,
+        )
+
         mockMvc.perform(
             post("/api/v1/matches/group/join")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"quizSetId": $quizSetId}""")
-                .withApiKey()
-                .withBearerToken(),
+                .content(objectMapper.writeValueAsString(GroupMatchJoinRequest(quizSetId = 10L))),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.quizSetId").value(quizSetId))
+            .andExpect(jsonPath("$.data.roomId").value(1))
             .andExpect(jsonPath("$.data.participantCount").value(1))
             .andExpect(jsonPath("$.data.isActive").value(false))
+            .andDo(
+                document(
+                    "group-match-join",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("그룹 매칭 참여")
+                            .description(
+                                "그룹 매칭에 참여합니다.\n\n" +
+                                    "- 참여 가능한 방이 있으면 기존 방에 배정됩니다.\n" +
+                                    "- 참여 가능한 방이 없으면 새 방을 생성합니다.\n" +
+                                    "- 참여자가 3명이 되면 방이 활성화(isActive=true)됩니다.",
+                            )
+                            .requestFields(
+                                fieldWithPath("quizSetId").description("퀴즈 세트 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.roomId").description("배정된 그룹 방 ID"),
+                                fieldWithPath("data.quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.participantCount").description("현재 참여자 수"),
+                                fieldWithPath("data.isActive").description("방 활성화 여부 (참여자 3명 이상이면 true)"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 
     @Test
-    @DisplayName("이미 그룹 매칭에 참여했으면 409를 반환한다")
+    @DisplayName("이미 참여한 경우 에러를 반환한다")
     fun joinGroupMatch_alreadyJoined() {
-        // 먼저 참여
-        mockMvc.perform(
-            post("/api/v1/matches/group/join")
-                .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"quizSetId": $quizSetId}""")
-                .withApiKey()
-                .withBearerToken(),
-        )
+        every { groupMatchService.joinGroupMatch(any(), any()) } throws WarnException(ErrorCode.ALREADY_JOINED_GROUP)
 
-        // 중복 참여
         mockMvc.perform(
             post("/api/v1/matches/group/join")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"quizSetId": $quizSetId}""")
-                .withApiKey()
-                .withBearerToken(),
+                .content(objectMapper.writeValueAsString(GroupMatchJoinRequest(quizSetId = 10L))),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(false))
@@ -69,28 +100,48 @@ class GroupMatchControllerTest : RestDocsTest() {
     @Test
     @DisplayName("그룹 매칭을 거절한다")
     fun declineGroupMatch() {
+        every { groupMatchService.declineGroupMatch(any(), any()) } returns Unit
+
         mockMvc.perform(
             post("/api/v1/matches/group/decline")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"quizSetId": $quizSetId}""")
-                .withApiKey()
-                .withBearerToken(),
+                .content(objectMapper.writeValueAsString(GroupMatchDeclineRequest(quizSetId = 10L))),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
+            .andDo(
+                document(
+                    "group-match-decline",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("그룹 매칭 거절")
+                            .description("그룹 매칭 참여를 거절합니다. 한 퀴즈셋당 한 번만 거절할 수 있습니다.")
+                            .requestFields(
+                                fieldWithPath("quizSetId").description("퀴즈 세트 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data").description("데이터 (null)").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
     }
 
     @Test
-    @DisplayName("이미 거절했으면 409를 반환한다")
+    @DisplayName("이미 거절한 경우 에러를 반환한다")
     fun declineGroupMatch_alreadyDeclined() {
-        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+        every { groupMatchService.declineGroupMatch(any(), any()) } throws WarnException(ErrorCode.ALREADY_DECLINED_GROUP)
 
         mockMvc.perform(
             post("/api/v1/matches/group/decline")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content("""{"quizSetId": $quizSetId}""")
-                .withApiKey()
-                .withBearerToken(),
+                .content(objectMapper.writeValueAsString(GroupMatchDeclineRequest(quizSetId = 10L))),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(false))

--- a/api/src/test/kotlin/com/ditto/api/match/GroupMatchControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/GroupMatchControllerTest.kt
@@ -1,0 +1,99 @@
+package com.ditto.api.match
+
+import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.match.entity.GroupMatchDecline
+import com.ditto.domain.match.repository.GroupMatchDeclineRepository
+import com.ditto.domain.match.repository.GroupMatchRepository
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class GroupMatchControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var groupMatchRepository: GroupMatchRepository
+
+    @Autowired
+    private lateinit var groupMatchDeclineRepository: GroupMatchDeclineRepository
+
+    // JWT 토큰은 memberId=1 로 발급
+    private val memberId = 1L
+    private val quizSetId = 10L
+
+    @Test
+    @DisplayName("그룹 매칭에 참여한다")
+    fun joinGroupMatch() {
+        mockMvc.perform(
+            post("/api/v1/matches/group/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"quizSetId": $quizSetId}""")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.quizSetId").value(quizSetId))
+            .andExpect(jsonPath("$.data.participantCount").value(1))
+            .andExpect(jsonPath("$.data.isActive").value(false))
+    }
+
+    @Test
+    @DisplayName("이미 그룹 매칭에 참여했으면 409를 반환한다")
+    fun joinGroupMatch_alreadyJoined() {
+        // 먼저 참여
+        mockMvc.perform(
+            post("/api/v1/matches/group/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"quizSetId": $quizSetId}""")
+                .withApiKey()
+                .withBearerToken(),
+        )
+
+        // 중복 참여
+        mockMvc.perform(
+            post("/api/v1/matches/group/join")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"quizSetId": $quizSetId}""")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("5005"))
+    }
+
+    @Test
+    @DisplayName("그룹 매칭을 거절한다")
+    fun declineGroupMatch() {
+        mockMvc.perform(
+            post("/api/v1/matches/group/decline")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"quizSetId": $quizSetId}""")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+    }
+
+    @Test
+    @DisplayName("이미 거절했으면 409를 반환한다")
+    fun declineGroupMatch_alreadyDeclined() {
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+        mockMvc.perform(
+            post("/api/v1/matches/group/decline")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content("""{"quizSetId": $quizSetId}""")
+                .withApiKey()
+                .withBearerToken(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("5006"))
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/GroupMatchServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/GroupMatchServiceTest.kt
@@ -1,0 +1,136 @@
+package com.ditto.api.match
+
+import com.ditto.api.match.dto.GroupMatchDeclineRequest
+import com.ditto.api.match.dto.GroupMatchJoinRequest
+import com.ditto.api.match.service.GroupMatchService
+import com.ditto.api.support.IntegrationTest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.match.GroupMatchFixture
+import com.ditto.domain.match.entity.GroupMatchDecline
+import com.ditto.domain.match.entity.GroupMatchMember
+import com.ditto.domain.match.repository.GroupMatchDeclineRepository
+import com.ditto.domain.match.repository.GroupMatchMemberRepository
+import com.ditto.domain.match.repository.GroupMatchRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import javax.sql.DataSource
+
+class GroupMatchServiceTest(
+    private val groupMatchService: GroupMatchService,
+    private val groupMatchRepository: GroupMatchRepository,
+    private val groupMatchMemberRepository: GroupMatchMemberRepository,
+    private val groupMatchDeclineRepository: GroupMatchDeclineRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    val memberId = 1L
+    val quizSetId = 10L
+
+    "그룹 매칭 참여" - {
+
+        "given: 아무 방도 없을 때" - {
+            "when: 첫 번째 멤버가 참여하면" - {
+                "then: 새 방이 생성되고 참여자 수가 1이 된다" {
+                    val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+
+                    result.quizSetId shouldBe quizSetId
+                    result.participantCount shouldBe 1
+                    result.isActive shouldBe false
+                    result.roomId shouldNotBe 0L
+                }
+            }
+        }
+
+        "given: 비활성 방이 이미 존재할 때" - {
+            "when: 새 멤버가 참여하면" - {
+                "then: 기존 방에 배정된다" {
+                    val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+
+                    val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+
+                    result.roomId shouldBe room.id
+                    result.participantCount shouldBe 1
+                }
+            }
+        }
+
+        "given: 3명이 같은 방에 참여할 때" - {
+            "when: 세 번째 멤버가 참여하면" - {
+                "then: 방이 활성화된다 (isActive = true)" {
+                    groupMatchService.joinGroupMatch(1L, GroupMatchJoinRequest(quizSetId))
+                    groupMatchService.joinGroupMatch(2L, GroupMatchJoinRequest(quizSetId))
+                    val result = groupMatchService.joinGroupMatch(3L, GroupMatchJoinRequest(quizSetId))
+
+                    result.isActive shouldBe true
+                    result.participantCount shouldBe 3
+                }
+            }
+        }
+
+        "given: 활성화된 방만 있을 때" - {
+            "when: 새 멤버가 참여하면" - {
+                "then: 새 방이 생성된다" {
+                    val activeRoom = groupMatchRepository.save(
+                        GroupMatchFixture.create(quizSetId = quizSetId, isActive = true, participantCount = 3)
+                    )
+
+                    val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+
+                    result.roomId shouldNotBe activeRoom.id
+                    result.isActive shouldBe false
+                }
+            }
+        }
+
+        "given: 이미 그룹 매칭에 참여했을 때" - {
+            "when: 같은 퀴즈셋으로 다시 참여하면" - {
+                "then: ALREADY_JOINED_GROUP 예외가 발생한다" {
+                    groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+
+                    shouldThrow<WarnException> {
+                        groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+                    }.errorCode shouldBe ErrorCode.ALREADY_JOINED_GROUP
+                }
+            }
+        }
+
+        "given: 그룹 매칭을 거절했을 때" - {
+            "when: 다시 참여하려 하면" - {
+                "then: ALREADY_DECLINED_GROUP 예외가 발생한다" {
+                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+                    shouldThrow<WarnException> {
+                        groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+                    }.errorCode shouldBe ErrorCode.ALREADY_DECLINED_GROUP
+                }
+            }
+        }
+    }
+
+    "그룹 매칭 거절" - {
+
+        "given: 거절 이력이 없을 때" - {
+            "when: 거절하면" - {
+                "then: GroupMatchDecline 레코드가 생성된다" {
+                    groupMatchService.declineGroupMatch(memberId, GroupMatchDeclineRequest(quizSetId))
+
+                    groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId) shouldBe true
+                }
+            }
+        }
+
+        "given: 이미 거절했을 때" - {
+            "when: 다시 거절하면" - {
+                "then: ALREADY_DECLINED_GROUP 예외가 발생한다" {
+                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+                    shouldThrow<WarnException> {
+                        groupMatchService.declineGroupMatch(memberId, GroupMatchDeclineRequest(quizSetId))
+                    }.errorCode shouldBe ErrorCode.ALREADY_DECLINED_GROUP
+                }
+            }
+        }
+    }
+})

--- a/api/src/test/kotlin/com/ditto/api/match/GroupMatchServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/GroupMatchServiceTest.kt
@@ -8,7 +8,6 @@ import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
 import com.ditto.domain.match.GroupMatchFixture
 import com.ditto.domain.match.entity.GroupMatchDecline
-import com.ditto.domain.match.entity.GroupMatchMember
 import com.ditto.domain.match.repository.GroupMatchDeclineRepository
 import com.ditto.domain.match.repository.GroupMatchMemberRepository
 import com.ditto.domain.match.repository.GroupMatchRepository
@@ -28,109 +27,91 @@ class GroupMatchServiceTest(
     val memberId = 1L
     val quizSetId = 10L
 
-    "그룹 매칭 참여" - {
+    "빈 방이 없으면 새 방을 생성하고 참여자 수가 1이 된다" {
+        // when
+        val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
 
-        "given: 아무 방도 없을 때" - {
-            "when: 첫 번째 멤버가 참여하면" - {
-                "then: 새 방이 생성되고 참여자 수가 1이 된다" {
-                    val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
-
-                    result.quizSetId shouldBe quizSetId
-                    result.participantCount shouldBe 1
-                    result.isActive shouldBe false
-                    result.roomId shouldNotBe 0L
-                }
-            }
-        }
-
-        "given: 비활성 방이 이미 존재할 때" - {
-            "when: 새 멤버가 참여하면" - {
-                "then: 기존 방에 배정된다" {
-                    val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
-
-                    val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
-
-                    result.roomId shouldBe room.id
-                    result.participantCount shouldBe 1
-                }
-            }
-        }
-
-        "given: 3명이 같은 방에 참여할 때" - {
-            "when: 세 번째 멤버가 참여하면" - {
-                "then: 방이 활성화된다 (isActive = true)" {
-                    groupMatchService.joinGroupMatch(1L, GroupMatchJoinRequest(quizSetId))
-                    groupMatchService.joinGroupMatch(2L, GroupMatchJoinRequest(quizSetId))
-                    val result = groupMatchService.joinGroupMatch(3L, GroupMatchJoinRequest(quizSetId))
-
-                    result.isActive shouldBe true
-                    result.participantCount shouldBe 3
-                }
-            }
-        }
-
-        "given: 활성화된 방만 있을 때" - {
-            "when: 새 멤버가 참여하면" - {
-                "then: 새 방이 생성된다" {
-                    val activeRoom = groupMatchRepository.save(
-                        GroupMatchFixture.create(quizSetId = quizSetId, isActive = true, participantCount = 3)
-                    )
-
-                    val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
-
-                    result.roomId shouldNotBe activeRoom.id
-                    result.isActive shouldBe false
-                }
-            }
-        }
-
-        "given: 이미 그룹 매칭에 참여했을 때" - {
-            "when: 같은 퀴즈셋으로 다시 참여하면" - {
-                "then: ALREADY_JOINED_GROUP 예외가 발생한다" {
-                    groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
-
-                    shouldThrow<WarnException> {
-                        groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
-                    }.errorCode shouldBe ErrorCode.ALREADY_JOINED_GROUP
-                }
-            }
-        }
-
-        "given: 그룹 매칭을 거절했을 때" - {
-            "when: 다시 참여하려 하면" - {
-                "then: ALREADY_DECLINED_GROUP 예외가 발생한다" {
-                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
-
-                    shouldThrow<WarnException> {
-                        groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
-                    }.errorCode shouldBe ErrorCode.ALREADY_DECLINED_GROUP
-                }
-            }
-        }
+        // then
+        result.quizSetId shouldBe quizSetId
+        result.participantCount shouldBe 1
+        result.isActive shouldBe false
+        result.roomId shouldNotBe 0L
     }
 
-    "그룹 매칭 거절" - {
+    "비활성 방이 있으면 기존 방에 배정된다" {
+        // given
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
 
-        "given: 거절 이력이 없을 때" - {
-            "when: 거절하면" - {
-                "then: GroupMatchDecline 레코드가 생성된다" {
-                    groupMatchService.declineGroupMatch(memberId, GroupMatchDeclineRequest(quizSetId))
+        // when
+        val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
 
-                    groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId) shouldBe true
-                }
-            }
-        }
+        // then
+        result.roomId shouldBe room.id
+        result.participantCount shouldBe 1
+    }
 
-        "given: 이미 거절했을 때" - {
-            "when: 다시 거절하면" - {
-                "then: ALREADY_DECLINED_GROUP 예외가 발생한다" {
-                    groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+    "3번째 멤버가 참여하면 방이 활성화된다" {
+        // given
+        groupMatchService.joinGroupMatch(1L, GroupMatchJoinRequest(quizSetId))
+        groupMatchService.joinGroupMatch(2L, GroupMatchJoinRequest(quizSetId))
 
-                    shouldThrow<WarnException> {
-                        groupMatchService.declineGroupMatch(memberId, GroupMatchDeclineRequest(quizSetId))
-                    }.errorCode shouldBe ErrorCode.ALREADY_DECLINED_GROUP
-                }
-            }
-        }
+        // when
+        val result = groupMatchService.joinGroupMatch(3L, GroupMatchJoinRequest(quizSetId))
+
+        // then
+        result.isActive shouldBe true
+        result.participantCount shouldBe 3
+    }
+
+    "활성화된 방만 있으면 새 방이 생성된다" {
+        // given
+        val activeRoom = groupMatchRepository.save(
+            GroupMatchFixture.create(quizSetId = quizSetId, isActive = true, participantCount = 3)
+        )
+
+        // when
+        val result = groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+
+        // then
+        result.roomId shouldNotBe activeRoom.id
+        result.isActive shouldBe false
+    }
+
+    "이미 참여한 퀴즈셋에 다시 참여하면 ALREADY_JOINED_GROUP 예외가 발생한다" {
+        // given
+        groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+
+        // when & then
+        shouldThrow<WarnException> {
+            groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+        }.errorCode shouldBe ErrorCode.ALREADY_JOINED_GROUP
+    }
+
+    "거절한 퀴즈셋에 참여하려 하면 ALREADY_DECLINED_GROUP 예외가 발생한다" {
+        // given
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+        // when & then
+        shouldThrow<WarnException> {
+            groupMatchService.joinGroupMatch(memberId, GroupMatchJoinRequest(quizSetId))
+        }.errorCode shouldBe ErrorCode.ALREADY_DECLINED_GROUP
+    }
+
+    "그룹 매칭을 거절하면 GroupMatchDecline 레코드가 생성된다" {
+        // when
+        groupMatchService.declineGroupMatch(memberId, GroupMatchDeclineRequest(quizSetId))
+
+        // then
+        groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId) shouldBe true
+    }
+
+    "이미 거절한 퀴즈셋을 다시 거절하면 ALREADY_DECLINED_GROUP 예외가 발생한다" {
+        // given
+        groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
+
+        // when & then
+        shouldThrow<WarnException> {
+            groupMatchService.declineGroupMatch(memberId, GroupMatchDeclineRequest(quizSetId))
+        }.errorCode shouldBe ErrorCode.ALREADY_DECLINED_GROUP
     }
 })

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/GroupMatchMemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/GroupMatchMemberRepository.kt
@@ -1,27 +1,12 @@
 package com.ditto.domain.match.repository
 
 import com.ditto.domain.match.entity.GroupMatchMember
+import com.ditto.domain.match.repository.querydsl.GroupMatchMemberRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
-import org.springframework.data.jpa.repository.Query
-import org.springframework.data.repository.query.Param
 
-interface GroupMatchMemberRepository : JpaRepository<GroupMatchMember, Long> {
+interface GroupMatchMemberRepository : JpaRepository<GroupMatchMember, Long>, GroupMatchMemberRepositoryCustom {
 
     fun existsByRoomIdAndMemberId(roomId: Long, memberId: Long): Boolean
 
     fun findByRoomId(roomId: Long): List<GroupMatchMember>
-
-    /** 특정 퀴즈셋의 그룹 방에 참여 중인지 확인 (GroupMatch JOIN) */
-    @Query(
-        """
-        SELECT CASE WHEN COUNT(gmm) > 0 THEN true ELSE false END
-        FROM GroupMatchMember gmm
-        JOIN GroupMatch gm ON gmm.roomId = gm.id
-        WHERE gmm.memberId = :memberId AND gm.quizSetId = :quizSetId
-        """,
-    )
-    fun existsByMemberIdAndQuizSetId(
-        @Param("memberId") memberId: Long,
-        @Param("quizSetId") quizSetId: Long,
-    ): Boolean
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/GroupMatchMemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/GroupMatchMemberRepository.kt
@@ -2,10 +2,26 @@ package com.ditto.domain.match.repository
 
 import com.ditto.domain.match.entity.GroupMatchMember
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
 
 interface GroupMatchMemberRepository : JpaRepository<GroupMatchMember, Long> {
 
     fun existsByRoomIdAndMemberId(roomId: Long, memberId: Long): Boolean
 
     fun findByRoomId(roomId: Long): List<GroupMatchMember>
+
+    /** 특정 퀴즈셋의 그룹 방에 참여 중인지 확인 (GroupMatch JOIN) */
+    @Query(
+        """
+        SELECT CASE WHEN COUNT(gmm) > 0 THEN true ELSE false END
+        FROM GroupMatchMember gmm
+        JOIN GroupMatch gm ON gmm.roomId = gm.id
+        WHERE gmm.memberId = :memberId AND gm.quizSetId = :quizSetId
+        """,
+    )
+    fun existsByMemberIdAndQuizSetId(
+        @Param("memberId") memberId: Long,
+        @Param("quizSetId") quizSetId: Long,
+    ): Boolean
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/GroupMatchMemberRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/GroupMatchMemberRepositoryCustom.kt
@@ -1,0 +1,6 @@
+package com.ditto.domain.match.repository.querydsl
+
+interface GroupMatchMemberRepositoryCustom {
+
+    fun existsByMemberIdAndQuizSetId(memberId: Long, quizSetId: Long): Boolean
+}

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/GroupMatchMemberRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/GroupMatchMemberRepositoryImpl.kt
@@ -1,0 +1,22 @@
+package com.ditto.domain.match.repository.querydsl
+
+import com.ditto.domain.match.entity.QGroupMatch.groupMatch
+import com.ditto.domain.match.entity.QGroupMatchMember.groupMatchMember
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+class GroupMatchMemberRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : GroupMatchMemberRepositoryCustom {
+
+    override fun existsByMemberIdAndQuizSetId(memberId: Long, quizSetId: Long): Boolean = queryFactory
+        .selectOne()
+        .from(groupMatchMember)
+        .join(groupMatch).on(groupMatchMember.roomId.eq(groupMatch.id))
+        .where(
+            groupMatchMember.memberId.eq(memberId),
+            groupMatch.quizSetId.eq(quizSetId),
+        )
+        .fetchFirst() != null
+}

--- a/domain/src/test/kotlin/com/ditto/domain/match/entity/GroupMatchTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/match/entity/GroupMatchTest.kt
@@ -105,6 +105,47 @@ class GroupMatchRoomTest(
                 }
             }
         }
+
+        "given: 멤버1이 quizSetId=1 인 방에 참여해 있을 때" - {
+            "when: existsByMemberIdAndQuizSetId(memberId=1, quizSetId=1) 를 조회하면" - {
+                "then: true 를 반환한다" {
+                    val room = groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
+                    groupMatchRoomMemberRepository.save(GroupMatchMember.of(roomId = room.id, memberId = 1L))
+
+                    groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(
+                        memberId = 1L,
+                        quizSetId = 1L,
+                    ) shouldBe true
+                }
+            }
+        }
+
+        "given: 멤버1이 quizSetId=1 인 방에 참여해 있을 때" - {
+            "when: existsByMemberIdAndQuizSetId(memberId=1, quizSetId=2) 를 조회하면" - {
+                "then: quizSetId 가 달라 false 를 반환한다" {
+                    val room = groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
+                    groupMatchRoomMemberRepository.save(GroupMatchMember.of(roomId = room.id, memberId = 1L))
+
+                    groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(
+                        memberId = 1L,
+                        quizSetId = 2L,
+                    ) shouldBe false
+                }
+            }
+        }
+
+        "given: 멤버1이 아무 방에도 참여하지 않았을 때" - {
+            "when: existsByMemberIdAndQuizSetId(memberId=1, quizSetId=1) 를 조회하면" - {
+                "then: false 를 반환한다" {
+                    groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
+
+                    groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(
+                        memberId = 1L,
+                        quizSetId = 1L,
+                    ) shouldBe false
+                }
+            }
+        }
     }
 
     "GroupMatchDecline" - {

--- a/domain/src/test/kotlin/com/ditto/domain/match/entity/GroupMatchTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/match/entity/GroupMatchTest.kt
@@ -106,45 +106,39 @@ class GroupMatchRoomTest(
             }
         }
 
-        "given: 멤버1이 quizSetId=1 인 방에 참여해 있을 때" - {
-            "when: existsByMemberIdAndQuizSetId(memberId=1, quizSetId=1) 를 조회하면" - {
-                "then: true 를 반환한다" {
-                    val room = groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
-                    groupMatchRoomMemberRepository.save(GroupMatchMember.of(roomId = room.id, memberId = 1L))
+        "멤버1이 quizSetId=1 인 방에 참여해 있을 때, 동일 quizSetId 로 조회하면 true 를 반환한다" {
+            // given
+            val room = groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
+            groupMatchRoomMemberRepository.save(GroupMatchMember.of(roomId = room.id, memberId = 1L))
 
-                    groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(
-                        memberId = 1L,
-                        quizSetId = 1L,
-                    ) shouldBe true
-                }
-            }
+            // when
+            val result = groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(memberId = 1L, quizSetId = 1L)
+
+            // then
+            result shouldBe true
         }
 
-        "given: 멤버1이 quizSetId=1 인 방에 참여해 있을 때" - {
-            "when: existsByMemberIdAndQuizSetId(memberId=1, quizSetId=2) 를 조회하면" - {
-                "then: quizSetId 가 달라 false 를 반환한다" {
-                    val room = groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
-                    groupMatchRoomMemberRepository.save(GroupMatchMember.of(roomId = room.id, memberId = 1L))
+        "멤버1이 quizSetId=1 인 방에 참여해 있을 때, 다른 quizSetId 로 조회하면 false 를 반환한다" {
+            // given
+            val room = groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
+            groupMatchRoomMemberRepository.save(GroupMatchMember.of(roomId = room.id, memberId = 1L))
 
-                    groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(
-                        memberId = 1L,
-                        quizSetId = 2L,
-                    ) shouldBe false
-                }
-            }
+            // when
+            val result = groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(memberId = 1L, quizSetId = 2L)
+
+            // then
+            result shouldBe false
         }
 
-        "given: 멤버1이 아무 방에도 참여하지 않았을 때" - {
-            "when: existsByMemberIdAndQuizSetId(memberId=1, quizSetId=1) 를 조회하면" - {
-                "then: false 를 반환한다" {
-                    groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
+        "멤버1이 아무 방에도 참여하지 않았을 때, existsByMemberIdAndQuizSetId 는 false 를 반환한다" {
+            // given
+            groupMatchRoomRepository.save(GroupMatchFixture.create(quizSetId = 1L))
 
-                    groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(
-                        memberId = 1L,
-                        quizSetId = 1L,
-                    ) shouldBe false
-                }
-            }
+            // when
+            val result = groupMatchRoomMemberRepository.existsByMemberIdAndQuizSetId(memberId = 1L, quizSetId = 1L)
+
+            // then
+            result shouldBe false
         }
     }
 


### PR DESCRIPTION
## Summary
- `POST /api/v1/matches/group/join` — 그룹 매칭 참여 (비활성 방 배정 or 신규 생성, 3명 시 자동 활성화)
- `POST /api/v1/matches/group/decline` — 그룹 매칭 거절 (중복 거절 방지)
- `GroupMatchMemberRepository`에 JPQL `existsByMemberIdAndQuizSetId` 추가

## Test plan
- [ ] 서비스 테스트 8개 통과 확인
- [ ] 컨트롤러 테스트 4개 통과 확인
- [ ] 비활성 방 있을 때 기존 방에 배정되는지 확인
- [ ] 3명 참여 시 방이 활성화(isActive=true)되는지 확인
- [ ] 이미 참여/거절 시 각각 5005/5006 에러 반환 확인

🤖 Generated with [Claude Code](https://claude.com/claude-code)