### PR TITLE
refactor. 회원가입 API를 액세스 토큰 memberId 기반으로 전환

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/SecurityConfig.kt
@@ -75,7 +75,7 @@ class SecurityConfig(
     }
 
     /**
-     * API Key만 필요 (토큰 갱신, 회원가입 등 JWT 불필요)
+     * API Key만 필요 (토큰 갱신·닉네임 중복확인 등 JWT 불필요)
      */
     @Bean
     @Order(4)
@@ -83,7 +83,6 @@ class SecurityConfig(
         return http
             .securityMatcher(
                 "/api/v1/users/auth/refresh",
-                "/api/v1/users",
                 "/api/v1/users/nickname/**",
             )
             .csrf { it.disable() }
@@ -148,7 +147,13 @@ class SecurityConfig(
     }
 
     companion object {
-        // PENDING(가입 미완료) 회원도 JWT만으로 접근 가능한 경로 — 가입 정보 prefill 조회용.
-        private val PENDING_ALLOWED_PATHS = setOf("/api/v1/users/me")
+        // PENDING(가입 미완료) 회원도 JWT만으로 접근 가능한 경로.
+        // - GET /api/v1/users/me: 가입 정보 prefill 조회
+        // - POST /api/v1/users: 회원가입 완료(추가 정보 입력) — 호출 시점엔 아직 PENDING이므로 허용 필요
+        //
+        // ⚠️ JwtAuthenticationFilter는 HTTP method를 무시하고 경로(requestURI)만으로 매칭한다.
+        //    같은 경로에 다른 method 엔드포인트(예: GET/DELETE /api/v1/users)를 추가하면
+        //    PENDING 회원에게도 함께 열리므로, 그때 PENDING 노출 여부를 반드시 재검토할 것.
+        private val PENDING_ALLOWED_PATHS = setOf("/api/v1/users/me", "/api/v1/users")
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
@@ -15,7 +15,6 @@ import kotlin.jvm.optionals.getOrNull
 class JwtAuthenticationFilter(
     private val jwtTokenProvider: JwtTokenProvider,
     private val memberRepository: MemberRepository,
-    // PENDING 회원도 접근을 허용할 경로 (예: 가입 정보 조회용 /me). 그 외 보호 API는 SIGNUP_REQUIRED로 차단.
     private val pendingAllowedPaths: Set<String> = emptySet(),
 ) : OncePerRequestFilter() {
     override fun doFilterInternal(

--- a/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
@@ -22,8 +22,11 @@ class UserController(
 ) {
 
     @PostMapping("/api/v1/users")
-    fun register(@Valid @RequestBody request: CreateUserRequest): ApiResponse<RegisterResponse> {
-        val result = userService.register(request)
+    fun register(
+        @Valid @RequestBody request: CreateUserRequest,
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<RegisterResponse> {
+        val result = userService.register(principal.memberId, request)
         return ApiResponse.ok(result)
     }
 

--- a/api/src/main/kotlin/com/ditto/api/user/dto/CreateUserRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/CreateUserRequest.kt
@@ -1,10 +1,7 @@
 package com.ditto.api.user.dto
 
 import com.ditto.domain.member.entity.Gender
-import com.ditto.domain.socialaccount.entity.SocialProvider
 import jakarta.validation.constraints.Email
-import jakarta.validation.constraints.NotBlank
-import jakarta.validation.constraints.NotNull
 import jakarta.validation.constraints.Pattern
 import jakarta.validation.constraints.Size
 import java.time.LocalDateTime
@@ -29,10 +26,4 @@ data class CreateUserRequest(
     val age: Int? = null,
 
     val birthDate: LocalDateTime? = null,
-
-    @field:NotNull
-    val provider: SocialProvider,
-
-    @field:NotBlank
-    val providerUserId: String,
 )

--- a/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
@@ -25,12 +25,10 @@ class UserService(
 ) {
 
     @Transactional
-    fun register(request: CreateUserRequest): RegisterResponse {
-        val socialAccount =
-            socialAccountRepository.findByProviderAndProviderUserId(request.provider, request.providerUserId)
-                ?: throw ErrorException(ErrorCode.NOT_FOUND)
-
-        val member = memberRepository.findById(socialAccount.memberId).orElseThrow {
+    fun register(memberId: Long, request: CreateUserRequest): RegisterResponse {
+        // memberId는 JWT 필터가 검증해 넘긴 값이라 회원이 존재해야 정상이다.
+        // 여기서 못 찾으면 클라이언트 잘못이 아니라 토큰-DB 정합성이 깨진 서버 오류다.
+        val member = memberRepository.findById(memberId).orElseThrow {
             ErrorException(ErrorCode.INTERNAL_ERROR)
         }
 

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -29,7 +29,7 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: "#/components/schemas/api-v1-users-1422985128"
+              $ref: "#/components/schemas/api-v1-users1226513419"
             examples:
               user-register:
                 value: |-
@@ -40,9 +40,7 @@ paths:
                     "email" : null,
                     "gender" : "MALE",
                     "age" : 25,
-                    "birthDate" : null,
-                    "provider" : "KAKAO",
-                    "providerUserId" : "register-user"
+                    "birthDate" : null
                   }
       responses:
         "200":
@@ -65,13 +63,15 @@ paths:
                         "gender" : "MALE",
                         "age" : 25,
                         "birthDate" : null,
-                        "joinedAt" : "2026-06-05 12:17:56",
+                        "joinedAt" : "2026-06-05 18:31:29",
                         "role" : null,
-                        "createdAt" : "2026-06-05 12:17:56",
-                        "updatedAt" : "2026-06-05 12:17:56"
+                        "createdAt" : "2026-06-05 18:31:29",
+                        "updatedAt" : "2026-06-05 18:31:29"
                       },
                       "error" : null
                     }
+      security:
+      - bearerAuthJWT: []
   /api/v1/matches/1on1:
     get:
       tags:
@@ -278,8 +278,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-06-04 12:17:56",
-                          "endDate" : "2026-06-06 12:17:56",
+                          "startDate" : "2026-06-04 18:31:29",
+                          "endDate" : "2026-06-06 18:31:29",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -296,8 +296,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-06-05 12:17:56",
-                            "updatedAt" : "2026-06-05 12:17:56"
+                            "createdAt" : "2026-06-05 18:31:29",
+                            "updatedAt" : "2026-06-05 18:31:29"
                           } ]
                         } ]
                       },
@@ -343,8 +343,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-06-05 12:17:56",
-                        "updatedAt" : "2026-06-05 12:17:56"
+                        "createdAt" : "2026-06-05 18:31:29",
+                        "updatedAt" : "2026-06-05 18:31:29"
                       },
                       "error" : null
                     }
@@ -609,7 +609,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwNjI5NDczLCJleHAiOjE3ODA2MzMwNzN9.b2U7L1yO4RJ774e9RC_YBQTdaoX_LJHi1MxKQHG0XKGszrRRUVW-nJ9NFVDb3gb0el2anvvMRZjsgXLPWViZXQ"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwNjUxODg3LCJleHAiOjE3ODA2NTU0ODd9.IuUzdEIQJyIX_OcxEYIqJgjZzm2qZ_iT3ofgn1GLyazCOu4OQ9g7tGJVCBoz5LsWWeRuJkZPiJio4YdvBb9WQA"
                       },
                       "error" : null
                     }
