### PR TITLE
feat. OAuth 엔드포인트 X-API-Key 인증 예외 처리 (#56)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
@@ -55,14 +55,31 @@ class SecurityConfig(
     }
 
     /**
-     * API Key만 필요 (소셜 로그인, 토큰 갱신 등 JWT 불필요)
+     * 인증 불필요 (permitAll) — X-API-Key·JWT 없이 접근 가능한 공개 엔드포인트
      */
     @Bean
     @Order(3)
+    fun publicApiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
+        return http
+            .securityMatcher(
+                "/api/v1/users/social-login/*",
+                "/api/v1/users/social-login/*/callback",
+            )
+            .csrf { it.disable() }
+            .cors { it.configurationSource(corsConfigurationSource()) }
+            .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
+            .authorizeHttpRequests { it.anyRequest().permitAll() }
+            .build()
+    }
+
+    /**
+     * API Key만 필요 (토큰 갱신, 회원가입 등 JWT 불필요)
+     */
+    @Bean
+    @Order(4)
     fun apiKeyOnlySecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
             .securityMatcher(
-                "/api/v1/users/social-login/**",
                 "/api/v1/users/auth/refresh",
                 "/api/v1/users",
                 "/api/v1/users/nickname/**",
@@ -79,7 +96,7 @@ class SecurityConfig(
      * API — API Key + JWT 인증 필수
      */
     @Bean
-    @Order(4)
+    @Order(5)
     fun apiSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
             .securityMatcher("/api/**")
@@ -96,7 +113,7 @@ class SecurityConfig(
      * 그 외 모든 경로 — 차단
      */
     @Bean
-    @Order(5)
+    @Order(6)
     fun defaultSecurityFilterChain(http: HttpSecurity): SecurityFilterChain {
         return http
             .csrf { it.disable() }

--- a/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
@@ -127,6 +127,30 @@ class SecurityConfigTest : RestDocsTest() {
     }
 
     @Nested
+    @DisplayName("OAuth 인증 예외")
+    inner class OAuthExempt {
+
+        @Test
+        @DisplayName("API Key 없이 소셜 로그인 시작 엔드포인트에 접근할 수 있다")
+        fun loginWithoutApiKey() {
+            mockMvc.perform(get("/api/v1/users/social-login/{provider}", "KAKAO"))
+                .andExpect(status().isFound)
+                .andExpect(header().exists("Location"))
+        }
+
+        @Test
+        @DisplayName("API Key 없이 소셜 로그인 콜백 엔드포인트에 접근할 수 있다")
+        fun callbackWithoutApiKey() {
+            mockMvc.perform(
+                get("/api/v1/users/social-login/{provider}/callback", "KAKAO")
+                    .param("code", "test-auth-code"),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+    }
+
+    @Nested
     @DisplayName("CORS")
     inner class Cors {
 


### PR DESCRIPTION
## Summary
- `publicApiSecurityFilterChain` (Order 3, `permitAll`) 추가 — 소셜 로그인 시작/콜백을 `X-API-Key` 없이 접근 가능하게 예외 처리
  - `GET /api/v1/users/social-login/{provider}`
  - `GET /api/v1/users/social-login/{provider}/callback`
- `ApiKeyAuthFilter`는 경로와 무관하게 키가 없으면 401을 반환하므로, 해당 필터가 없는 별도 `SecurityFilterChain`으로 분리
- `apiKeyOnly` 매처에서 `social-login/**` 제거, 필터체인 Order 재정렬 (3~6)

## 배경
OAuth 시작은 브라우저 네비게이션(302), 콜백은 카카오 서버 리다이렉트로 호출되어 `X-API-Key` 헤더를 부착할 수 없음. 기존엔 `apiKeyOnly` 체인에 묶여 API Key가 강제되어 정상 로그인 플로우가 막혔음.

## Test plan
- [x] 전체 api 153개 테스트 통과 (failures=0)
- [x] API Key 없이 social-login 시작 → 302 + `Location`
- [x] API Key 없이 social-login 콜백 → 200, `success=true`
- [x] 기존 `OAuthControllerTest` 회귀 없음

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)
