### PR TITLE
feat. OAuth 콜백 응답을 프론트엔드 페이지로 리다이렉트

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -46,8 +46,8 @@
                     "value": "https://test.ditto.pics,http://localhost:3000"
                 },
                 {
-                    "name": "FRONT_URL",
-                    "value": "https://test.ditto.pics"
+                    "name": "FRONT_OAUTH_CALLBACK_URL",
+                    "value": "https://test.ditto.pics/auth/callback"
                 }
             ],
             "secrets": [

--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -44,6 +44,10 @@
                 {
                     "name": "CORS_ALLOWED_ORIGINS",
                     "value": "https://test.ditto.pics,http://localhost:3000"
+                },
+                {
+                    "name": "FRONT_URL",
+                    "value": "https://test.ditto.pics"
                 }
             ],
             "secrets": [

--- a/api/src/main/kotlin/com/ditto/api/auth/controller/OAuthController.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/controller/OAuthController.kt
@@ -1,7 +1,6 @@
 package com.ditto.api.auth.controller
 
 import com.ditto.api.auth.facade.OAuthFacade
-import com.ditto.api.config.FrontProperties
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -10,14 +9,12 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
-import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
 @RestController
 @RequestMapping("api/v1/users/social-login")
 class OAuthController(
     private val oAuthFacade: OAuthFacade,
-    private val frontProperties: FrontProperties,
 ) {
 
     @GetMapping("/{provider}")
@@ -33,17 +30,9 @@ class OAuthController(
         @PathVariable provider: SocialProvider,
         @RequestParam code: String,
     ): ResponseEntity<Unit> {
-        val result = oAuthFacade.login(provider, code)
-        val redirectUri = UriComponentsBuilder.fromUriString(frontProperties.url)
-            .path(frontProperties.oauthCallbackPath)
-            .apply {
-                result.accessToken?.let { queryParam("accessToken", it) }
-                result.refreshToken?.let { queryParam("refreshToken", it) }
-            }
-            .build()
-            .toUri()
+        val redirectUrl = oAuthFacade.login(provider, code)
         return ResponseEntity.status(HttpStatus.FOUND)
-            .location(redirectUri)
+            .location(URI.create(redirectUrl))
             .build()
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/controller/OAuthController.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/controller/OAuthController.kt
@@ -1,8 +1,7 @@
 package com.ditto.api.auth.controller
 
-import com.ditto.api.auth.dto.OAuthLoginResponse
 import com.ditto.api.auth.facade.OAuthFacade
-import com.ditto.common.response.ApiResponse
+import com.ditto.api.config.FrontProperties
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
@@ -11,12 +10,14 @@ import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.RequestMapping
 import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
+import org.springframework.web.util.UriComponentsBuilder
 import java.net.URI
 
 @RestController
 @RequestMapping("api/v1/users/social-login")
 class OAuthController(
     private val oAuthFacade: OAuthFacade,
+    private val frontProperties: FrontProperties,
 ) {
 
     @GetMapping("/{provider}")
@@ -31,8 +32,18 @@ class OAuthController(
     fun callback(
         @PathVariable provider: SocialProvider,
         @RequestParam code: String,
-    ): ApiResponse<OAuthLoginResponse> {
+    ): ResponseEntity<Unit> {
         val result = oAuthFacade.login(provider, code)
-        return ApiResponse.ok(result)
+        val redirectUri = UriComponentsBuilder.fromUriString(frontProperties.url)
+            .path(frontProperties.oauthCallbackPath)
+            .apply {
+                result.accessToken?.let { queryParam("accessToken", it) }
+                result.refreshToken?.let { queryParam("refreshToken", it) }
+            }
+            .build()
+            .toUri()
+        return ResponseEntity.status(HttpStatus.FOUND)
+            .location(redirectUri)
+            .build()
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.auth.facade
 
-import com.ditto.api.auth.dto.OAuthLoginResponse
 import com.ditto.api.auth.service.AuthService
 import com.ditto.api.auth.service.MemberSocialAccountService
 import com.ditto.api.auth.service.OAuthService
@@ -15,19 +14,21 @@ class OAuthFacade(
     private val jwtTokenProvider: JwtTokenProvider,
     private val authService: AuthService,
 ) {
-    fun getAuthorizationUrl(provider: SocialProvider): String =
-        oAuthService.getAuthorizationUrl(provider)
+    fun getAuthorizationUrl(provider: SocialProvider): String = oAuthService.getAuthorizationUrl(provider)
 
-    fun login(provider: SocialProvider, code: String): OAuthLoginResponse {
+    fun login(
+        provider: SocialProvider,
+        code: String,
+    ): String {
         val userInfo = oAuthService.getOAuthUserInfo(provider, code)
         val member = memberSocialAccountService.findOrCreateMember(provider, userInfo.id, userInfo.email)
 
         if (member.isPending()) {
-            return OAuthLoginResponse()
+            return oAuthService.getAuthCallbackUrl(accessToken = null, refreshToken = null)
         }
 
         val accessToken = jwtTokenProvider.generateAccessToken(member.id)
         val refreshToken = authService.createRefreshToken(member.id)
-        return OAuthLoginResponse(accessToken = accessToken, refreshToken = refreshToken.token)
+        return oAuthService.getAuthCallbackUrl(accessToken, refreshToken.token)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/service/OAuthService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/OAuthService.kt
@@ -1,20 +1,38 @@
 package com.ditto.api.auth.service
 
+import com.ditto.api.config.FrontProperties
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.ditto.infrastructure.oauth.OAuthClientFactory
 import com.ditto.infrastructure.oauth.OAuthUserInfo
 import org.springframework.stereotype.Service
+import org.springframework.web.util.UriComponentsBuilder
 
 @Service
 class OAuthService(
     private val oAuthClientFactory: OAuthClientFactory,
+    private val frontProperties: FrontProperties,
 ) {
     fun getAuthorizationUrl(provider: SocialProvider): String =
         oAuthClientFactory.getClient(provider).getAuthorizationUrl()
 
-    fun getOAuthUserInfo(provider: SocialProvider, code: String): OAuthUserInfo {
+    fun getOAuthUserInfo(
+        provider: SocialProvider,
+        code: String,
+    ): OAuthUserInfo {
         val client = oAuthClientFactory.getClient(provider)
         val accessToken = client.getAccessToken(code)
         return client.getUserInfo(accessToken)
     }
+
+    fun getAuthCallbackUrl(
+        accessToken: String?,
+        refreshToken: String?,
+    ): String =
+        UriComponentsBuilder
+            .fromUriString(frontProperties.oauthCallbackUrl)
+            .apply {
+                accessToken?.let { queryParam("accessToken", it) }
+                refreshToken?.let { queryParam("refreshToken", it) }
+            }.build()
+            .toUriString()
 }

--- a/api/src/main/kotlin/com/ditto/api/config/FrontProperties.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/FrontProperties.kt
@@ -4,6 +4,5 @@ import org.springframework.boot.context.properties.ConfigurationProperties
 
 @ConfigurationProperties(prefix = "ditto.front")
 data class FrontProperties(
-    val url: String,
-    val oauthCallbackPath: String = "/auth/callback",
+    val oauthCallbackUrl: String,
 )

--- a/api/src/main/kotlin/com/ditto/api/config/FrontProperties.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/FrontProperties.kt
@@ -1,0 +1,9 @@
+package com.ditto.api.config
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "ditto.front")
+data class FrontProperties(
+    val url: String,
+    val oauthCallbackPath: String = "/auth/callback",
+)

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -29,5 +29,4 @@ ditto:
     expiration-ms: 3600000
     refresh-expiration-ms: 1209600000
   front:
-    url: ${FRONT_URL:http://localhost:3000}
-    oauth-callback-path: /auth/callback
+    oauth-callback-url: ${FRONT_OAUTH_CALLBACK_URL:http://localhost:3000/auth/callback}

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -28,3 +28,6 @@ ditto:
     secret: local-dev-jwt-secret-key-must-be-at-least-256-bits-long-for-hmac-sha
     expiration-ms: 3600000
     refresh-expiration-ms: 1209600000
+  front:
+    url: ${FRONT_URL:http://localhost:3000}
+    oauth-callback-path: /auth/callback

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -65,10 +65,10 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-05-31 22:26:53",
+                        "joinedAt" : "2026-05-31 22:59:01",
                         "role" : null,
-                        "createdAt" : "2026-05-31 22:26:53",
-                        "updatedAt" : "2026-05-31 22:26:53"
+                        "createdAt" : "2026-05-31 22:59:01",
+                        "updatedAt" : "2026-05-31 22:59:01"
                       },
                       "error" : null
                     }
@@ -278,8 +278,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-05-30 22:26:53",
-                          "endDate" : "2026-06-01 22:26:53",
+                          "startDate" : "2026-05-30 22:59:00",
+                          "endDate" : "2026-06-01 22:59:00",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -296,8 +296,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-05-31 22:26:53",
-                            "updatedAt" : "2026-05-31 22:26:53"
+                            "createdAt" : "2026-05-31 22:59:01",
+                            "updatedAt" : "2026-05-31 22:59:01"
                           } ]
                         } ]
                       },
@@ -343,8 +343,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-05-31 22:26:53",
-                        "updatedAt" : "2026-05-31 22:26:53"
+                        "createdAt" : "2026-05-31 22:59:01",
+                        "updatedAt" : "2026-05-31 22:59:01"
                       },
                       "error" : null
                     }
@@ -577,7 +577,7 @@ paths:
               token-refresh:
                 value: |-
                   {
-                    "refreshToken" : "e94be462-9ea7-4b1d-a300-bfb8261760ef"
+                    "refreshToken" : "f0b3006c-48e1-4d51-b152-b71529c63ec8"
                   }
       responses:
         "200":
@@ -592,8 +592,8 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwMjM0MDA4LCJleHAiOjE3ODAyMzc2MDh9.PE2CHflgiY6B-gtSAKUWw8GD_nrVaaH3fRujZvG60cJdnQ9c4nER2XXlJmvhZtqyscwWlYb4MU7wH3BFJbWjTg",
-                        "refreshToken" : "6a75c2d1-fba5-411f-a5af-23ff55122a3b"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwMjM1OTM2LCJleHAiOjE3ODAyMzk1MzZ9.-40h2oPbK8fWGHq9gxgclpHkNkeVllwDE161wJPQ6Q2Fe0oPlaaVdEe6dEdtlud0boDLmvy7xXpM70YjPW8Mng",
+                        "refreshToken" : "8dc3caec-646f-49f9-85ab-f073ef0eac9f"
                       },
                       "error" : null
                     }
@@ -651,8 +651,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-05-31 22:26:53",
-                        "updatedAt" : "2026-05-31 22:26:53"
+                        "createdAt" : "2026-05-31 22:59:01",
+                        "updatedAt" : "2026-05-31 22:59:01"
                       },
                       "error" : null
                     }