@@ -667,8 +667,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-06-05 12:17:56",
-                        "updatedAt" : "2026-06-05 12:17:56"
+                        "createdAt" : "2026-06-05 18:31:29",
+                        "updatedAt" : "2026-06-05 18:31:29"
                       },
                       "error" : null
                     }
@@ -879,23 +879,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-refresh1774976609:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-quiz-sets-current-week-523790867:
       required:
       - error
@@ -1019,6 +1002,23 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-matches-request-793255208:
       required:
       - quizSetId
@@ -1040,6 +1040,29 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users1226513419:
+      type: object
+      properties:
+        phoneNumber:
+          type: string
+          description: 전화번호 (010-0000-0000)
+          nullable: true
+        gender:
+          type: string
+          description: "성별 (MALE, FEMALE)"
+          nullable: true
+        nickname:
+          type: string
+          description: "닉네임 (2~10자, 한글·영문·숫자)"
+          nullable: true
+        name:
+          type: string
+          description: 이름
+          nullable: true
+        age:
+          type: number
+          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
+          nullable: true
     api-v1-users-me506188890:
       required:
       - error
@@ -1204,38 +1227,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-1422985128:
-      required:
-      - provider
-      - providerUserId
-      type: object
-      properties:
-        phoneNumber:
-          type: string
-          description: 전화번호 (010-0000-0000)
-          nullable: true
-        gender:
-          type: string
-          description: "성별 (MALE, FEMALE)"
-          nullable: true
-        provider:
-          type: string
-          description: 소셜 로그인 제공자 (KAKAO)
-        nickname:
-          type: string
-          description: "닉네임 (2~10자, 한글·영문·숫자)"
-          nullable: true
-        name:
-          type: string
-          description: 이름
-          nullable: true
-        providerUserId:
-          type: string
-          description: 소셜 로그인 제공자의 사용자 ID
-        age:
-          type: number
-          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
-          nullable: true
     api-v1-users-nickname-nickname-availability-125958969:
       required:
       - error
