### PR TITLE
feat. 카카오 로그인 시 이름·전화번호·성별 수집

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
@@ -27,6 +27,9 @@ class OAuthFacade(
             providerUserId = userInfo.id,
             email = userInfo.email,
             birthDate = userInfo.birthDate?.atStartOfDay(),
+            name = userInfo.name,
+            phoneNumber = userInfo.phoneNumber,
+            gender = userInfo.gender,
         )
 
         val accessToken = jwtTokenProvider.generateAccessToken(member.id)

--- a/api/src/main/kotlin/com/ditto/api/auth/service/MemberSocialAccountService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/MemberSocialAccountService.kt
@@ -3,6 +3,7 @@ package com.ditto.api.auth.service
 import com.ditto.api.auth.NicknameGenerator
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
+import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Member
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
@@ -24,6 +25,9 @@ class MemberSocialAccountService(
         providerUserId: String,
         email: String?,
         birthDate: LocalDateTime?,
+        name: String? = null,
+        phoneNumber: String? = null,
+        gender: Gender? = null,
     ): Member {
         val existingAccount = socialAccountRepository.findByProviderAndProviderUserId(provider, providerUserId)
 
@@ -38,10 +42,20 @@ class MemberSocialAccountService(
                 log.info { "Member(id=${member.id}) 이메일 변경: ${member.email} -> $email" }
                 member.updateEmail(email)
             }
+            member.updateOAuthInfo(name = name, phoneNumber = phoneNumber, gender = gender)
             return member
         }
 