@@ -1413,51 +1413,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-refresh1056639717:
-      required:
-      - refreshToken
-      type: object
-      properties:
-        refreshToken:
-          type: string
-          description: 리프레시 토큰
-    api-v1-users-id-leave-1444522536:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - age
-          - birthDate
-          - createdAt
-          - email
-          - gender
-          - id
-          - joinedAt
-          - name
-          - nickname
-          - phoneNumber
-          - role
-          - updatedAt
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 생성일시
-            nickname:
-              type: string
-              description: 닉네임
-            id:
-              type: number
-              description: 사용자 ID
-            updatedAt:
-              type: string
-              description: 수정일시
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-1on1-795708692:
       required:
       - error
@@ -1532,6 +1487,51 @@ components:
                   status:
                     type: string
                     description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-refresh1056639717:
+      required:
+      - refreshToken
+      type: object
+      properties:
+        refreshToken:
+          type: string
+          description: 리프레시 토큰
+    api-v1-users-id-leave-1444522536:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - age
+          - birthDate
+          - createdAt
+          - email
+          - gender
+          - id
+          - joinedAt
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 생성일시
+            nickname:
+              type: string
+              description: 닉네임
+            id:
+              type: number
+              description: 사용자 ID
+            updatedAt:
+              type: string
+              description: 수정일시
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -65,10 +65,100 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-05-01 16:59:26",
+                        "joinedAt" : "2026-05-31 22:26:53",
                         "role" : null,
