### PR TITLE
feat. OAuth refreshToken 쿠키 전환 및 PENDING status 게이트

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -48,6 +48,10 @@
                 {
                     "name": "FRONT_OAUTH_CALLBACK_URL",
                     "value": "https://test.ditto.pics/auth/callback"
+                },
+                {
+                    "name": "COOKIE_SECURE",
+                    "value": "true"
                 }
             ],
             "secrets": [

--- a/api/src/main/kotlin/com/ditto/api/auth/controller/AuthController.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/controller/AuthController.kt
@@ -1,30 +1,41 @@
 package com.ditto.api.auth.controller
 
-import com.ditto.api.auth.dto.TokenRefreshRequest
 import com.ditto.api.auth.dto.TokenRefreshResponse
 import com.ditto.api.auth.service.AuthService
 import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.config.auth.RefreshTokenCookieFactory
 import com.ditto.common.response.ApiResponse
-import jakarta.validation.Valid
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.CookieValue
 import org.springframework.web.bind.annotation.PostMapping
-import org.springframework.web.bind.annotation.RequestBody
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class AuthController(
     private val authService: AuthService,
+    private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
 ) {
 
     @PostMapping("/api/v1/users/auth/refresh")
-    fun refresh(@Valid @RequestBody request: TokenRefreshRequest): ApiResponse<TokenRefreshResponse> {
-        val result = authService.refresh(request)
-        return ApiResponse.ok(result)
+    fun refresh(
+        @CookieValue(RefreshTokenCookieFactory.REFRESH_TOKEN_COOKIE) refreshToken: String,
+        response: HttpServletResponse,
+    ): ApiResponse<TokenRefreshResponse> {
+        val result = authService.refresh(refreshToken)
+        refreshTokenCookieFactory.addTo(response, result.refreshToken)
+
+        return ApiResponse.ok(TokenRefreshResponse(result.accessToken))
     }
 
     @PostMapping("/api/v1/users/auth/logout")
-    fun logout(@AuthenticationPrincipal principal: MemberPrincipal): ApiResponse<Unit> {
+    fun logout(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+        response: HttpServletResponse,
+    ): ApiResponse<Unit> {
         authService.logout(principal.memberId)
+        refreshTokenCookieFactory.expireTo(response)
+
         return ApiResponse(success = true)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/controller/OAuthController.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/controller/OAuthController.kt
@@ -1,7 +1,9 @@
 package com.ditto.api.auth.controller
 
 import com.ditto.api.auth.facade.OAuthFacade
+import com.ditto.api.config.auth.RefreshTokenCookieFactory
 import com.ditto.domain.socialaccount.entity.SocialProvider
+import jakarta.servlet.http.HttpServletResponse
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.GetMapping
@@ -15,10 +17,13 @@ import java.net.URI
 @RequestMapping("api/v1/users/social-login")
 class OAuthController(
     private val oAuthFacade: OAuthFacade,
+    private val refreshTokenCookieFactory: RefreshTokenCookieFactory,
 ) {
 
     @GetMapping("/{provider}")
-    fun login(@PathVariable provider: SocialProvider): ResponseEntity<Unit> {
+    fun login(
+        @PathVariable provider: SocialProvider,
+    ): ResponseEntity<Unit> {
         val authorizationUrl = oAuthFacade.getAuthorizationUrl(provider)
         return ResponseEntity.status(HttpStatus.FOUND)
             .location(URI.create(authorizationUrl))
@@ -29,10 +34,13 @@ class OAuthController(
     fun callback(
         @PathVariable provider: SocialProvider,
         @RequestParam code: String,
+        response: HttpServletResponse,
     ): ResponseEntity<Unit> {
-        val redirectUrl = oAuthFacade.login(provider, code)
+        val oauthLoginResult = oAuthFacade.login(provider, code)
+        refreshTokenCookieFactory.addTo(response, oauthLoginResult.refreshToken)
+
         return ResponseEntity.status(HttpStatus.FOUND)
-            .location(URI.create(redirectUrl))
+            .location(URI.create(oauthLoginResult.redirectUrl))
             .build()
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/dto/OAuthLoginResult.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/dto/OAuthLoginResult.kt
@@ -1,0 +1,11 @@
+package com.ditto.api.auth.dto
+
+/**
+ * OAuth 로그인 결과 (facade → controller 전달용).
+ * - redirectUrl: accessToken·signupRequired 쿼리가 포함된 프론트 콜백 URL
+ * - refreshToken: 컨트롤러에서 HttpOnly 쿠키로 전달
+ */
+data class OAuthLoginResult(
+    val redirectUrl: String,
+    val refreshToken: String,
+)

--- a/api/src/main/kotlin/com/ditto/api/auth/dto/TokenRefreshRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/dto/TokenRefreshRequest.kt
@@ -1,8 +1,0 @@
-package com.ditto.api.auth.dto
-
-import jakarta.validation.constraints.NotBlank
-
-data class TokenRefreshRequest(
-    @field:NotBlank
-    val refreshToken: String,
-)

--- a/api/src/main/kotlin/com/ditto/api/auth/dto/TokenRefreshResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/dto/TokenRefreshResponse.kt
@@ -2,5 +2,4 @@ package com.ditto.api.auth.dto
 
 data class TokenRefreshResponse(
     val accessToken: String,
-    val refreshToken: String,
 )

--- a/api/src/main/kotlin/com/ditto/api/auth/dto/TokenRefreshResult.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/dto/TokenRefreshResult.kt
@@ -1,0 +1,11 @@
+package com.ditto.api.auth.dto
+
+/**
+ * 토큰 갱신 결과 (서비스 계층 내부 전달용).
+ * - accessToken: 응답 바디로 전달
+ * - refreshToken: 컨트롤러에서 HttpOnly 쿠키로 재발급
+ */
+data class TokenRefreshResult(
+    val accessToken: String,
+    val refreshToken: String,
+)

--- a/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
@@ -1,5 +1,6 @@
 package com.ditto.api.auth.facade
 
+import com.ditto.api.auth.dto.OAuthLoginResult
 import com.ditto.api.auth.service.AuthService
 import com.ditto.api.auth.service.MemberSocialAccountService
 import com.ditto.api.auth.service.OAuthService
@@ -19,16 +20,14 @@ class OAuthFacade(
     fun login(
         provider: SocialProvider,
         code: String,
-    ): String {
+    ): OAuthLoginResult {
         val userInfo = oAuthService.getOAuthUserInfo(provider, code)
         val member = memberSocialAccountService.findOrCreateMember(provider, userInfo.id, userInfo.email)
 
-        if (member.isPending()) {
-            return oAuthService.getAuthCallbackUrl(accessToken = null, refreshToken = null)
-        }
-
         val accessToken = jwtTokenProvider.generateAccessToken(member.id)
         val refreshToken = authService.createRefreshToken(member.id)
-        return oAuthService.getAuthCallbackUrl(accessToken, refreshToken.token)
+        val redirectUrl = oAuthService.getAuthCallbackUrl(accessToken, signupRequired = member.isPending())
+
+        return OAuthLoginResult(redirectUrl = redirectUrl, refreshToken = refreshToken.token)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
@@ -1,7 +1,6 @@
 package com.ditto.api.auth.service
 
-import com.ditto.api.auth.dto.TokenRefreshRequest
-import com.ditto.api.auth.dto.TokenRefreshResponse
+import com.ditto.api.auth.dto.TokenRefreshResult
 import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
@@ -35,19 +34,20 @@ class AuthService(
     }
 
     @Transactional
-    fun refresh(request: TokenRefreshRequest): TokenRefreshResponse {
-        val refreshToken = refreshTokenRepository.findByToken(request.refreshToken)
+    fun refresh(refreshToken: String): TokenRefreshResult {
+        val existedRefreshToken = refreshTokenRepository.findByToken(refreshToken)
             ?: throw ErrorException(ErrorCode.REFRESH_TOKEN_NOT_FOUND)
-        if (refreshToken.isExpired()) {
+
+        if (existedRefreshToken.isExpired()) {
             throw WarnException(ErrorCode.REFRESH_TOKEN_EXPIRED)
         }
 
-        refreshTokenRepository.delete(refreshToken)
+        refreshTokenRepository.delete(existedRefreshToken)
 
-        val newAccessToken = jwtTokenProvider.generateAccessToken(refreshToken.memberId)
-        val newRefreshToken = createRefreshToken(refreshToken.memberId)
+        val newAccessToken = jwtTokenProvider.generateAccessToken(existedRefreshToken.memberId)
+        val newRefreshToken = createRefreshToken(existedRefreshToken.memberId)
 
-        return TokenRefreshResponse(
+        return TokenRefreshResult(
             accessToken = newAccessToken,
             refreshToken = newRefreshToken.token,
         )

--- a/api/src/main/kotlin/com/ditto/api/auth/service/OAuthService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/OAuthService.kt
@@ -25,14 +25,13 @@ class OAuthService(
     }
 
     fun getAuthCallbackUrl(
-        accessToken: String?,
-        refreshToken: String?,
+        accessToken: String,
+        signupRequired: Boolean,
     ): String =
         UriComponentsBuilder
             .fromUriString(frontProperties.oauthCallbackUrl)
-            .apply {
-                accessToken?.let { queryParam("accessToken", it) }
-                refreshToken?.let { queryParam("refreshToken", it) }
-            }.build()
+            .queryParam("accessToken", accessToken)
+            .queryParam("signupRequired", signupRequired)
+            .build()
             .toUriString()
 }

--- a/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
@@ -5,6 +5,7 @@ import com.ditto.api.config.auth.ApiKeyProperties
 import com.ditto.api.config.auth.CorsProperties
 import com.ditto.api.config.auth.JwtAuthenticationFilter
 import com.ditto.api.config.auth.JwtTokenProvider
+import com.ditto.domain.member.repository.MemberRepository
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.core.annotation.Order
@@ -23,6 +24,7 @@ class SecurityConfig(
     private val apiKeyProperties: ApiKeyProperties,
     private val jwtTokenProvider: JwtTokenProvider,
     private val corsProperties: CorsProperties,
+    private val memberRepository: MemberRepository,
 ) {
 
     /**
@@ -104,7 +106,7 @@ class SecurityConfig(
             .cors { it.configurationSource(corsConfigurationSource()) }
             .sessionManagement { it.sessionCreationPolicy(SessionCreationPolicy.STATELESS) }
             .addFilterBefore(ApiKeyAuthFilter(apiKeyProperties), UsernamePasswordAuthenticationFilter::class.java)
-            .addFilterAfter(JwtAuthenticationFilter(jwtTokenProvider), ApiKeyAuthFilter::class.java)
+            .addFilterAfter(JwtAuthenticationFilter(jwtTokenProvider, memberRepository), ApiKeyAuthFilter::class.java)
             .authorizeHttpRequests { it.anyRequest().authenticated() }
             .build()
     }
@@ -125,7 +127,8 @@ class SecurityConfig(
     /**
      * CORS 설정 — 허용 origin은 `ditto.cors.allowed-origins`(yml/환경변수)로 관리
      * 인증 헤더(Authorization, X-API-Key)를 allowedHeaders에 포함한다.
-     * Bearer 토큰 기반이라 쿠키를 쓰지 않으므로 allowCredentials는 false.
+     * refreshToken을 HttpOnly 쿠키로 주고받으므로 allowCredentials는 true.
+     * (allowCredentials=true이면 allowedOrigins에 와일드카드 `*`를 쓸 수 없어 명시적 origin 목록을 사용한다.)
      */
     @Bean
     fun corsConfigurationSource(): CorsConfigurationSource {
@@ -133,7 +136,7 @@ class SecurityConfig(
             allowedOrigins = corsProperties.allowedOrigins
             allowedMethods = listOf("GET", "POST", "PUT", "PATCH", "DELETE", "OPTIONS")
             allowedHeaders = listOf("Authorization", "Content-Type", "X-API-Key")
-            allowCredentials = false
+            allowCredentials = true
             maxAge = 3600L
         }
         return UrlBasedCorsConfigurationSource().apply {

--- a/api/src/main/kotlin/com/ditto/api/config/auth/CookieProperties.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/CookieProperties.kt
@@ -1,0 +1,10 @@
+package com.ditto.api.config.auth
+
+import org.springframework.boot.context.properties.ConfigurationProperties
+
+@ConfigurationProperties(prefix = "ditto.auth.cookie")
+data class CookieProperties(
+    val secure: Boolean = false,
+    val sameSite: String = "Lax",
+    val path: String = "/api/v1/users/auth",
+)

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
@@ -3,15 +3,18 @@ package com.ditto.api.config.auth
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.response.ApiResponse
 import com.ditto.common.serialization.ObjectMapperFactory
+import com.ditto.domain.member.repository.MemberRepository
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.context.SecurityContextHolder
 import org.springframework.web.filter.OncePerRequestFilter
+import kotlin.jvm.optionals.getOrNull
 
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
+    private val memberRepository: MemberRepository,
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(
         request: HttpServletRequest,
@@ -21,11 +24,24 @@ class JwtAuthenticationFilter(
         val token = resolveToken(request)
 
         if (token == null || !jwtTokenProvider.isValid(token)) {
-            retrieveUnauthorized(response)
+            sendError(response, ErrorCode.UNAUTHORIZED_ERROR)
             return
         }
 
-        setAuthentication(token)
+        val memberId = jwtTokenProvider.getMemberId(token)
+        val member = memberRepository.findById(memberId).getOrNull()
+            ?: run {
+                sendError(response, ErrorCode.UNAUTHORIZED_ERROR)
+                return
+            }
+
+        // 회원가입 미완료(PENDING) 회원은 보호 API 접근을 차단한다.
+        if (member.isPending()) {
+            sendError(response, ErrorCode.SIGNUP_REQUIRED)
+            return
+        }
+
+        setAuthentication(memberId)
 
         filterChain.doFilter(request, response)
     }
@@ -36,17 +52,18 @@ class JwtAuthenticationFilter(
             ?.takeIf { it.startsWith(BEARER_PREFIX) }
             ?.substring(BEARER_PREFIX.length)
 
-    private fun retrieveUnauthorized(response: HttpServletResponse) {
-        response.status = HttpServletResponse.SC_UNAUTHORIZED
+    private fun sendError(
+        response: HttpServletResponse,
+        errorCode: ErrorCode,
+    ) {
+        response.status = errorCode.status
         response.contentType = "application/json"
-        response.writer.write(objectMapper.writeValueAsString(ApiResponse.error(ErrorCode.UNAUTHORIZED_ERROR)))
+        response.characterEncoding = "UTF-8"
+        response.writer.write(objectMapper.writeValueAsString(ApiResponse.error(errorCode)))
     }
 
-    private fun setAuthentication(token: String) {
-        val principal =
-            MemberPrincipal(
-                memberId = jwtTokenProvider.getMemberId(token),
-            )
+    private fun setAuthentication(memberId: Long) {
+        val principal = MemberPrincipal(memberId = memberId)
 
         val authentication =
             UsernamePasswordAuthenticationToken(

--- a/api/src/main/kotlin/com/ditto/api/config/auth/RefreshTokenCookieFactory.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/RefreshTokenCookieFactory.kt
@@ -1,0 +1,48 @@
+package com.ditto.api.config.auth
+
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpHeaders
+import org.springframework.http.ResponseCookie
+import org.springframework.stereotype.Component
+
+/**
+ * refreshToken을 담는 HttpOnly 쿠키를 응답에 설정한다.
+ * - HttpOnly: JS(XSS)의 토큰 탈취 차단
+ * - Secure/SameSite/Path: [CookieProperties]로 환경별 제어 (로컬 http는 secure=false)
+ * - Max-Age: refresh 토큰 만료(ms)와 동일
+ */
+@Component
+class RefreshTokenCookieFactory(
+    private val cookieProperties: CookieProperties,
+    private val jwtProperties: JwtProperties,
+) {
+    fun addTo(
+        response: HttpServletResponse,
+        token: String,
+    ) = response.addHeader(
+        HttpHeaders.SET_COOKIE,
+        createCookie(token, jwtProperties.refreshExpirationMs / 1_000).toString()
+    )
+
+    fun expireTo(response: HttpServletResponse)
+    = response.addHeader(
+        HttpHeaders.SET_COOKIE,
+        createCookie("", 0).toString()
+    )
+
+    private fun createCookie(
+        value: String,
+        maxAgeSeconds: Long,
+    ): ResponseCookie =
+        ResponseCookie.from(REFRESH_TOKEN_COOKIE, value)
+            .httpOnly(true)
+            .secure(cookieProperties.secure)
+            .sameSite(cookieProperties.sameSite)
+            .path(cookieProperties.path)
+            .maxAge(maxAgeSeconds)
+            .build()
+
+    companion object {
+        const val REFRESH_TOKEN_COOKIE = "refreshToken"
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/config/exception/GlobalExceptionHandler.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/exception/GlobalExceptionHandler.kt
@@ -8,6 +8,7 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.http.HttpStatus
 import org.springframework.http.converter.HttpMessageNotReadableException
 import org.springframework.web.bind.MethodArgumentNotValidException
+import org.springframework.web.bind.MissingRequestCookieException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.ResponseStatus
 import org.springframework.web.bind.annotation.RestControllerAdvice
@@ -45,6 +46,12 @@ class GlobalExceptionHandler {
     @ExceptionHandler(HttpMessageNotReadableException::class)
     fun handleMessageNotReadable(e: HttpMessageNotReadableException): ApiResponse<Unit> {
         logger.warn { "[PARSE_ERROR] ${e.message}" }
+        return ApiResponse.error(ErrorCode.BAD_REQUEST)
+    }
+
+    @ExceptionHandler(MissingRequestCookieException::class)
+    fun handleMissingCookie(e: MissingRequestCookieException): ApiResponse<Unit> {
+        logger.warn { "[MISSING_COOKIE] ${e.cookieName}" }
         return ApiResponse.error(ErrorCode.BAD_REQUEST)
     }
 

--- a/api/src/main/resources/application.yml
+++ b/api/src/main/resources/application.yml
@@ -19,6 +19,11 @@ springdoc:
 ditto:
   security:
     api-key: test-api-key
+  auth:
+    cookie:
+      secure: ${COOKIE_SECURE:false}
+      same-site: Lax
+      path: /api/v1/users/auth
   cors:
     # TODO(#54): 웹 프론트 dev origin 확정 필요
     allowed-origins:

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -65,10 +65,10 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-05-31 22:59:01",
+                        "joinedAt" : "2026-06-02 17:14:23",
                         "role" : null,
-                        "createdAt" : "2026-05-31 22:59:01",
-                        "updatedAt" : "2026-05-31 22:59:01"
+                        "createdAt" : "2026-06-02 17:14:23",
+                        "updatedAt" : "2026-06-02 17:14:23"
                       },
                       "error" : null
                     }
@@ -187,7 +187,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-quiz-progress-reset-1831456372"
+                $ref: "#/components/schemas/api-v1-users-auth-logout-1831456372"
               examples:
                 quiz-progress-submit-answer:
                   value: |-
@@ -238,7 +238,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-quiz-progress-reset-1831456372"
+                $ref: "#/components/schemas/api-v1-users-auth-logout-1831456372"
               examples:
                 quiz-progress-reset:
                   value: |-
@@ -268,8 +268,8 @@ paths:
                       "success" : true,
                       "data" : {
                         "year" : 2026,
-                        "month" : 5,
-                        "week" : 5,
+                        "month" : 6,
+                        "week" : 1,
                         "quizSets" : [ {
                           "id" : 1,
                           "year" : 2026,
@@ -278,8 +278,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-05-30 22:59:00",
-                          "endDate" : "2026-06-01 22:59:00",
+                          "startDate" : "2026-06-01 17:14:23",
+                          "endDate" : "2026-06-03 17:14:23",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -296,8 +296,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-05-31 22:59:01",
-                            "updatedAt" : "2026-05-31 22:59:01"
+                            "createdAt" : "2026-06-02 17:14:23",
+                            "updatedAt" : "2026-06-02 17:14:23"
                           } ]
                         } ]
                       },
@@ -343,8 +343,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-05-31 22:59:01",
-                        "updatedAt" : "2026-05-31 22:59:01"
+                        "createdAt" : "2026-06-02 17:14:23",
+                        "updatedAt" : "2026-06-02 17:14:23"
                       },
                       "error" : null
                     }
@@ -542,7 +542,7 @@ paths:
       tags:
       - Auth
       summary: 로그아웃
-      description: 액세스 토큰의 회원 정보로 모든 리프레시 토큰을 삭제합니다.
+      description: 액세스 토큰의 회원 정보로 모든 리프레시 토큰을 삭제하고 refreshToken 쿠키를 만료시킵니다.
       operationId: logout
       responses:
         "200":
@@ -550,7 +550,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-quiz-progress-reset-1831456372"
+                $ref: "#/components/schemas/api-v1-users-auth-logout-1831456372"
               examples:
                 logout:
                   value: |-
@@ -566,34 +566,22 @@ paths:
       tags:
       - Auth
       summary: 토큰 갱신
-      description: 리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.
+      description: refreshToken 쿠키로 새 액세스 토큰을 발급하고 refreshToken 쿠키를 재설정합니다.
       operationId: token-refresh
-      requestBody:
-        content:
-          application/json;charset=UTF-8:
-            schema:
-              $ref: "#/components/schemas/api-v1-users-auth-refresh1056639717"
-            examples:
-              token-refresh:
-                value: |-
-                  {
-                    "refreshToken" : "f0b3006c-48e1-4d51-b152-b71529c63ec8"
-                  }
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-auth-refresh-42454406"
+                $ref: "#/components/schemas/api-v1-users-auth-refresh1774976609"
               examples:
                 token-refresh:
                   value: |-
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwMjM1OTM2LCJleHAiOjE3ODAyMzk1MzZ9.-40h2oPbK8fWGHq9gxgclpHkNkeVllwDE161wJPQ6Q2Fe0oPlaaVdEe6dEdtlud0boDLmvy7xXpM70YjPW8Mng",
-                        "refreshToken" : "8dc3caec-646f-49f9-85ab-f073ef0eac9f"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwMzg4MDYxLCJleHAiOjE3ODAzOTE2NjF9.Fufj-xvDtaErR6IZbkaWaw8fJ5gVOcEV5j6Uc47eQfACsF48jSZ_w3u-1B9zMRPeMzPQsNuEgChdql3Eut3T0Q"
                       },
                       "error" : null
                     }
@@ -651,8 +639,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-05-31 22:59:01",
-                        "updatedAt" : "2026-05-31 22:59:01"
+                        "createdAt" : "2026-06-02 17:14:23",
+                        "updatedAt" : "2026-06-02 17:14:23"
                       },
                       "error" : null
                     }
@@ -768,9 +756,8 @@ paths:
       tags:
       - OAuth
       summary: 소셜 로그인 콜백
-      description: "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트합니다. 기존 사용자는 accessToken/refreshToken\
-        \ 쿼리 파라미터가 포함되고, 신규 사용자는 미포함됩니다."
-      operationId: oauth-callback-new-user
+      description: 신규 사용자는 토큰을 발급하지 않습니다. 회원가입이 필요합니다.
+      operationId: oauth-callback
       parameters:
       - name: provider
         in: path
@@ -785,6 +772,23 @@ paths:
         schema:
           type: string
       responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-social-login-provider-callback1248644946"
+              examples:
+                oauth-callback-new-user:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "accessToken" : null,
+                        "refreshToken" : null
+                      },
+                      "error" : null
+                    }
         "302":
           description: "302"
 components:
@@ -797,27 +801,6 @@ components:
         quizSetId:
           type: number
           description: 퀴즈 세트 ID
-    api-v1-users-auth-refresh-42454406:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          - refreshToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
-            refreshToken:
-              type: string
-              description: 새 리프레시 토큰
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-group-join-2080112672:
       required:
       - error
@@ -881,6 +864,23 @@ components:
             status:
               type: string
               description: 매칭 상태 (PENDING)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
         success:
           type: boolean
           description: 성공 여부
@@ -1220,7 +1220,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-quiz-progress-reset-1831456372:
+    api-v1-users-auth-logout-1831456372:
       required:
       - data
       - error
@@ -1296,6 +1296,58 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users-107230905:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - age
+          - birthDate
+          - createdAt
+          - email
+          - gender
+          - id
+          - joinedAt
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 생성일시
+            phoneNumber:
+              type: string
+              description: 전화번호
+            gender:
+              type: string
+              description: 성별
+            joinedAt:
+              type: string
+              description: 가입일시
+            nickname:
+              type: string
+              description: 닉네임
+            name:
+              type: string
+              description: 이름
+            id:
+              type: number
+              description: 사용자 ID
+            age:
+              type: number
+              description: 나이대
+            updatedAt:
+              type: string
+              description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-quiz-sets-id1440540832:
       required:
       - error
@@ -1361,7 +1413,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-107230905:
+    api-v1-users-id-leave-1444522536:
       required:
       - error
       - success
@@ -1386,27 +1438,12 @@ components:
             createdAt:
               type: string
               description: 생성일시
-            phoneNumber:
-              type: string
-              description: 전화번호
-            gender:
-              type: string
-              description: 성별
-            joinedAt:
-              type: string
-              description: 가입일시
             nickname:
               type: string
               description: 닉네임
-            name:
-              type: string
-              description: 이름
             id:
               type: number
               description: 사용자 ID
-            age:
-              type: number
-              description: 나이대
             updatedAt:
               type: string
               description: 수정일시
@@ -1490,15 +1527,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-refresh1056639717:
-      required:
-      - refreshToken
-      type: object
-      properties:
-        refreshToken:
-          type: string
-          description: 리프레시 토큰
-    api-v1-users-id-leave-1444522536:
+    api-v1-users-social-login-provider-callback1248644946:
       required:
       - error
       - success
@@ -1506,32 +1535,10 @@ components:
       properties:
         data:
           required:
-          - age
-          - birthDate
-          - createdAt
-          - email
-          - gender
-          - id
-          - joinedAt
-          - name
-          - nickname
-          - phoneNumber
-          - role
-          - updatedAt
+          - accessToken
+          - refreshToken
           type: object
-          properties:
-            createdAt:
-              type: string
-              description: 생성일시
-            nickname:
-              type: string
-              description: 닉네임
-            id:
-              type: number
-              description: 사용자 ID
-            updatedAt:
-              type: string
-              description: 수정일시
+          properties: {}
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/test/kotlin/com/ditto/api/auth/AuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/AuthControllerTest.kt
@@ -1,25 +1,26 @@
 package com.ditto.api.auth
 
-import com.ditto.api.auth.dto.TokenRefreshRequest
 import com.ditto.api.auth.service.AuthService
+import com.ditto.api.config.auth.RefreshTokenCookieFactory
 import com.ditto.api.support.RestDocsTest
 import com.ditto.domain.member.entity.Member
-import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
 import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.epages.restdocs.apispec.ResourceDocumentation.resource
 import com.epages.restdocs.apispec.ResourceSnippetParameters
+import jakarta.servlet.http.Cookie
+import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
-import org.springframework.http.MediaType
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
 import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
 import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.header
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -29,29 +30,24 @@ class AuthControllerTest : RestDocsTest() {
     private lateinit var authService: AuthService
 
     @Autowired
-    private lateinit var memberRepository: MemberRepository
-
-    @Autowired
     private lateinit var socialAccountRepository: SocialAccountRepository
 
     @Test
-    @DisplayName("리프레시 토큰으로 새 토큰 쌍을 발급한다")
+    @DisplayName("리프레시 토큰 쿠키로 새 액세스 토큰을 발급하고 refreshToken 쿠키를 재설정한다")
     fun refresh() {
         val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))
         socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "providerUserId"))
         val refreshToken = authService.createRefreshToken(member.id)
-        val request = TokenRefreshRequest(refreshToken = refreshToken.token)
 
         mockMvc.perform(
             post("/api/v1/users/auth/refresh")
                 .withApiKey()
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)),
+                .cookie(Cookie(REFRESH_TOKEN_COOKIE, refreshToken.token)),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.accessToken").exists())
-            .andExpect(jsonPath("$.data.refreshToken").exists())
+            .andExpect(header().string("Set-Cookie", containsString("$REFRESH_TOKEN_COOKIE=")))
             .andDo(
                 document(
                     "token-refresh",
@@ -61,14 +57,10 @@ class AuthControllerTest : RestDocsTest() {
                         ResourceSnippetParameters.builder()
                             .tag("Auth")
                             .summary("토큰 갱신")
-                            .description("리프레시 토큰으로 새로운 액세스 토큰과 리프레시 토큰을 발급합니다.")
-                            .requestFields(
-                                fieldWithPath("refreshToken").description("리프레시 토큰"),
-                            )
+                            .description("refreshToken 쿠키로 새 액세스 토큰을 발급하고 refreshToken 쿠키를 재설정합니다.")
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),
                                 fieldWithPath("data.accessToken").description("새 JWT 액세스 토큰"),
-                                fieldWithPath("data.refreshToken").description("새 리프레시 토큰"),
                                 fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),
@@ -78,15 +70,24 @@ class AuthControllerTest : RestDocsTest() {
     }
 
     @Test
+    @DisplayName("리프레시 토큰 쿠키가 없으면 잘못된 요청 에러를 반환한다")
+    fun refreshWithoutCookie() {
+        mockMvc.perform(
+            post("/api/v1/users/auth/refresh")
+                .withApiKey(),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("0001"))
+    }
+
+    @Test
     @DisplayName("존재하지 않는 리프레시 토큰이면 에러를 반환한다")
     fun refreshWithInvalidToken() {
-        val request = TokenRefreshRequest(refreshToken = "invalid-token")
-
         mockMvc.perform(
             post("/api/v1/users/auth/refresh")
                 .withApiKey()
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(objectMapper.writeValueAsString(request)),
+                .cookie(Cookie(REFRESH_TOKEN_COOKIE, "invalid-token")),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(false))
@@ -94,20 +95,22 @@ class AuthControllerTest : RestDocsTest() {
     }
 
     @Test
-    @DisplayName("액세스 토큰으로 로그아웃한다")
+    @DisplayName("액세스 토큰으로 로그아웃하고 refreshToken 쿠키를 만료시킨다")
     fun logout() {
-        val member = memberRepository.save(Member(nickname = "테스트유저"))
+        val member = memberRepository.save(Member(nickname = "테스트유저").apply { activate() })
         socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "test-user"))
         authService.createRefreshToken(member.id)
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id)
 
         mockMvc.perform(
             post("/api/v1/users/auth/logout")
                 .withApiKey()
-                .withBearerToken(),
+                .header("Authorization", "Bearer $accessToken"),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data").doesNotExist())
+            .andExpect(header().string("Set-Cookie", containsString("$REFRESH_TOKEN_COOKIE=")))
             .andDo(
                 document(
                     "logout",
@@ -117,7 +120,7 @@ class AuthControllerTest : RestDocsTest() {
                         ResourceSnippetParameters.builder()
                             .tag("Auth")
                             .summary("로그아웃")
-                            .description("액세스 토큰의 회원 정보로 모든 리프레시 토큰을 삭제합니다.")
+                            .description("액세스 토큰의 회원 정보로 모든 리프레시 토큰을 삭제하고 refreshToken 쿠키를 만료시킵니다.")
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),
                                 fieldWithPath("data").description("데이터 (로그아웃 시 null)"),
@@ -127,5 +130,9 @@ class AuthControllerTest : RestDocsTest() {
                     ),
                 ),
             )
+    }
+
+    companion object {
+        private const val REFRESH_TOKEN_COOKIE = RefreshTokenCookieFactory.REFRESH_TOKEN_COOKIE
     }
 }

--- a/api/src/test/kotlin/com/ditto/api/auth/AuthServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/AuthServiceTest.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.auth
 
-import com.ditto.api.auth.dto.TokenRefreshRequest
 import com.ditto.api.auth.service.AuthService
 import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.api.support.IntegrationTest
@@ -32,7 +31,7 @@ class AuthServiceTest(
                 val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))
                 val refreshToken = authService.createRefreshToken(member.id)
 
-                val result = authService.refresh(TokenRefreshRequest(refreshToken = refreshToken.token))
+                val result = authService.refresh(refreshToken.token)
 
                 result.accessToken shouldNotBe null
                 jwtTokenProvider.isValid(result.accessToken) shouldBe true
@@ -42,7 +41,7 @@ class AuthServiceTest(
 
             "존재하지 않는 리프레시 토큰이면 예외가 발생한다" {
                 val exception = shouldThrow<ErrorException> {
-                    authService.refresh(TokenRefreshRequest(refreshToken = "non-existent-token"))
+                    authService.refresh("non-existent-token")
                 }
                 exception.errorCode shouldBe ErrorCode.REFRESH_TOKEN_NOT_FOUND
             }
@@ -57,7 +56,7 @@ class AuthServiceTest(
                 refreshTokenRepository.save(expiredToken)
 
                 val exception = shouldThrow<WarnException> {
-                    authService.refresh(TokenRefreshRequest(refreshToken = "expired-token"))
+                    authService.refresh("expired-token")
                 }
                 exception.errorCode shouldBe ErrorCode.REFRESH_TOKEN_EXPIRED
             }
@@ -67,10 +66,10 @@ class AuthServiceTest(
                 val refreshToken = authService.createRefreshToken(member.id)
                 val oldToken = refreshToken.token
 
-                authService.refresh(TokenRefreshRequest(refreshToken = oldToken))
+                authService.refresh(oldToken)
 
                 val exception = shouldThrow<ErrorException> {
-                    authService.refresh(TokenRefreshRequest(refreshToken = oldToken))
+                    authService.refresh(oldToken)
                 }
                 exception.errorCode shouldBe ErrorCode.REFRESH_TOKEN_NOT_FOUND
             }
@@ -106,7 +105,7 @@ class AuthServiceTest(
                 authService.logout(member.id)
 
                 val exception = shouldThrow<ErrorException> {
-                    authService.refresh(TokenRefreshRequest(refreshToken = refreshToken.token))
+                    authService.refresh(refreshToken.token)
                 }
                 exception.errorCode shouldBe ErrorCode.REFRESH_TOKEN_NOT_FOUND
             }

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthControllerTest.kt
@@ -6,6 +6,7 @@ import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
 import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
 import com.epages.restdocs.apispec.ResourceDocumentation.resource
 import com.epages.restdocs.apispec.ResourceSnippetParameters
+import org.hamcrest.Matchers.containsString
 import org.hamcrest.Matchers.startsWith
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
@@ -50,18 +51,21 @@ class OAuthControllerTest : RestDocsTest() {
     }
 
     @Test
-    @DisplayName("신규 사용자면 토큰 없이 프론트 콜백으로 리다이렉트한다")
-    fun callbackNewUser() {
+    @DisplayName("콜백은 accessToken·signupRequired를 쿼리로, refreshToken을 HttpOnly 쿠키로 전달한다")
+    fun callback() {
         mockMvc.perform(
             get("/api/v1/users/social-login/{provider}/callback", "KAKAO").withApiKey()
                 .param("code", "test-auth-code"),
         )
             .andExpect(status().isFound)
             .andExpect(header().string("Location", startsWith("http://localhost:3000/auth/callback")))
-            .andExpect(header().string("Location", org.hamcrest.Matchers.not(org.hamcrest.Matchers.containsString("accessToken"))))
+            .andExpect(header().string("Location", containsString("accessToken")))
+            .andExpect(header().string("Location", containsString("signupRequired")))
+            .andExpect(header().string("Set-Cookie", containsString("refreshToken=")))
+            .andExpect(header().string("Set-Cookie", containsString("HttpOnly")))
             .andDo(
                 document(
-                    "oauth-callback-new-user",
+                    "oauth-callback",
                     preprocessRequest(prettyPrint()),
                     preprocessResponse(prettyPrint()),
                     resource(
@@ -69,8 +73,9 @@ class OAuthControllerTest : RestDocsTest() {
                             .tag("OAuth")
                             .summary("소셜 로그인 콜백")
                             .description(
-                                "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트합니다. " +
-                                    "기존 사용자는 accessToken/refreshToken 쿼리 파라미터가 포함되고, 신규 사용자는 미포함됩니다.",
+                                "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트한다. " +
+                                    "accessToken과 회원가입 필요 여부(signupRequired)는 쿼리 파라미터로, " +
+                                    "refreshToken은 HttpOnly 쿠키로 전달된다.",
                             )
                             .pathParameters(
                                 parameterWithName("provider").description(PROVIDER_DESCRIPTION),

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
@@ -61,62 +61,67 @@ class OAuthFacadeTest(
         }
 
         "소셜 로그인" - {
-            "신규 사용자면 PENDING 상태로 생성되고 토큰 없는 redirect URL을 반환한다" {
-                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+            "신규 사용자면 PENDING으로 생성되고 토큰과 signupRequired=true를 반환한다" {
+                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                redirectUrl shouldNotContain "accessToken"
-                redirectUrl shouldNotContain "refreshToken"
+                val params = UriComponentsBuilder.fromUriString(result.redirectUrl).build().queryParams
+                params["accessToken"]?.first() shouldNotBe null
+                params["signupRequired"]?.first() shouldBe "true"
+                result.refreshToken shouldNotBe null
                 memberRepository.count() shouldBe 1
                 memberRepository.findAll().first().status shouldBe MemberStatus.PENDING
                 socialAccountRepository.count() shouldBe 1
-                refreshTokenRepository.count() shouldBe 0
-            }
-
-            "PENDING 사용자가 재로그인하면 토큰 없는 redirect URL을 반환한다" {
-                oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
-
-                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
-
-                redirectUrl shouldNotContain "accessToken"
-                redirectUrl shouldNotContain "refreshToken"
-                memberRepository.count() shouldBe 1
-            }
-
-            "ACTIVE 사용자면 토큰을 포함한 redirect URL을 반환한다" {
-                val member =
-                    memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
-                member.activate()
-                memberRepository.save(member)
-
-                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
-
-                val params = UriComponentsBuilder.fromUriString(redirectUrl).build().queryParams
-                params["accessToken"]?.first() shouldNotBe null
-                params["refreshToken"]?.first() shouldNotBe null
-                jwtTokenProvider.isValid(params["accessToken"]!!.first()) shouldBe true
                 refreshTokenRepository.count() shouldBe 1
             }
 
-            "ACTIVE 사용자의 redirect URL이 설정된 프론트 콜백 URL로 시작한다" {
-                val member =
-                    memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
-                member.activate()
-                memberRepository.save(member)
+            "PENDING 사용자가 재로그인해도 토큰과 signupRequired=true를 반환한다" {
+                oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                redirectUrl shouldContain frontProperties.oauthCallbackUrl
+                val params = UriComponentsBuilder.fromUriString(result.redirectUrl).build().queryParams
+                params["signupRequired"]?.first() shouldBe "true"
+                result.refreshToken shouldNotBe null
+                memberRepository.count() shouldBe 1
             }
 
-            "ACTIVE 사용자의 JWT에 memberId가 포함된다" {
+            "ACTIVE 사용자면 signupRequired=false와 토큰을 반환한다" {
                 val member =
                     memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
                 member.activate()
                 memberRepository.save(member)
 
-                val redirectUrl = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
 
-                val accessToken = UriComponentsBuilder.fromUriString(redirectUrl)
+                val params = UriComponentsBuilder.fromUriString(result.redirectUrl).build().queryParams
+                params["accessToken"]?.first() shouldNotBe null
+                params["signupRequired"]?.first() shouldBe "false"
+                jwtTokenProvider.isValid(params["accessToken"]!!.first()) shouldBe true
+                result.refreshToken shouldNotBe null
+                refreshTokenRepository.count() shouldBe 1
+            }
+
+            "refreshToken은 redirect 쿼리 파라미터에 포함되지 않는다" {
+                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+
+                result.redirectUrl shouldNotContain "refreshToken"
+            }
+
+            "redirect URL이 설정된 프론트 콜백 URL을 포함한다" {
+                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+
+                result.redirectUrl shouldContain frontProperties.oauthCallbackUrl
+            }
+
+            "JWT에 memberId가 포함된다" {
+                val member =
+                    memberSocialAccountService.findOrCreateMember(SocialProvider.KAKAO, "12345", "test@example.com")
+                member.activate()
+                memberRepository.save(member)
+
+                val result = oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+
+                val accessToken = UriComponentsBuilder.fromUriString(result.redirectUrl)
                     .build().queryParams["accessToken"]!!.first()
                 jwtTokenProvider.getMemberId(accessToken) shouldBe member.id
             }

--- a/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
@@ -2,10 +2,13 @@ package com.ditto.api.config.auth
 
 import com.ditto.api.config.TestExceptionController
 import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.member.entity.Member
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.context.annotation.Import
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
@@ -13,9 +16,10 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class JwtAuthenticationFilterTest : RestDocsTest() {
 
     @Test
-    @DisplayName("유효한 Bearer 토큰이면 MemberPrincipal을 받을 수 있다")
+    @DisplayName("유효한 Bearer 토큰이고 ACTIVE 회원이면 MemberPrincipal을 받을 수 있다")
     fun validBearerToken() {
-        val token = jwtTokenProvider.generateAccessToken(1L)
+        val member = memberRepository.save(Member(nickname = "활성유저").apply { activate() })
+        val token = jwtTokenProvider.generateAccessToken(member.id)
 
         mockMvc.perform(
             get("/api/test/me")
@@ -24,7 +28,52 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.memberId").value(1))
+            .andExpect(jsonPath("$.data.memberId").value(member.id))
+    }
+
+    @Test
+    @DisplayName("PENDING 회원이 보호 API에 접근하면 403과 에러 정보를 반환한다")
+    fun pendingMemberForbidden() {
+        val member = memberRepository.save(Member(nickname = "대기유저"))
+        val token = jwtTokenProvider.generateAccessToken(member.id)
+
+        mockMvc.perform(
+            get("/api/test/me")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("3001"))
+    }
+
+    @Test
+    @DisplayName("PENDING 회원은 로그아웃 경로도 차단된다(403)")
+    fun pendingMemberCannotLogout() {
+        val member = memberRepository.save(Member(nickname = "대기유저-logout"))
+        val token = jwtTokenProvider.generateAccessToken(member.id)
+
+        mockMvc.perform(
+            post("/api/v1/users/auth/logout")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.error.code").value("3001"))
+    }
+
+    @Test
+    @DisplayName("토큰은 유효하지만 존재하지 않는 회원이면 401과 에러 정보를 반환한다")
+    fun unknownMember() {
+        val token = jwtTokenProvider.generateAccessToken(99999L)
+
+        mockMvc.perform(
+            get("/api/test/me")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isUnauthorized)
+            .andExpect(jsonPath("$.error.code").value("0002"))
     }
 
     @Test

--- a/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
@@ -2,6 +2,8 @@ package com.ditto.api.support
 
 import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.common.serialization.ObjectMapperFactory
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.repository.MemberRepository
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.extension.ExtendWith
 import org.springframework.beans.factory.annotation.Autowired
@@ -11,6 +13,7 @@ import org.springframework.boot.test.context.SpringBootTest
 import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockHttpServletRequestBuilder
+import java.util.concurrent.atomic.AtomicLong
 
 @SpringBootTest
 @AutoConfigureMockMvc
@@ -25,18 +28,31 @@ abstract class RestDocsTest {
     @Autowired
     lateinit var jwtTokenProvider: JwtTokenProvider
 
+    @Autowired
+    lateinit var memberRepository: MemberRepository
+
     protected val objectMapper: ObjectMapper = ObjectMapperFactory.create()
 
     protected fun MockHttpServletRequestBuilder.withApiKey(): MockHttpServletRequestBuilder {
         return this.header("X-API-Key", TEST_API_KEY)
     }
 
+    /**
+     * ACTIVE 회원을 새로 만들어 그 회원의 Bearer 토큰을 헤더에 추가한다.
+     * JWT 필터가 회원 status를 조회하므로, 인증이 필요한 테스트는 ACTIVE 회원이 있어야 한다.
+     */
     protected fun MockHttpServletRequestBuilder.withBearerToken(): MockHttpServletRequestBuilder {
-        val token = jwtTokenProvider.generateAccessToken(1L)
-        return this.header("Authorization", "Bearer $token")
+        val member = memberRepository.save(Member(nickname = "auth-${memberSeq.incrementAndGet()}").apply { activate() })
+        return withBearerToken(member.id)
+    }
+
+    /** 지정한 회원 id의 Bearer 토큰을 헤더에 추가한다. */
+    protected fun MockHttpServletRequestBuilder.withBearerToken(memberId: Long): MockHttpServletRequestBuilder {
+        return this.header("Authorization", "Bearer ${jwtTokenProvider.generateAccessToken(memberId)}")
     }
 
     companion object {
         const val TEST_API_KEY = "test-api-key"
+        private val memberSeq = AtomicLong(0)
     }
 }

--- a/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
@@ -4,7 +4,6 @@ import com.ditto.api.support.RestDocsTest
 import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Member
-import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
@@ -26,9 +25,6 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPat
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 
 class UserControllerTest : RestDocsTest() {
-
-    @Autowired
-    private lateinit var memberRepository: MemberRepository
 
     @Autowired
     private lateinit var socialAccountRepository: SocialAccountRepository
@@ -138,13 +134,13 @@ class UserControllerTest : RestDocsTest() {
     @Test
     @DisplayName("회원 탈퇴에 성공한다")
     fun leaveUser() {
-        val member = memberRepository.save(Member(nickname = "탈퇴유저"))
+        val member = memberRepository.save(Member(nickname = "탈퇴유저").apply { activate() })
         socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "test-user"))
 
         mockMvc.perform(
             post("/api/v1/users/{id}/leave", member.id)
                 .withApiKey()
-                .withBearerToken(),
+                .withBearerToken(member.id),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))

--- a/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
+++ b/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
@@ -12,6 +12,7 @@ enum class ErrorCode(
     UNSUPPORTED_PROVIDER(400, "1001", "지원하지 않는 소셜 로그인 제공자입니다."),
     REFRESH_TOKEN_NOT_FOUND(401, "2001", "리프레시 토큰이 존재하지 않습니다."),
     REFRESH_TOKEN_EXPIRED(401, "2002", "리프레시 토큰이 만료되었습니다."),
+    SIGNUP_REQUIRED(403, "3001", "회원가입을 완료해야 이용할 수 있습니다."),
     MEMBER_ALREADY_EXISTS(409, "3002", "이미 존재하는 사용자입니다."),
     NICKNAME_ALREADY_EXISTS(409, "3003", "이미 사용 중인 닉네임입니다."),
     QUIZ_NOT_IN_ACTIVE_SET(400, "4001", "현재 활성화된 퀴즈 세트에 속한 퀴즈가 아닙니다."),


### PR DESCRIPTION
## 개요
이슈 #59 — OAuth 로그인에서 `refreshToken`을 URL 쿼리 대신 **HttpOnly 쿠키**로 전환하고, **PENDING 회원 status 게이트**를 추가합니다.

Closes #59

## 변경 사항
- **콜백 응답**: `accessToken`·`signupRequired`는 쿼리 파라미터, `refreshToken`은 HttpOnly·Secure·SameSite=Lax 쿠키(Path=`/api/v1/users/auth`)
- **pending·active 공통 토큰 발급**: PENDING access는 후속 회원가입 식별용, refresh는 access 갱신용(refresh API는 apiKeyOnly라 PENDING도 갱신 가능)
- **status 게이트**: `JwtAuthenticationFilter`가 멤버 status 조회 → PENDING은 보호 API 차단(`SIGNUP_REQUIRED`)
- **refresh 갱신 API**: 쿠키 입출력으로 전환, 쿠키 누락은 `BAD_REQUEST`(`GlobalExceptionHandler`)
- **쿠키 로직 응집**: `RefreshTokenCookieFactory`(`addTo`/`expireTo`)
- **CORS** `allowCredentials=true`, `COOKIE_SECURE` 환경변수(운영 `true`, task-definition)

## 의도된 trade-off
- `accessToken`을 쿼리로 전달: 단명(1h)이라 URL 노출 감수, 장수명 refresh만 쿠키로 보호
- 필터의 매 요청 멤버 DB 조회: status 실시간 정확성을 위해 채택(MVP 규모 적정)

## 후속 작업 (별도 이슈 예정)
- ⚠️ 회원가입 API(`UserService.register`)를 access의 `memberId` 식별로 전환(현재 `provider`+`providerUserId`) — 이게 합쳐져야 pending→회원가입 흐름이 완성됨
- refresh rotation의 race condition (락/`@Version`)
- `OAuthFacade.login` `@Transactional`(단, 외부 호출 `getOAuthUserInfo`는 트랜잭션 밖)
- PENDING orphan refresh 정리(TTL/배치)
- CORS 와일드카드 런타임 검증

🤖 Generated with [Claude Code](https://claude.com/claude-code)