@@ -1275,6 +1266,112 @@ components:
         quizId:
           type: number
           description: 퀴즈 ID
+    api-v1-matching-status-quizSetId-1585477117:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - groupMatchStatus
+          - quizSetId
+          type: object
+          properties:
+            groupMatchStatus:
+              type: string
+              description: 그룹 매칭 상태 (NONE / JOINED / DECLINED)
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            groupMatchRoomId:
+              type: number
+              description: 참여 중인 그룹 방 ID (JOINED 일 때만 존재)
+              nullable: true
+            personalMatch:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  description: 요청 생성일시
+                  nullable: true
+                receiverId:
+                  type: number
+                  description: 수신자 ID
+                  nullable: true
+                requesterId:
+                  type: number
+                  description: 요청자 ID
+                  nullable: true
+                respondedAt:
+                  type: string
+                  description: 응답 일시 (없으면 null)
+                  nullable: true
+                id:
+                  type: number
+                  description: 매칭 ID
+                  nullable: true
+                status:
+                  type: string
+                  description: 매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED /
+                    EXPIRED)
+                  nullable: true
+              description: 1:1 매칭 정보 (없으면 null)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-107230905:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - age
+          - birthDate
+          - createdAt
+          - email
+          - gender
+          - id
+          - joinedAt
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 생성일시
+            phoneNumber:
+              type: string
+              description: 전화번호
+            gender:
+              type: string
+              description: 성별
+            joinedAt:
+              type: string
+              description: 가입일시
+            nickname:
+              type: string
+              description: 닉네임
+            name:
+              type: string
+              description: 이름
+            id:
+              type: number
+              description: 사용자 ID
+            age:
+              type: number
+              description: 나이대
+            updatedAt:
+              type: string
+              description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-quiz-sets-id1440540832:
       required:
       - error