-                        "createdAt" : "2026-05-01 16:59:26",
-                        "updatedAt" : "2026-05-01 16:59:26"
+                        "createdAt" : "2026-05-31 22:26:53",
+                        "updatedAt" : "2026-05-31 22:26:53"
+                      },
+                      "error" : null
+                    }
+  /api/v1/matches/1on1:
+    get:
+      tags:
+      - Matching
+      summary: 1:1 매칭 요청 목록 조회
+      description: 퀴즈셋에 대한 내가 보낸/받은 1:1 매칭 요청 목록을 조회합니다.
+      operationId: personal-match-list
+      parameters:
+      - name: quizSetId
+        in: query
+        description: 퀴즈 세트 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matches-1on1-795708692"
+              examples:
+                personal-match-list:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "sent" : [ {
+                          "id" : 1,
+                          "quizSetId" : 10,
+                          "requesterId" : 1,
+                          "receiverId" : 2,
+                          "status" : "PENDING",
+                          "createdAt" : "2026-05-01 12:00:00",
+                          "respondedAt" : null
+                        } ],
+                        "received" : [ {
+                          "id" : 2,
+                          "quizSetId" : 10,
+                          "requesterId" : 3,
+                          "receiverId" : 1,
+                          "status" : "PENDING",
+                          "createdAt" : "2026-05-01 12:00:00",
+                          "respondedAt" : null
+                        } ]
+                      },
+                      "error" : null
+                    }
+  /api/v1/matches/request:
+    post:
+      tags:
+      - Matching
+      summary: 1:1 매칭 요청
+      description: 상대방에게 1:1 매칭을 요청합니다.
+      operationId: personal-match-request
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api-v1-matches-request-793255208"
+            examples:
+              personal-match-request:
+                value: |-
+                  {
+                    "receiverId" : 2,
+                    "quizSetId" : 10
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matches-request-1327932902"
+              examples:
+                personal-match-request:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "quizSetId" : 10,
+                        "requesterId" : 1,
+                        "receiverId" : 2,
+                        "status" : "PENDING",
+                        "createdAt" : "2026-05-01 12:00:00",
+                        "respondedAt" : null
                       },
                       "error" : null
                     }
