### PR TITLE
feat. CORS 설정 추가 (#54)

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -40,6 +40,10 @@
                 {
                     "name": "JWT_EXPIRATION_MS",
                     "value": "3600000"
+                },
+                {
+                    "name": "CORS_ALLOWED_ORIGINS",
+                    "value": "https://test.ditto.pics,http://localhost:3000"
                 }
             ],
             "secrets": [

--- a/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
@@ -2,6 +2,7 @@ package com.ditto.api.config
 
 import com.ditto.api.config.auth.ApiKeyAuthFilter
 import com.ditto.api.config.auth.ApiKeyProperties
+import com.ditto.api.config.auth.CorsProperties
 import com.ditto.api.config.auth.JwtAuthenticationFilter
 import com.ditto.api.config.auth.JwtTokenProvider
 import org.springframework.context.annotation.Bean
@@ -12,12 +13,16 @@ import org.springframework.security.config.annotation.web.configuration.EnableWe
 import org.springframework.security.config.http.SessionCreationPolicy
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import org.springframework.web.cors.CorsConfiguration
+import org.springframework.web.cors.CorsConfigurationSource
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource
 
 @Configuration
 @EnableWebSecurity
 class SecurityConfig(
     private val apiKeyProperties: ApiKeyProperties,
     private val jwtTokenProvider: JwtTokenProvider,
+    private val corsProperties: CorsProperties,
 ) {
 
     /**
@@ -63,6 +68,7 @@ class SecurityConfig(
                 "/api/v1/users/nickname/**",
             )
             .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .addFilterBefore(ApiKeyAuthFilter(apiKeyProperties), UsernamePasswordAuthenticationFilter::class.java)
             .authorizeHttpRequests { it.anyRequest().authenticated() }
@@ -78,6 +84,7 @@ class SecurityConfig(
         return http
             .securityMatcher("/api/**")
             .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .addFilterBefore(ApiKeyAuthFilter(apiKeyProperties), UsernamePasswordAuthenticationFilter::class.java)
             .addFilterAfter(JwtAuthenticationFilter(jwtTokenProvider), ApiKeyAuthFilter::class.java)
@@ -96,5 +103,24 @@ class SecurityConfig(
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .authorizeHttpRequests { it.anyRequest().denyAll() }
             .build()
+    }
+
+    /**
+     * CORS 설정 — 허용 origin은 `ditto.cors.allowed-origins`(yml/환경변수)로 관리
+     * 인증 헤더(Authorization, X-API-Key)를 allowedHeaders에 포함한다.
+     * Bearer 토큰 기반이라 쿠키를 쓰지 않으므로 allowCredentials는 false.
+     */
+    @Bean
+    fun corsConfigurationSource(): CorsConfigurationSource {
+        val config = CorsConfiguration().apply {
+            allowedOrigins = corsProperties.allowedOrigins
+            allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
+            allowedHeaders = listOf("Authorization", "Content-Type", "X-API-Key")
+            allowCredentials = false
+            maxAge = 3600L
+        }
+        return UrlBasedCorsConfigurationSource().apply {
+            registerCorsConfiguration("/api/**", config)
+        }
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/config/auth/CorsProperties.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/CorsProperties.kt
@@ -1,0 +1,8 @@
+package com.ditto.api.config.auth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "ditto.cors")
+data class CorsProperties(
+    val allowedOrigins: List<String> = emptyList(),
+)

--- a/api/src/main/resources/application-prod.yml
+++ b/api/src/main/resources/application-prod.yml
@@ -25,6 +25,9 @@ ditto:
       - WEDNESDAY
   security:
     api-key: ${API_KEY}
+  cors:
+    # 쉼표 구분 환경변수 (예: https://ditto.pics,https://www.ditto.pics) — TODO(#54): 프론트 도메인 확정 필요
+    allowed-origins: ${CORS_ALLOWED_ORIGINS}
   jwt:
     secret: ${JWT_SECRET}
     expiration-ms: ${JWT_EXPIRATION_MS}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -19,6 +19,11 @@ springdoc:
 ditto:
   security:
     api-key: test-api-key
+  cors:
+    # TODO(#54): 웹 프론트 dev origin 확정 필요
+    allowed-origins:
+      - http://localhost:3000
+      - http://localhost:5173
   jwt:
     secret: local-dev-jwt-secret-key-must-be-at-least-256-bits-long-for-hmac-sha
     expiration-ms: 3600000

--- a/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
@@ -7,7 +7,9 @@ import org.junit.jupiter.api.Test
 import org.springframework.context.annotation.Import
 import org.springframework.http.MediaType
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.options
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -121,6 +123,34 @@ class SecurityConfigTest : RestDocsTest() {
                     .content(request),
             )
                 .andExpect(status().isUnauthorized)
+        }
+    }
+
+    @Nested
+    @DisplayName("CORS")
+    inner class Cors {
+
+        @Test
+        @DisplayName("허용된 origin의 preflight 요청은 CORS 헤더와 함께 허용된다")
+        fun allowedOriginPreflight() {
+            mockMvc.perform(
+                options("/api/test/warn")
+                    .header("Origin", "http://localhost:3000")
+                    .header("Access-Control-Request-Method", "GET"),
+            )
+                .andExpect(status().isOk)
+                .andExpect(header().string("Access-Control-Allow-Origin", "http://localhost:3000"))
+        }
+
+        @Test
+        @DisplayName("허용되지 않은 origin의 preflight 요청은 차단된다")
+        fun disallowedOriginPreflight() {
+            mockMvc.perform(
+                options("/api/test/warn")
+                    .header("Origin", "https://evil.com")
+                    .header("Access-Control-Request-Method", "GET"),
+            )
+                .andExpect(status().isForbidden)
         }
     }
 


### PR DESCRIPTION
## Summary
- `SecurityConfig`에 `CorsConfigurationSource` 빈 추가, `/api/**` 필터체인(Order 3·4)에 `.cors` 적용
- 허용 origin을 `ditto.cors.allowed-origins`로 외부화 (`CorsProperties` 신규)
  - local/test: `http://localhost:3000`, `http://localhost:5173`
  - prod: `${CORS_ALLOWED_ORIGINS}` (task-definition env) → `https://test.ditto.pics`, `http://localhost:3000`
- `allowedHeaders`에 `Authorization`·`X-API-Key` 포함, `allowCredentials=false`, `maxAge=3600`
- preflight `OPTIONS`가 `denyAll`에 막히던 문제 해결

## Test plan
- [x] `SecurityConfigTest` 13개 전부 통과 (CORS 2개 포함, failures=0)
- [x] 허용 origin preflight(`OPTIONS`) → 200 + `Access-Control-Allow-Origin` 헤더 확인
- [x] 미허용 origin preflight → 403 차단 확인
- [ ] prod 배포 후 `https://test.ditto.pics`에서 cross-origin 호출 정상 확인

Closes #54

🤖 Generated with [Claude Code](https://claude.com/claude-code)