-        val newMember = memberRepository.save(Member(nickname = generateUniqueNickname(), email = email, birthDate = birthDate))
+        val newMember = memberRepository.save(
+            Member(
+                nickname = generateUniqueNickname(),
+                email = email,
+                birthDate = birthDate,
+                name = name,
+                phoneNumber = phoneNumber,
+                gender = gender,
+            ),
+        )
         socialAccountRepository.save(
             SocialAccount.create(
                 memberId = newMember.id,

--- a/api/src/test/kotlin/com/ditto/api/auth/MemberSocialAccountServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/MemberSocialAccountServiceTest.kt
@@ -3,6 +3,7 @@ package com.ditto.api.auth
 import com.ditto.api.auth.service.MemberSocialAccountService
 import com.ditto.api.support.IntegrationTest
 import com.ditto.common.exception.ErrorException
+import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Member
 import com.ditto.domain.member.entity.MemberStatus
 import com.ditto.domain.member.repository.MemberRepository
@@ -66,6 +67,51 @@ class MemberSocialAccountServiceTest(
                 )
 
                 member.birthDate shouldBe birthDate
+            }
+
+            "신규 사용자면 카카오에서 받은 이름·전화번호·성별을 저장한다" {
+                val member = memberSocialAccountService.findOrCreateMember(
+                    SocialProvider.KAKAO, "kakao-123", "test@kakao.com", null,
+                    name = "홍길동", phoneNumber = "010-1234-5678", gender = Gender.MALE,
+                )
+
+                member.name shouldBe "홍길동"
+                member.phoneNumber shouldBe "010-1234-5678"
+                member.gender shouldBe Gender.MALE
+            }
+
+            "기존 사용자 재로그인 시 이름·전화번호·성별을 카카오 값으로 갱신한다" {
+                val created = memberSocialAccountService.findOrCreateMember(
+                    SocialProvider.KAKAO, "kakao-123", "test@kakao.com", null,
+                    name = "홍길동", phoneNumber = "010-1111-1111", gender = Gender.MALE,
+                )
+
+                val found = memberSocialAccountService.findOrCreateMember(
+                    SocialProvider.KAKAO, "kakao-123", "test@kakao.com", null,
+                    name = "김철수", phoneNumber = "010-2222-2222", gender = Gender.FEMALE,
+                )
+
+                found.id shouldBe created.id
+                found.name shouldBe "김철수"
+                found.phoneNumber shouldBe "010-2222-2222"
+                found.gender shouldBe Gender.FEMALE
+            }
+
+            "기존 사용자 재로그인 시 이름·전화번호·성별이 null이면 기존 값을 유지한다" {
+                val created = memberSocialAccountService.findOrCreateMember(
+                    SocialProvider.KAKAO, "kakao-123", "test@kakao.com", null,
+                    name = "홍길동", phoneNumber = "010-1111-1111", gender = Gender.MALE,
+                )
+
+                val found = memberSocialAccountService.findOrCreateMember(
+                    SocialProvider.KAKAO, "kakao-123", "test@kakao.com", null,
+                    name = null, phoneNumber = null, gender = null,
+                )
+
+                found.id shouldBe created.id
+                found.name shouldBe "홍길동"
+                found.phoneNumber shouldBe "010-1111-1111"
+                found.gender shouldBe Gender.MALE
             }
 
             "기존 사용자면 기존 Member를 반환한다" {

--- a/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/OAuthFacadeTest.kt
@@ -9,6 +9,7 @@ import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.api.support.IntegrationTest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
+import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.MemberStatus
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
@@ -80,6 +81,16 @@ class OAuthFacadeTest(
 
                 // KakaoOAuthFakeClient가 1995-03-15를 반환한다.
                 memberRepository.findAll().first().birthDate shouldBe LocalDateTime.of(1995, 3, 15, 0, 0)
+            }
+
+            "신규 사용자면 카카오에서 받은 이름·전화번호·성별이 Member에 저장된다" {
+                oAuthFacade.login(SocialProvider.KAKAO, "auth-code")
+
+                // KakaoOAuthFakeClient가 이름=테스트, 전화번호=010-1234-5678, 성별=MALE을 반환한다.
+                val member = memberRepository.findAll().first()
+                member.name shouldBe "테스트"
+                member.phoneNumber shouldBe "010-1234-5678"
+                member.gender shouldBe Gender.MALE
             }
 
             "PENDING 사용자가 재로그인해도 토큰과 signupRequired=true를 반환한다" {

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
@@ -77,6 +77,20 @@ class Member(
         }
     }
 
+    /**
+     * 소셜 로그인에서 받은 개인정보로 갱신한다.
+     * 제공된(non-null) 값만 덮어쓰며, 미동의로 null이 온 항목은 기존 값을 유지한다.
+     */
+    fun updateOAuthInfo(
+        name: String?,
+        phoneNumber: String?,
+        gender: Gender?,
+    ) {
+        if (name != null) this.name = name
+        if (phoneNumber != null) this.phoneNumber = phoneNumber
+        if (gender != null) this.gender = gender
+    }
+
     fun isPending(): Boolean = status == MemberStatus.PENDING
 
     fun register(

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberTest.kt
@@ -70,6 +70,33 @@ class MemberTest(
             }
         }
 
+        "Member 소셜 개인정보 갱신" - {
+            "updateOAuthInfo() - 이름·전화번호·성별을 갱신한다" {
+                val member = Member(nickname = "테스트유저")
+
+                member.updateOAuthInfo(name = "홍길동", phoneNumber = "010-1234-5678", gender = Gender.FEMALE)
+
+                member.name shouldBe "홍길동"
+                member.phoneNumber shouldBe "010-1234-5678"
+                member.gender shouldBe Gender.FEMALE
+            }
+
+            "updateOAuthInfo() - null 값인 필드는 기존 값을 유지한다" {
+                val member = Member(
+                    nickname = "테스트유저",
+                    name = "기존이름",
+                    phoneNumber = "010-1111-1111",
+                    gender = Gender.MALE,
+                )
+
+                member.updateOAuthInfo(name = null, phoneNumber = null, gender = null)
+
+                member.name shouldBe "기존이름"
+                member.phoneNumber shouldBe "010-1111-1111"
+                member.gender shouldBe Gender.MALE
+            }
+        }
+
         "Member 상태 변경" - {
             "activate() 호출 시 ACTIVE 상태로 변경된다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))

--- a/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/OAuthUserInfo.kt
+++ b/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/OAuthUserInfo.kt
@@ -1,5 +1,6 @@
 package com.ditto.infrastructure.oauth
 
+import com.ditto.domain.member.entity.Gender
 import java.time.LocalDate
 
 data class OAuthUserInfo(
@@ -7,4 +8,7 @@ data class OAuthUserInfo(
     val nickname: String,
     val email: String?,
     val birthDate: LocalDate? = null,
+    val name: String? = null,
+    val phoneNumber: String? = null,
+    val gender: Gender? = null,
 )

--- a/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/OAuthUserInfo.kt
+++ b/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/OAuthUserInfo.kt
@@ -8,7 +8,7 @@ data class OAuthUserInfo(
     val nickname: String,
     val email: String?,
     val birthDate: LocalDate? = null,
-    val name: String? = null,
-    val phoneNumber: String? = null,
-    val gender: Gender? = null,
+    val name: String?,
+    val phoneNumber: String?,
+    val gender: Gender?,
 )

--- a/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthClient.kt
+++ b/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthClient.kt
@@ -1,5 +1,6 @@
 package com.ditto.infrastructure.oauth.kakao
 
+import com.ditto.domain.member.entity.Gender
 import com.ditto.infrastructure.oauth.OAuthClient
 import com.ditto.infrastructure.oauth.OAuthUserInfo
 import com.ditto.infrastructure.oauth.constants.OAuthConstants
@@ -39,7 +40,51 @@ class KakaoOAuthClient(
                 birthyear = kakaoAccount?.birthyear,
                 birthday = kakaoAccount?.birthday,
             ),
+            name = kakaoAccount?.name,
+            phoneNumber = formatPhoneNumber(kakaoAccount?.phoneNumber),
+            gender = parseGender(kakaoAccount?.gender),
         )
+    }
+
+    /**
+     * 카카오 전화번호("+82 10-1234-5678" 등)를 국내 표준 "010-XXXX-XXXX" 포맷으로 변환한다.
+     * - 숫자만 추출 → 국가코드(82) 제거 → 선두 0 보정 → 11자리면 하이픈 포맷
+     * - 미동의/비정상 포맷이면 로그인 자체는 성공해야 하므로 예외 없이 null + 경고 로그
+     */
+    private fun formatPhoneNumber(phoneNumber: String?): String? {
+        if (phoneNumber.isNullOrBlank()) return null
+
+        var digits = phoneNumber.filter { it.isDigit() }
+        if (digits.startsWith(KOREA_COUNTRY_CODE)) {
+            digits = digits.removePrefix(KOREA_COUNTRY_CODE)
+        }
+        if (!digits.startsWith("0")) {
+            digits = "0$digits"
+        }
+
+        if (digits.length != PHONE_NUMBER_LENGTH) {
+            log.warn { "카카오 전화번호 포맷 비정상(11자리 아님): $phoneNumber" }
+            return null
+        }
+
+        return "${digits.substring(0, 3)}-${digits.substring(3, 7)}-${digits.substring(7)}"
+    }
+
+    /**
+     * 카카오 성별("male"/"female")을 Gender enum으로 변환한다.
+     * - 미동의/알 수 없는 값이면 예외 없이 null + 경고 로그
+     */
+    private fun parseGender(gender: String?): Gender? {
+        if (gender.isNullOrBlank()) return null
+
+        return when (gender.lowercase()) {
+            KAKAO_GENDER_MALE -> Gender.MALE
+            KAKAO_GENDER_FEMALE -> Gender.FEMALE
+            else -> {
+                log.warn { "카카오 성별 값 알 수 없음: $gender" }
+                null
+            }
+        }
     }
 
     /**
@@ -90,8 +135,13 @@ class KakaoOAuthClient(
         private const val AUTHORIZATION_URI = "https://kauth.kakao.com/oauth/authorize"
         private const val BIRTHDAY_LENGTH = 4 // MMDD
 
+        private const val KOREA_COUNTRY_CODE = "82"
+        private const val PHONE_NUMBER_LENGTH = 11 // 01012345678
+        private const val KAKAO_GENDER_MALE = "male"
+        private const val KAKAO_GENDER_FEMALE = "female"
+
         // 카카오는 콤마로 구분된 scope 목록을 허용한다.
         private const val SCOPE_DELIMITER = ","
-        private val SCOPES = listOf("account_email", "birthyear", "birthday")
+        private val SCOPES = listOf("account_email", "birthyear", "birthday", "name", "phone_number", "gender")
     }
 }

--- a/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthFakeClient.kt
+++ b/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthFakeClient.kt
@@ -1,5 +1,6 @@
 package com.ditto.infrastructure.oauth.kakao
 
+import com.ditto.domain.member.entity.Gender
 import com.ditto.infrastructure.oauth.OAuthClient
 import com.ditto.infrastructure.oauth.OAuthUserInfo
 import com.ditto.infrastructure.oauth.constants.OAuthConstants
@@ -30,6 +31,9 @@ class KakaoOAuthFakeClient(
             nickname = "테스트유저",
             email = "test@example.com",
             birthDate = LocalDate.of(1995, 3, 15),
+            name = "테스트",
+            phoneNumber = "010-1234-5678",
+            gender = Gender.MALE,
         )
     }
 }

--- a/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/kakao/dto/KakaoUserResponse.kt
+++ b/infrastructure/src/main/kotlin/com/ditto/infrastructure/oauth/kakao/dto/KakaoUserResponse.kt
@@ -14,6 +14,9 @@ data class KakaoUserResponse(
         val email: String?,
         val birthyear: String?,
         val birthday: String?,
+        val name: String?,
+        val phoneNumber: String?,
+        val gender: String?,
     )
 
     @JsonNaming(PropertyNamingStrategies.SnakeCaseStrategy::class)

--- a/infrastructure/src/test/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthClientTest.kt
+++ b/infrastructure/src/test/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthClientTest.kt
@@ -1,5 +1,6 @@
 package com.ditto.infrastructure.oauth.kakao
 
+import com.ditto.domain.member.entity.Gender
 import com.ditto.infrastructure.oauth.constants.OAuthConstants
 import com.ditto.infrastructure.oauth.kakao.dto.KakaoTokenResponse
 import com.ditto.infrastructure.oauth.kakao.dto.KakaoUserResponse
@@ -31,10 +32,10 @@ class KakaoOAuthClientTest : FreeSpec(
                 url shouldContain "${OAuthConstants.PARAM_RESPONSE_TYPE}=${OAuthConstants.RESPONSE_TYPE_CODE}"
             }
 
-            "scope에 account_email·birthyear·birthday를 포함한다" {
+            "scope에 account_email·birthyear·birthday·name·phone_number·gender를 포함한다" {
                 val url = client.getAuthorizationUrl()
 
-                url shouldContain "${OAuthConstants.PARAM_SCOPE}=account_email,birthyear,birthday"
+                url shouldContain "${OAuthConstants.PARAM_SCOPE}=account_email,birthyear,birthday,name,phone_number,gender"
             }
         }
 
@@ -95,11 +96,17 @@ class KakaoOAuthClientTest : FreeSpec(
                 email: String? = "user@kakao.com",
                 birthyear: String? = null,
                 birthday: String? = null,
+                name: String? = null,
+                phoneNumber: String? = null,
+                gender: String? = null,
             ) = KakaoUserResponse.KakaoAccount(
                 profile = KakaoUserResponse.KakaoProfile(nickname = nickname),
                 email = email,
                 birthyear = birthyear,
                 birthday = birthday,
+                name = name,
+                phoneNumber = phoneNumber,
+                gender = gender,
             )
 
             "닉네임과 이메일이 있으면 해당 값을 반환한다" {
@@ -134,6 +141,9 @@ class KakaoOAuthClientTest : FreeSpec(
                         email = "user@kakao.com",
                         birthyear = null,
                         birthday = null,
+                        name = null,
+                        phoneNumber = null,
+                        gender = null,
                     ),
                 )
 
@@ -228,6 +238,116 @@ class KakaoOAuthClientTest : FreeSpec(
                 val userInfo = client.getUserInfo("test-token")
 
                 userInfo.birthDate shouldBe null
+            }
+
+            "이름이 있으면 해당 값을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(name = "홍길동"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.name shouldBe "홍길동"
+            }
+
+            "이름이 없으면 null을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(name = null),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.name shouldBe null
+            }
+
+            "전화번호 +82 국가코드를 010-XXXX-XXXX 포맷으로 변환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(phoneNumber = "+82 10-1234-5678"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.phoneNumber shouldBe "010-1234-5678"
+            }
+
+            "전화번호 +82 010 형식도 010-XXXX-XXXX로 변환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(phoneNumber = "+82 010-1234-5678"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.phoneNumber shouldBe "010-1234-5678"
+            }
+
+            "전화번호가 없으면 null을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(phoneNumber = null),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.phoneNumber shouldBe null
+            }
+
+            "전화번호 자릿수가 비정상이면 예외 없이 null을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(phoneNumber = "+82 10-123"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.phoneNumber shouldBe null
+            }
+
+            "성별 male을 MALE로 변환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(gender = "male"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.gender shouldBe Gender.MALE
+            }
+
+            "성별 female을 FEMALE로 변환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(gender = "female"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.gender shouldBe Gender.FEMALE
+            }
+
+            "성별이 없으면 null을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(gender = null),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.gender shouldBe null
+            }
+
+            "성별 값을 알 수 없으면 예외 없이 null을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(gender = "unknown"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.gender shouldBe null
             }
         }
     },

--- a/infrastructure/src/test/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthClientTest.kt
+++ b/infrastructure/src/test/kotlin/com/ditto/infrastructure/oauth/kakao/KakaoOAuthClientTest.kt
@@ -284,10 +284,32 @@ class KakaoOAuthClientTest : FreeSpec(
                 userInfo.phoneNumber shouldBe "010-1234-5678"
             }
 
+            "전화번호가 국가코드 없는 국내 포맷이면 그대로 010-XXXX-XXXX로 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(phoneNumber = "010-9876-5432"),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.phoneNumber shouldBe "010-9876-5432"
+            }
+
             "전화번호가 없으면 null을 반환한다" {
                 every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
                     id = 12345L,
                     kakaoAccount = kakaoAccount(phoneNumber = null),
+                )
+
+                val userInfo = client.getUserInfo("test-token")
+
+                userInfo.phoneNumber shouldBe null
+            }
+
+            "전화번호가 빈 문자열이면 null을 반환한다" {
+                every { apiSender.getUserInfo("Bearer test-token") } returns KakaoUserResponse(
+                    id = 12345L,
+                    kakaoAccount = kakaoAccount(phoneNumber = "  "),
                 )
 
                 val userInfo = client.getUserInfo("test-token")


### PR DESCRIPTION
## 개요
카카오 로그인 시 기존 닉네임/이메일/생년월일에 더해 **이름·전화번호·성별**을 수집해 회원 정보에 저장한다.

Closes #73

## 변경 사항
### infrastructure (카카오 수집·변환)
- `KakaoUserResponse.KakaoAccount`에 `name` / `phone_number` / `gender` 필드 추가
- `OAuthUserInfo`에 `name` / `phoneNumber` / `gender(Gender)` 필드 추가
- `KakaoOAuthClient`
  - scope에 `name`, `phone_number`, `gender` 추가
  - **전화번호 변환**: `+82 10-1234-5678` → `010-1234-5678` (숫자추출 → 국가코드 제거 → 선두 0 보정 → 하이픈 포맷)
  - **성별 변환**: `male`→`MALE`, `female`→`FEMALE`
  - 비정상 포맷/예외 상황은 예외 없이 `null` + warn 로그 (로그인 자체는 성공) — 기존 `parseBirthDate` 정책과 동일
- `KakaoOAuthFakeClient` 더미값 보강

### api / domain (영속화)
- `Member.updateOAuthInfo()` 추가 (제공된 non-null 값만 갱신)
- `MemberSocialAccountService.findOrCreateMember` — 신규 회원 저장 + 기존 회원 재로그인 시 갱신
- `OAuthFacade.login` — 수집한 값을 등록 흐름으로 전달

## 포맷 규칙
- 전화번호: DB에 `010-xxxx-xxxx` 형식으로 저장 (`CreateUserRequest` 검증 정규식과 일치)
- 성별: `Gender` enum(`MALE`/`FEMALE`)으로 저장

## 테스트
- `KakaoOAuthClientTest`: scope·이름·전화번호(국가코드/국내포맷/비정상/빈값)·성별(male/female/unknown/null) 케이스
- `MemberSocialAccountServiceTest`: 신규 저장·기존 갱신·null 유지 케이스
- `MemberTest`: `updateOAuthInfo` 단위 케이스
- `OAuthFacadeTest`: OAuth 로그인 시 개인정보 영속화 검증
- `./gradlew build check` 통과 (커버리지 충족)

## 참고
- `name`·`phone_number`·`gender`는 카카오 개발자 콘솔에 **필수 동의항목으로 이미 설정** 완료 → 로그인 시 값이 항상 내려온다.
- 다만 전화번호 미인증 계정 등 예외 케이스 대비해 `null` 허용 + warn 로그는 안전망으로 유지한다.