@@ -179,7 +269,7 @@ paths:
                       "data" : {
                         "year" : 2026,
                         "month" : 5,
-                        "week" : 1,
+                        "week" : 5,
                         "quizSets" : [ {
                           "id" : 1,
                           "year" : 2026,
@@ -188,8 +278,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-04-30 16:59:25",
-                          "endDate" : "2026-05-02 16:59:25",
+                          "startDate" : "2026-05-30 22:26:53",
+                          "endDate" : "2026-06-01 22:26:53",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -206,8 +296,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-05-01 16:59:25",
-                            "updatedAt" : "2026-05-01 16:59:25"
+                            "createdAt" : "2026-05-31 22:26:53",
+                            "updatedAt" : "2026-05-31 22:26:53"
                           } ]
                         } ]
                       },
@@ -253,13 +343,134 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-05-01 16:59:26",
-                        "updatedAt" : "2026-05-01 16:59:26"
+                        "createdAt" : "2026-05-31 22:26:53",
+                        "updatedAt" : "2026-05-31 22:26:53"
                       },
                       "error" : null
                     }
       security:
       - bearerAuthJWT: []
+  /api/v1/matches/group/decline:
+    post:
+      tags:
+      - Matching
+      summary: 그룹 매칭 거절
+      description: 그룹 매칭 참여를 거절합니다. 한 퀴즈셋당 한 번만 거절할 수 있습니다.
+      operationId: group-match-decline
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api-v1-matches-group-decline-1969670024"
+            examples:
+              group-match-decline:
+                value: |-
+                  {
+                    "quizSetId" : 10
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matches-group-decline-789252668"
+              examples:
+                group-match-decline:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "error" : null
+                    }
+  /api/v1/matches/group/join:
+    post:
+      tags:
+      - Matching
+      summary: 그룹 매칭 참여
+      description: |-
+        그룹 매칭에 참여합니다.
+
+        - 참여 가능한 방이 있으면 기존 방에 배정됩니다.
+        - 참여 가능한 방이 없으면 새 방을 생성합니다.
+        - 참여자가 3명이 되면 방이 활성화(isActive=true)됩니다.
+      operationId: group-match-join
+      requestBody:
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/api-v1-matches-group-decline-1969670024"
+            examples:
+              group-match-join:
+                value: |-
+                  {
+                    "quizSetId" : 10
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matches-group-join-2080112672"
+              examples:
+                group-match-join:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "roomId" : 1,
+                        "quizSetId" : 10,
+                        "participantCount" : 1,
+                        "isActive" : false
+                      },
+                      "error" : null
+                    }
+  /api/v1/matching/status/{quizSetId}:
+    get:
+      tags:
+      - Matching
+      summary: 매칭 상태 조회
+      description: |-
+        퀴즈셋에 대한 나의 매칭 현황을 조회합니다.
+
+        - **personalMatch**: ACCEPTED > PENDING 우선 반환. 없으면 null
+        - **groupMatchStatus**: DECLINED > JOINED > NONE 순으로 판단
+      operationId: matching-status
+      parameters:
+      - name: quizSetId
+        in: path
+        description: 퀴즈 세트 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matching-status-quizSetId-1585477117"
+              examples:
+                matching-status:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "quizSetId" : 10,
+                        "personalMatch" : {
+                          "id" : 1,
+                          "requesterId" : 1,
+                          "receiverId" : 2,
+                          "status" : "ACCEPTED",
+                          "createdAt" : "2026-05-01 12:00:00",
+                          "respondedAt" : "2026-05-01 12:30:00"
+                        },
+                        "groupMatchStatus" : "JOINED",
+                        "groupMatchRoomId" : 5
+                      },
+                      "error" : null
+                    }
   /api/v1/quiz-progress/quiz-sets/{id}:
     get:
       tags:
@@ -366,7 +577,7 @@ paths:
               token-refresh:
                 value: |-
                   {
-                    "refreshToken" : "7127eacb-a95e-4650-8d80-aa95bcdd1501"
+                    "refreshToken" : "e94be462-9ea7-4b1d-a300-bfb8261760ef"
                   }
       responses:
         "200":