@@ -1337,112 +1434,6 @@ components:
             updatedAt:
               type: string
               description: 수정일시
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-107230905:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - age
-          - birthDate
-          - createdAt
-          - email
-          - gender
-          - id
-          - joinedAt
-          - name
-          - nickname
-          - phoneNumber
-          - role
-          - updatedAt
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 생성일시
-            phoneNumber:
-              type: string
-              description: 전화번호
-            gender:
-              type: string
-              description: 성별
-            joinedAt:
-              type: string
-              description: 가입일시
-            nickname:
-              type: string
-              description: 닉네임
-            name:
-              type: string
-              description: 이름
-            id:
-              type: number
-              description: 사용자 ID
-            age:
-              type: number
-              description: 나이대
-            updatedAt:
-              type: string
-              description: 수정일시
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-matching-status-quizSetId-1585477117:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - groupMatchStatus
-          - quizSetId
-          type: object
-          properties:
-            groupMatchStatus:
-              type: string
-              description: 그룹 매칭 상태 (NONE / JOINED / DECLINED)
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            groupMatchRoomId:
-              type: number
-              description: 참여 중인 그룹 방 ID (JOINED 일 때만 존재)
-              nullable: true
-            personalMatch:
-              type: object
-              properties:
-                createdAt:
-                  type: string
-                  description: 요청 생성일시
-                  nullable: true
-                receiverId:
-                  type: number
-                  description: 수신자 ID
-                  nullable: true
-                requesterId:
-                  type: number
-                  description: 요청자 ID
-                  nullable: true
-                respondedAt:
-                  type: string
-                  description: 응답 일시 (없으면 null)
-                  nullable: true
-                id:
-                  type: number
-                  description: 매칭 ID
-                  nullable: true
-                status:
-                  type: string
-                  description: 매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED /
-                    EXPIRED)
-                  nullable: true
-              description: 1:1 매칭 정보 (없으면 null)
         success:
           type: boolean
           description: 성공 여부
@@ -1523,43 +1514,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-matches-request-id-accept-2011455419:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - createdAt
-          - id
-          - quizSetId
-          - receiverId
-          - requesterId
-          - status
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 요청 생성일시
-            receiverId:
-              type: number
-              description: 수신자 ID
-            requesterId:
-              type: number
-              description: 요청자 ID
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            id:
-              type: number
-              description: 매칭 ID
-            status:
-              type: string
-              description: 변경된 매칭 상태 (ACCEPTED)
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-users-id-leave-1444522536:
       required:
       - error
@@ -1594,6 +1548,43 @@ components:
             updatedAt:
               type: string
               description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-id-accept-2011455419:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 매칭 ID
+            status:
+              type: string
+              description: 변경된 매칭 상태 (ACCEPTED)
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
@@ -34,20 +34,18 @@ class UserControllerTest : RestDocsTest() {
     @DisplayName("회원가입에 성공한다")
     fun register() {
         val member = memberRepository.save(Member(nickname = "임시닉네임"))
-        socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "register-user"))
         val request = CreateUserRequest(
             name = "김철수",
             nickname = "철수123",
             phoneNumber = "010-1234-5678",
             gender = Gender.MALE,
             age = 25,
-            provider = SocialProvider.KAKAO,
-            providerUserId = "register-user",
         )
 
         mockMvc.perform(
             post("/api/v1/users")
                 .withApiKey()
+                .withBearerToken(member.id)
                 .contentType(MediaType.APPLICATION_JSON)
                 .content(objectMapper.writeValueAsString(request)),
         )
@@ -73,8 +71,6 @@ class UserControllerTest : RestDocsTest() {
                                 fieldWithPath("gender").description("성별 (MALE, FEMALE)").optional(),
                                 fieldWithPath("age").description("나이대 (20, 25, 30, 35, 40, 45, 50, 60)").optional(),
                                 fieldWithPath("birthDate").description("생년월일").optional(),
-                                fieldWithPath("provider").description("소셜 로그인 제공자 (KAKAO)"),
-                                fieldWithPath("providerUserId").description("소셜 로그인 제공자의 사용자 ID"),
                             )
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),

