### PR TITLE
feat. users/me 응답에 카카오 수집 정보(이름·전화번호·성별) 추가

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/user/dto/MeResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/MeResponse.kt
@@ -5,11 +5,16 @@ import java.time.LocalDate
 
 data class MeResponse(
     val email: String?,
-    // 생년월일은 날짜 개념이므로 시각 없이 LocalDate(yyyy-MM-dd)로 노출한다.
     val birthDate: LocalDate?,
+    val name: String?,
+    val phoneNumber: String?,
+    val gender: String?,
 )
 
 fun Member.toMeResponse() = MeResponse(
     email = email,
     birthDate = birthDate?.toLocalDate(),
+    name = name,
+    phoneNumber = phoneNumber,
+    gender = gender?.name,
 )

--- a/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
@@ -104,13 +104,16 @@ class UserControllerTest : RestDocsTest() {
     }
 
     @Test
-    @DisplayName("가입 정보(email·생년월일)를 조회한다 - PENDING 회원도 접근 가능")
+    @DisplayName("가입 정보(카카오 수집 정보)를 조회한다 - PENDING 회원도 접근 가능")
     fun getMe() {
         val member = memberRepository.save(
             Member(
                 nickname = "가입정보유저",
                 email = "user@kakao.com",
                 birthDate = LocalDateTime.of(1995, 3, 15, 0, 0),
+                name = "홍길동",
+                phoneNumber = "010-1234-5678",
+                gender = Gender.MALE,
             ),
         )
 
@@ -123,6 +126,9 @@ class UserControllerTest : RestDocsTest() {
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.email").value("user@kakao.com"))
             .andExpect(jsonPath("$.data.birthDate").value("1995-03-15"))
+            .andExpect(jsonPath("$.data.name").value("홍길동"))
+            .andExpect(jsonPath("$.data.phoneNumber").value("010-1234-5678"))
+            .andExpect(jsonPath("$.data.gender").value("MALE"))
             .andDo(
                 document(
                     "user-me",
@@ -133,13 +139,16 @@ class UserControllerTest : RestDocsTest() {
                             .tag("Users")
                             .summary("가입 정보 조회")
                             .description(
-                                "소셜 로그인에서 받아온 가입 정보(이메일·생년월일)를 조회합니다. " +
+                                "소셜 로그인에서 받아온 가입 정보(이메일·생년월일·이름·전화번호·성별)를 조회합니다. " +
                                     "온보딩 화면 prefill 용도이며, 가입 미완료(PENDING) 회원도 접근할 수 있습니다.",
                             )
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),
                                 fieldWithPath("data.email").description("이메일 (없으면 null)"),
                                 fieldWithPath("data.birthDate").description("생년월일 (없거나 음력이면 null)"),
+                                fieldWithPath("data.name").description("이름 (미동의 시 null)"),
+                                fieldWithPath("data.phoneNumber").description("전화번호 010-XXXX-XXXX (미동의 시 null)"),
+                                fieldWithPath("data.gender").description("성별 MALE/FEMALE (미동의 시 null)"),
                                 fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),

--- a/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
@@ -137,12 +137,15 @@ class UserServiceTest(
         }
 
         "가입 정보 조회" - {
-            "회원의 email과 생년월일을 반환한다" {
+            "회원의 카카오 수집 정보를 반환한다" {
                 val member = memberRepository.save(
                     Member(
                         nickname = "조회유저",
                         email = "user@kakao.com",
                         birthDate = LocalDateTime.of(1995, 3, 15, 0, 0),
+                        name = "홍길동",
+                        phoneNumber = "010-1234-5678",
+                        gender = Gender.MALE,
                     ),
                 )
 
@@ -150,15 +153,21 @@ class UserServiceTest(
 
                 result.email shouldBe "user@kakao.com"
                 result.birthDate shouldBe LocalDate.of(1995, 3, 15)
+                result.name shouldBe "홍길동"
+                result.phoneNumber shouldBe "010-1234-5678"
+                result.gender shouldBe "MALE"
             }
 
-            "email과 생년월일이 없으면 null을 반환한다" {
+            "카카오 수집 정보가 없으면 null을 반환한다" {
                 val member = memberRepository.save(Member(nickname = "정보없는유저"))
 
                 val result = userService.getMe(member.id)
 
                 result.email shouldBe null
                 result.birthDate shouldBe null
+                result.name shouldBe null
+                result.phoneNumber shouldBe null
+                result.gender shouldBe null
             }
 
             "존재하지 않는 회원이면 예외가 발생한다" {


### PR DESCRIPTION
## 개요
`GET /api/v1/users/me`(가입 정보 조회)가 카카오에서 수집해 저장한 정보를 **전부** 반환하도록 확장합니다.

## 배경
`#74`에서 카카오 로그인 시 `name`·`phoneNumber`·`gender`를 추가로 수집·저장하게 되었으나, `/users/me` 응답에는 여전히 `email`·`birthDate`만 노출되고 있었습니다.

## 변경 사항
- `MeResponse`에 `name`, `phoneNumber`, `gender` 추가
  - `gender`는 `RegisterResponse`와 동일하게 enum name(`MALE`/`FEMALE`) String으로 노출
- `UserServiceTest` / `UserControllerTest` 단언 및 REST Docs 응답 필드 보강
- `openapi.yaml` 자동 갱신

## 응답 예시
```json
{
  "success": true,
  "data": {
    "email": "user@kakao.com",
    "birthDate": "1995-03-15",
    "name": "홍길동",
    "phoneNumber": "010-1234-5678",
    "gender": "MALE"
  },
  "error": null
}
```
각 필드는 카카오 미동의 시 `null`.

## 테스트
- `UserServiceTest`, `UserControllerTest` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)