@@ -381,8 +592,8 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzc3NjIyMzY0LCJleHAiOjE3Nzc2MjU5NjR9.IT7EKgI_2kG8NlOeL9lRyLQBYLVqSZyU0NLTD97gLqVQ_wvK1HtFHHanV-uV35KY_-vIvd_G5_B_oPQMaumHmg",
-                        "refreshToken" : "c7fe58b3-baf6-4c4d-9e8c-925008bbf12e"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwMjM0MDA4LCJleHAiOjE3ODAyMzc2MDh9.PE2CHflgiY6B-gtSAKUWw8GD_nrVaaH3fRujZvG60cJdnQ9c4nER2XXlJmvhZtqyscwWlYb4MU7wH3BFJbWjTg",
+                        "refreshToken" : "6a75c2d1-fba5-411f-a5af-23ff55122a3b"
                       },
                       "error" : null
                     }
@@ -440,13 +651,87 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-05-01 16:59:26",
-                        "updatedAt" : "2026-05-01 16:59:26"
+                        "createdAt" : "2026-05-31 22:26:53",
+                        "updatedAt" : "2026-05-31 22:26:53"
                       },
                       "error" : null
                     }
       security:
       - bearerAuthJWT: []
+  /api/v1/matches/request/{id}/accept:
+    post:
+      tags:
+      - Matching
+      summary: 1:1 매칭 수락
+      description: 받은 매칭 요청을 수락합니다. 수신자만 호출 가능합니다.
+      operationId: personal-match-accept
+      parameters:
+      - name: id
+        in: path
+        description: 매칭 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matches-request-id-accept-2011455419"
+              examples:
+                personal-match-accept:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "quizSetId" : 10,
+                        "requesterId" : 1,
+                        "receiverId" : 2,
+                        "status" : "ACCEPTED",
+                        "createdAt" : "2026-05-01 12:00:00",
+                        "respondedAt" : null
+                      },
+                      "error" : null
+                    }
+  /api/v1/matches/request/{id}/reject:
+    post:
+      tags:
+      - Matching
+      summary: 1:1 매칭 거절
+      description: 받은 매칭 요청을 거절합니다. 수신자만 호출 가능합니다.
+      operationId: personal-match-reject
+      parameters:
+      - name: id
+        in: path
+        description: 매칭 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-matches-request-id-reject-1480143692"
+              examples:
+                personal-match-reject:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "id" : 1,
+                        "quizSetId" : 10,
+                        "requesterId" : 1,
+                        "receiverId" : 2,
+                        "status" : "REJECTED",
+                        "createdAt" : "2026-05-01 12:00:00",
+                        "respondedAt" : null
+                      },
+                      "error" : null
+                    }
   /api/v1/users/nickname/{nickname}/availability:
     get:
       tags:
@@ -483,7 +768,8 @@ paths:
       tags:
       - OAuth
       summary: 소셜 로그인 콜백
-      description: 신규 사용자는 토큰을 발급하지 않습니다. 회원가입이 필요합니다.
+      description: "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트합니다. 기존 사용자는 accessToken/refreshToken\
+        \ 쿼리 파라미터가 포함되고, 신규 사용자는 미포함됩니다."
       operationId: oauth-callback-new-user
       parameters:
       - name: provider
@@ -499,25 +785,18 @@ paths:
         schema:
           type: string
       responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/api-v1-users-social-login-provider-callback1248644946"
-              examples:
-                oauth-callback-new-user:
-                  value: |-
-                    {
-                      "success" : true,
-                      "data" : {
-                        "accessToken" : null,
-                        "refreshToken" : null
-                      },
-                      "error" : null
-                    }
+        "302":
+          description: "302"
 components:
   schemas:
+    api-v1-matches-group-decline-1969670024:
+      required:
+      - quizSetId
+      type: object
+      properties:
+        quizSetId:
+          type: number
+          description: 퀴즈 세트 ID
     api-v1-users-auth-refresh-42454406:
       required:
       - error
@@ -536,6 +815,72 @@ components:
             refreshToken:
               type: string
               description: 새 리프레시 토큰
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-group-join-2080112672:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - isActive
+          - participantCount
+          - quizSetId
+          - roomId
+          type: object
+          properties:
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            participantCount:
+              type: number
+              description: 현재 참여자 수
+            isActive:
+              type: boolean
+              description: 방 활성화 여부 (참여자 3명 이상이면 true)
+            roomId:
+              type: number
+              description: 배정된 그룹 방 ID
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-1327932902:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 생성된 매칭 ID
+            status:
+              type: string
+              description: 매칭 상태 (PENDING)
         success:
           type: boolean
           description: 성공 여부