--- a/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
@@ -36,17 +36,15 @@ class UserServiceTest(
         "회원가입" - {
             "PENDING 상태의 회원을 정상 등록한다" {
                 val member = memberRepository.save(Member(nickname = "임시닉네임"))
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "provider-user-1"))
 
                 val result = userService.register(
+                    member.id,
                     CreateUserRequest(
                         name = "김철수",
                         nickname = "철수123",
                         phoneNumber = "010-1234-5678",
                         gender = Gender.MALE,
                         age = 25,
-                        provider = SocialProvider.KAKAO,
-                        providerUserId = "provider-user-1",
                     ),
                 )
 
@@ -61,30 +59,25 @@ class UserServiceTest(
                 saved.status shouldBe MemberStatus.ACTIVE
             }
 
-            "존재하지 않는 소셜 계정이면 예외가 발생한다" {
+            "토큰의 회원이 존재하지 않으면 서버 오류가 발생한다" {
                 val exception = shouldThrow<ErrorException> {
                     userService.register(
-                        CreateUserRequest(
-                            provider = SocialProvider.KAKAO,
-                            providerUserId = "non-existent",
-                        ),
+                        99999L,
+                        CreateUserRequest(),
                     )
                 }
-                exception.errorCode shouldBe ErrorCode.NOT_FOUND
+                exception.errorCode shouldBe ErrorCode.INTERNAL_ERROR
             }
 
             "이미 ACTIVE인 회원이면 예외가 발생한다" {
                 val member = memberRepository.save(Member(nickname = "임시닉네임"))
                 member.activate()
                 memberRepository.save(member)
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "provider-user-2"))
 
                 val exception = shouldThrow<ErrorException> {
                     userService.register(
-                        CreateUserRequest(
-                            provider = SocialProvider.KAKAO,
-                            providerUserId = "provider-user-2",
-                        ),
+                        member.id,
+                        CreateUserRequest(),
                     )
                 }
                 exception.errorCode shouldBe ErrorCode.MEMBER_ALREADY_EXISTS
@@ -96,14 +89,12 @@ class UserServiceTest(
                 memberRepository.save(existingMember)
 
                 val pending = memberRepository.save(Member(nickname = "임시닉네임"))
-                socialAccountRepository.save(SocialAccount.create(pending.id, SocialProvider.KAKAO, "provider-user-3"))
 
                 val exception = shouldThrow<WarnException> {
                     userService.register(
+                        pending.id,
                         CreateUserRequest(
                             nickname = "중복닉네임",
-                            provider = SocialProvider.KAKAO,
-                            providerUserId = "provider-user-3",
                         ),
                     )
                 }


### PR DESCRIPTION
## 개요
`POST /api/v1/users`(회원가입) 인증 방식을 **요청 바디의 provider/providerUserId 기반 소셜 계정 조회**에서 **액세스 토큰(JWT)의 memberId 기반 직접 조회**로 전환합니다.

> ⚠️ 브랜치명이 `feature/66-register`지만 **이슈 #66(1:1 매칭)과 무관한 별개 register 작업**입니다.

## 변경 사항
- `CreateUserRequest`에서 `provider`·`providerUserId` 필드 제거 (소셜 식별 정보는 토큰에서 획득)
- `register`가 `@AuthenticationPrincipal MemberPrincipal`로 memberId 수신 → `register(memberId, request)`
- `UserService.register`: socialAccount 재조회 제거, `memberId`로 회원 직접 조회
- `SecurityConfig`: `apiKeyOnly` 체인에서 `/api/v1/users` 제외 → JWT 필수 체인으로 이동, `PENDING_ALLOWED_PATHS`에 추가 (가입 완료 호출 시점엔 아직 PENDING이므로 허용 필요)
- 토큰이 가리키는 회원이 없으면(JWT 필터가 이미 존재 보장) 정합성 오류로 `ErrorException(INTERNAL_ERROR)`

## 보안 / 설계 메모
- provider/providerUserId를 바디로 받지 않게 되어, 타인의 providerUserId 위변조로 가입을 가로챌 수 있던 표면이 제거됨
- `pendingAllowedPaths`는 HTTP method 무관 경로 매칭이라, 같은 경로에 다른 method 엔드포인트 추가 시 PENDING 노출 재검토 필요 → 코드에 경고 주석 추가

## openapi.yaml
- 변경 라인 대부분은 restdocs 재생성 시 발생하는 **operation 순서 재정렬 노이즈**(operationId 집합 불변). 실제 의미 변경은 register 요청에서 provider/providerUserId 필드 제거뿐.

## 테스트
- `./gradlew :api:clean :api:test` 통과 (전체 + jacoco 커버리지 50%)
- `UserControllerTest.register`: bearer token 기반으로 갱신
- `UserServiceTest`: memberId 인자 / INTERNAL_ERROR 케이스 반영

🤖 Generated with [Claude Code](https://claude.com/claude-code)