@@ -662,6 +1007,27 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-matches-request-793255208:
+      required:
+      - quizSetId
+      - receiverId
+      type: object
+      properties:
+        receiverId:
+          type: number
+          description: 요청 대상 회원 ID
+        quizSetId:
+          type: number
+          description: 퀴즈 세트 ID
+    api-v1-matches-group-decline-789252668:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-quiz-progress-quiz-sets-id-1569645469:
       required:
       - error
@@ -728,6 +1094,43 @@ components:
             totalCount:
               type: number
               description: 전체 퀴즈 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-id-reject-1480143692:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 매칭 ID
+            status:
+              type: string
+              description: 변경된 매칭 상태 (REJECTED)
         success:
           type: boolean
           description: 성공 여부
@@ -839,7 +1242,7 @@ components:
         quizId:
           type: number
           description: 퀴즈 ID
-    api-v1-users-107230905:
+    api-v1-matching-status-quizSetId-1585477117:
       required:
       - error
       - success
@@ -847,47 +1250,49 @@ components:
       properties:
         data:
           required:
-          - age
-          - birthDate
-          - createdAt
-          - email
-          - gender
-          - id
-          - joinedAt
-          - name
-          - nickname
-          - phoneNumber
-          - role
-          - updatedAt
+          - groupMatchStatus
+          - quizSetId
           type: object
           properties:
-            createdAt:
+            groupMatchStatus:
               type: string
-              description: 생성일시
-            phoneNumber:
-              type: string
-              description: 전화번호
-            gender:
-              type: string
-              description: 성별
-            joinedAt:
-              type: string
-              description: 가입일시
-            nickname:
-              type: string
-              description: 닉네임
-            name:
-              type: string
-              description: 이름
-            id:
+              description: 그룹 매칭 상태 (NONE / JOINED / DECLINED)
+            quizSetId:
               type: number
-              description: 사용자 ID
-            age:
+              description: 퀴즈 세트 ID
+            groupMatchRoomId:
               type: number
-              description: 나이대
-            updatedAt:
-              type: string
-              description: 수정일시
+              description: 참여 중인 그룹 방 ID (JOINED 일 때만 존재)
+              nullable: true
+            personalMatch:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  description: 요청 생성일시
+                  nullable: true
+                receiverId:
+                  type: number
+                  description: 수신자 ID
+                  nullable: true
+                requesterId:
+                  type: number
+                  description: 요청자 ID
+                  nullable: true
+                respondedAt:
+                  type: string
+                  description: 응답 일시 (없으면 null)
+                  nullable: true
+                id:
+                  type: number
+                  description: 매칭 ID
+                  nullable: true
+                status:
+                  type: string
+                  description: 매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED /
+                    EXPIRED)
+                  nullable: true
+              description: 1:1 매칭 정보 (없으면 null)
         success:
           type: boolean
           description: 성공 여부
@@ -956,7 +1361,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-social-login-provider-callback1248644946:
+    api-v1-users-107230905:
       required:
       - error
       - success
@@ -964,10 +1369,47 @@ components:
       properties:
         data:
           required:
-          - accessToken
-          - refreshToken
+          - age
+          - birthDate
+          - createdAt
+          - email
+          - gender
+          - id
+          - joinedAt
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
           type: object
-          properties: {}
+          properties:
+            createdAt:
+              type: string
+              description: 생성일시
+            phoneNumber:
+              type: string
+              description: 전화번호
+            gender:
+              type: string
+              description: 성별
+            joinedAt:
+              type: string
+              description: 가입일시
+            nickname:
+              type: string
+              description: 닉네임
+            name:
+              type: string
+              description: 이름
+            id:
+              type: number
+              description: 사용자 ID
+            age:
+              type: number
+              description: 나이대
+            updatedAt:
+              type: string
+              description: 수정일시
         success:
           type: boolean
           description: 성공 여부
@@ -1013,6 +1455,120 @@ components:
             updatedAt:
               type: string
               description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-1on1-795708692:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - received
+          - sent
+          type: object
+          properties:
+            received:
+              type: array
+              description: 내가 받은 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태
+            sent:
+              type: array
+              description: 내가 보낸 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-id-accept-2011455419:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 매칭 ID
+            status:
+              type: string
+              description: 변경된 매칭 상태 (ACCEPTED)
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthControllerTest.kt
@@ -6,13 +6,13 @@ import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.epages.restdocs.apispec.ResourceDocumentation.resource
 import com.epages.restdocs.apispec.ResourceSnippetParameters
+import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
 import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
-import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -50,16 +50,15 @@ class OAuthControllerTest : RestDocsTest() {
     }
 
     @Test
-    @DisplayName("신규 사용자면 토큰 없이 응답한다")
+    @DisplayName("신규 사용자면 토큰 없이 프론트 콜백으로 리다이렉트한다")
     fun callbackNewUser() {
         mockMvc.perform(
             get("/api/v1/users/social-login/{provider}/callback", "KAKAO").withApiKey()
                 .param("code", "test-auth-code"),
         )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.accessToken").isEmpty)
-            .andExpect(jsonPath("$.data.refreshToken").isEmpty)
+            .andExpect(status().isFound)
+            .andExpect(header().string("Location", startsWith("http://localhost:3000/auth/callback")))
+            .andExpect(header().string("Location", org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("accessToken"))))
             .andDo(
                 document(
                     "oauth-callback-new-user",
@@ -69,18 +68,15 @@ class OAuthControllerTest : RestDocsTest() {
                         ResourceSnippetParameters.builder()
                             .tag("OAuth")
                             .summary("소셜 로그인 콜백")
-                            .description("신규 사용자는 토큰을 발급하지 않습니다. 회원가입이 필요합니다.")
+                            .description(
+                                "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트합니다. " +
+                                    "기존 사용자는 accessToken/refreshToken 쿼리 파라미터가 포함되고, 신규 사용자는 미포함됩니다.",
+                            )
                             .pathParameters(
                                 parameterWithName("provider").description(PROVIDER_DESCRIPTION),
                             )
                             .queryParameters(
                                 parameterWithName("code").description("소셜 로그인 제공자로부터 받은 인가 코드"),
-                            )
-                            .responseFields(
-                                fieldWithPath("success").description("성공 여부"),
-                                fieldWithPath("data.accessToken").description("JWT 액세스 토큰 (신규 사용자는 null)"),
-                                fieldWithPath("data.refreshToken").description("리프레시 토큰 (신규 사용자는 null)"),
-                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),
                     ),

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
@@ -4,6 +4,7 @@ import com.ditto.api.auth.facade.OAuthFacade
 import com.ditto.api.auth.service.AuthService
 import com.ditto.api.auth.service.MemberSocialAccountService
 import com.ditto.api.auth.service.OAuthService
+import com.ditto.api.config.FrontProperties
 import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.api.support.IntegrationTest
 import com.ditto.common.exception.ErrorCode
@@ -17,6 +18,9 @@ import com.ditto.infrastructure.oauth.OAuthClientFactory
 import io.kotest.assertions.throwables.shouldThrow
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
+import io.kotest.matchers.string.shouldContain
+import io.kotest.matchers.string.shouldNotContain
+import org.springframework.web.util.UriComponentsBuilder
 import javax.sql.DataSource
 
 class OAuthFacadeTest(
@@ -27,6 +31,7 @@ class OAuthFacadeTest(
     private val refreshTokenRepository: RefreshTokenRepository,
     private val jwtTokenProvider: JwtTokenProvider,
     private val authService: AuthService,
+    private val frontProperties: FrontProperties,
     dataSource: DataSource,
 ) : IntegrationTest(
     dataSource,
@@ -42,7 +47,7 @@ class OAuthFacadeTest(
 
             "지원하지 않는 제공자면 예외가 발생한다" {
                 val facadeWithNoClients = OAuthFacade(
-                    oAuthService = OAuthService(OAuthClientFactory(emptyMap())),
+                    oAuthService = OAuthService(OAuthClientFactory(emptyMap()), frontProperties),
                     memberSocialAccountService = memberSocialAccountService,
                     jwtTokenProvider = jwtTokenProvider,
                     authService = authService,
@@ -56,39 +61,51 @@ class OAuthFacadeTest(
         }
 
         "소셜 로그인" - {
-            "신규 사용자면 PENDING 상태로 생성되고 토큰을 발급하지 않는다" {
-                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+            "신규 사용자면 PENDING 상태로 생성되고 토큰 없는 redirect URL을 반환한다" {
+                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                result.accessToken shouldBe null
-                result.refreshToken shouldBe null
+                redirectUrl shouldNotContain "accessToken"
+                redirectUrl shouldNotContain "refreshToken"
                 memberRepository.count() shouldBe 1
                 memberRepository.findAll().first().status shouldBe MemberStatus.PENDING
                 socialAccountRepository.count() shouldBe 1
                 refreshTokenRepository.count() shouldBe 0
             }
 
-            "PENDING 사용자가 재로그인하면 토큰을 발급하지 않는다" {
+            "PENDING 사용자가 재로그인하면 토큰 없는 redirect URL을 반환한다" {
                 oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                result.accessToken shouldBe null
-                result.refreshToken shouldBe null
+                redirectUrl shouldNotContain "accessToken"
+                redirectUrl shouldNotContain "refreshToken"
                 memberRepository.count() shouldBe 1
             }
 
-            "ACTIVE 사용자면 JWT를 발급한다" {
+            "ACTIVE 사용자면 토큰을 포함한 redirect URL을 반환한다" {
                 val member =
                     memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
                 member.activate()
                 memberRepository.save(member)
 
-                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                result.accessToken shouldNotBe null
-                jwtTokenProvider.isValid(result.accessToken!!) shouldBe true
-                result.refreshToken shouldNotBe null
+                val params = UriComponentsBuilder.fromUriString(redirectUrl).build().queryParams
+                params["accessToken"]?.first() shouldNotBe null
+                params["refreshToken"]?.first() shouldNotBe null
+                jwtTokenProvider.isValid(params["accessToken"]!!.first()) shouldBe true
                 refreshTokenRepository.count() shouldBe 1
+            }
+
+            "ACTIVE 사용자의 redirect URL이 설정된 프론트 콜백 URL로 시작한다" {
+                val member =
+                    memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
+                member.activate()
+                memberRepository.save(member)
+
+                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+
+                redirectUrl shouldContain frontProperties.oauthCallbackUrl
             }
 
             "ACTIVE 사용자의 JWT에 memberId가 포함된다" {
@@ -97,9 +114,11 @@ class OAuthFacadeTest(
                 member.activate()
                 memberRepository.save(member)
 
-                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                jwtTokenProvider.getMemberId(result.accessToken!!) shouldBe member.id
+                val accessToken = UriComponentsBuilder.fromUriString(redirectUrl)
+                    .build().queryParams["accessToken"]!!.first()
+                jwtTokenProvider.getMemberId(accessToken) shouldBe member.id
             }
         }
     },

--- a/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/SecurityConfigTest.kt
@@ -145,8 +145,8 @@ class SecurityConfigTest : RestDocsTest() {
                 get("/api/v1/users/social-login/{provider}/callback", "KAKAO")
                     .param("code", "test-auth-code"),
             )
-                .andExpect(status().isOk)
-                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(status().isFound)
+                .andExpect(header().exists("Location"))
         }
     }
 


### PR DESCRIPTION
## Summary
- OAuth 콜백이 JSON으로 토큰을 응답해 사용자 브라우저가 BE 호스트(`api.ditto.pics`)에 갇히던 문제 수정
- BE 콜백을 302 redirect 응답으로 변경해 FE 콜백 페이지(`/auth/callback`)로 토큰 실어 보냄
- redirect URL 빌드 로직을 `OAuthService.getAuthCallbackUrl()`로 분리

## 변경 사항
- `FrontProperties`: `ditto.front.oauth-callback-url` 설정 추가 (local: `http://localhost:3000/auth/callback`)
- `OAuthService.getAuthCallbackUrl(accessToken?, refreshToken?)`: 토큰을 쿼리 파라미터로 붙인 redirect URL 생성
- `OAuthFacade.login()`: redirect URL을 String으로 반환
- `OAuthController.callback()`: JSON 응답 → 302 redirect로 변경
- `.aws/task-definition.json`: 운영 환경변수 `FRONT_OAUTH_CALLBACK_URL` 추가
- 테스트(`OAuthControllerTest`, `OAuthFacadeTest`, `SecurityConfigTest`) redirect 검증으로 업데이트

## 응답 동작
| 상황 | Location 헤더 |
|---|---|
| 기존(ACTIVE) 사용자 | `https://test.ditto.pics/auth/callback?accessToken=...&refreshToken=...` |
| 신규(PENDING) 사용자 | `https://test.ditto.pics/auth/callback` (토큰 없음) |

FE는 `/auth/callback` 경로에서 토큰 유무로 기존/신규 사용자 분기 처리.

## Test plan
- [x] `./gradlew :api:test` 전체 통과 (154 tests)
- [ ] 운영 ECS task definition 새 리비전 등록 + 서비스 배포
- [ ] 카카오 로그인 종단 흐름 — 기존 사용자 토큰 발급 및 FE 라우팅 확인
- [ ] 신규 사용자 토큰 없이 `/auth/callback` 도달 확인
- [ ] CloudWatch `/ecs/ditto-api`에서 `[UNHANDLED]` 라인 없음 확인

## 후속 검토 사항 (이번 PR 범위 밖)
- 토큰을 URL 쿼리에 노출하는 보안 이슈: 추후 `HttpOnly Secure` 쿠키 또는 URL fragment(`#`)로 전환 검토
- "원래 사용자가 OAuth 시작했던 페이지로 복귀" 기능: FE에서 localStorage로 처리하거나 BE에 `state` 파라미터 도입 검토

🤖 Generated with [Claude Code](https://claude.com/claude-code)