### PR TITLE
feat. 타인 공개 프로필 조회 API (GET /users/{id}/profile)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/intronote/service/IntroNoteService.kt
+++ b/api/src/main/kotlin/com/ditto/api/intronote/service/IntroNoteService.kt
@@ -2,22 +2,19 @@ package com.ditto.api.intronote.service
 
 import com.ditto.api.intronote.dto.IntroNoteResponse
 import com.ditto.api.intronote.dto.IntroNotesResponse
+import com.ditto.api.match.MatchAccessChecker
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
 import com.ditto.domain.intronote.entity.IntroNote
 import com.ditto.domain.intronote.entity.IntroQuestion
 import com.ditto.domain.intronote.repository.IntroNoteRepository
-import com.ditto.domain.match.entity.PersonalMatchStatus
-import com.ditto.domain.match.repository.GroupMatchMemberRepository
-import com.ditto.domain.match.repository.PersonalMatchRepository
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 
 @Service
 class IntroNoteService(
     private val introNoteRepository: IntroNoteRepository,
-    private val personalMatchRepository: PersonalMatchRepository,
-    private val groupMatchMemberRepository: GroupMatchMemberRepository,
+    private val matchAccessChecker: MatchAccessChecker,
 ) {
 
     /** 질문 하나의 답변을 저장/수정(upsert)하고 전체 소개노트를 반환한다. */
@@ -40,20 +37,10 @@ class IntroNoteService(
     /** 타인 소개노트 조회. 매칭 성사 또는 같은 그룹 채팅 참여자만 가능. */
     @Transactional(readOnly = true)
     fun getIntroNotes(viewerId: Long, targetId: Long): IntroNotesResponse {
-        if (viewerId != targetId && !canView(viewerId, targetId)) {
+        if (viewerId != targetId && !matchAccessChecker.isMatched(viewerId, targetId)) {
             throw WarnException(ErrorCode.FORBIDDEN)
         }
         return buildResponse(targetId)
-    }
-
-    private fun canView(viewerId: Long, targetId: Long): Boolean {
-        val matched = personalMatchRepository.existsByMemberId1AndMemberId2AndStatus(
-            minOf(viewerId, targetId),
-            maxOf(viewerId, targetId),
-            PersonalMatchStatus.ACCEPTED,
-        )
-        if (matched) return true
-        return groupMatchMemberRepository.existsSharedRoom(viewerId, targetId)
     }
 
     private fun buildResponse(memberId: Long): IntroNotesResponse {

--- a/api/src/main/kotlin/com/ditto/api/match/MatchAccessChecker.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/MatchAccessChecker.kt
@@ -1,0 +1,29 @@
+package com.ditto.api.match
+
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.GroupMatchMemberRepository
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import org.springframework.stereotype.Component
+
+/**
+ * 두 회원 간 "매칭 관계" 여부를 판단한다.
+ * - 개인 매칭 성사(ACCEPTED) 또는
+ * - 같은 그룹 채팅방 참여
+ *
+ * 타인 소개노트·프로필 조회 권한 등에서 공통으로 사용한다.
+ */
+@Component
+class MatchAccessChecker(
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val groupMatchMemberRepository: GroupMatchMemberRepository,
+) {
+    fun isMatched(memberId: Long, otherMemberId: Long): Boolean {
+        val matched = personalMatchRepository.existsByMemberId1AndMemberId2AndStatus(
+            minOf(memberId, otherMemberId),
+            maxOf(memberId, otherMemberId),
+            PersonalMatchStatus.ACCEPTED,
+        )
+        if (matched) return true
+        return groupMatchMemberRepository.existsSharedRoom(memberId, otherMemberId)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
@@ -5,6 +5,7 @@ import com.ditto.api.user.dto.CheckNicknameResponse
 import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.api.user.dto.LeaveResponse
 import com.ditto.api.user.dto.MeResponse
+import com.ditto.api.user.dto.PublicProfileResponse
 import com.ditto.api.user.dto.RegisterResponse
 import com.ditto.api.user.service.UserService
 import com.ditto.common.response.ApiResponse
@@ -33,6 +34,15 @@ class UserController(
     @GetMapping("/api/v1/users/me")
     fun getMe(@AuthenticationPrincipal principal: MemberPrincipal): ApiResponse<MeResponse> {
         val result = userService.getMe(principal.memberId)
+        return ApiResponse.ok(result)
+    }
+
+    @GetMapping("/api/v1/users/{id}/profile")
+    fun getPublicProfile(
+        @PathVariable id: Long,
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<PublicProfileResponse> {
+        val result = userService.getPublicProfile(principal.memberId, id)
         return ApiResponse.ok(result)
     }
 

--- a/api/src/main/kotlin/com/ditto/api/user/dto/PublicProfileResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/PublicProfileResponse.kt
@@ -1,0 +1,22 @@
+package com.ditto.api.user.dto
+
+/**
+ * 타인 공개 프로필 응답. 민감정보(email·phoneNumber·실명)는 포함하지 않는다.
+ * location·occupation·interests는 FE와 공유하는 code로 반환한다.
+ */
+data class PublicProfileResponse(
+    val userId: Long,
+    val nickname: String,
+    val gender: String?,
+    val age: Int?,
+    // 자기소개는 소개노트 ONE_WORD 답변으로 채운다. 없으면 null.
+    val introduction: String?,
+    val profileImageUrl: String?,
+    val location: String?,
+    val occupation: String?,
+    val interests: List<String>,
+    // 아래 3개는 아직 데이터 소스가 없어 null. (rating: 평가 도메인 별도 / preferred: FE 미사용)
+    val rating: Double? = null,
+    val preferredMinAge: Int? = null,
+    val preferredMaxAge: Int? = null,
+)

--- a/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
@@ -1,9 +1,11 @@
 package com.ditto.api.user.service
 
+import com.ditto.api.match.MatchAccessChecker
 import com.ditto.api.user.dto.CheckNicknameResponse
 import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.api.user.dto.LeaveResponse
 import com.ditto.api.user.dto.MeResponse
+import com.ditto.api.user.dto.PublicProfileResponse
 import com.ditto.api.user.dto.RegisterResponse
 import com.ditto.api.user.dto.toLeaveResponse
 import com.ditto.api.user.dto.toMeResponse
@@ -11,6 +13,8 @@ import com.ditto.api.user.dto.toRegisterResponse
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
 import com.ditto.common.exception.WarnException
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.intronote.repository.IntroNoteRepository
 import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
 import com.ditto.domain.member.entity.Location
@@ -23,6 +27,8 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserService(
     private val memberRepository: MemberRepository,
+    private val introNoteRepository: IntroNoteRepository,
+    private val matchAccessChecker: MatchAccessChecker,
     private val socialAccountRepository: SocialAccountRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
 ) {
@@ -66,6 +72,38 @@ class UserService(
             WarnException(ErrorCode.NOT_FOUND)
         }
         return member.toMeResponse()
+    }
+
+    /**
+     * 타인 공개 프로필 조회. 매칭이 성사된 상대(또는 같은 그룹채팅 참여자)만 조회 가능.
+     * 민감정보(email·전화번호·실명)는 반환하지 않는다.
+     */
+    @Transactional(readOnly = true)
+    fun getPublicProfile(viewerId: Long, targetId: Long): PublicProfileResponse {
+        if (viewerId != targetId && !matchAccessChecker.isMatched(viewerId, targetId)) {
+            throw WarnException(ErrorCode.FORBIDDEN)
+        }
+
+        val member = memberRepository.findById(targetId).orElseThrow {
+            WarnException(ErrorCode.NOT_FOUND)
+        }
+
+        // 자기소개는 소개노트 ONE_WORD 답변으로 채운다. 미작성/공백이면 null.
+        val introduction = introNoteRepository.findByMemberIdAndQuestion(targetId, IntroQuestion.ONE_WORD)
+            ?.answer
+            ?.ifBlank { null }
+
+        return PublicProfileResponse(
+            userId = member.id,
+            nickname = member.nickname,
+            gender = member.gender?.name,
+            age = member.age,
+            introduction = introduction,
+            profileImageUrl = member.caricature,
+            location = member.location?.code,
+            occupation = member.job?.code,
+            interests = member.interests.map { it.code },
+        )
     }
 
     @Transactional(readOnly = true)

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -71,10 +71,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-06-05 23:26:54",
+                        "joinedAt" : "2026-06-06 00:09:02",
                         "role" : null,
-                        "createdAt" : "2026-06-05 23:26:54",
-                        "updatedAt" : "2026-06-05 23:26:54"
+                        "createdAt" : "2026-06-06 00:09:02",
+                        "updatedAt" : "2026-06-06 00:09:02"
                       },
                       "error" : null
                     }
@@ -286,8 +286,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-06-04 23:26:54",
-                          "endDate" : "2026-06-06 23:26:54",
+                          "startDate" : "2026-06-05 00:09:02",
+                          "endDate" : "2026-06-07 00:09:02",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -304,8 +304,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-06-05 23:26:54",
-                            "updatedAt" : "2026-06-05 23:26:54"
+                            "createdAt" : "2026-06-06 00:09:02",
+                            "updatedAt" : "2026-06-06 00:09:02"
                           } ]
                         } ]
                       },
@@ -351,8 +351,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-06-05 23:26:54",
-                        "updatedAt" : "2026-06-05 23:26:54"
+                        "createdAt" : "2026-06-06 00:09:02",
+                        "updatedAt" : "2026-06-06 00:09:02"
                       },
                       "error" : null
                     }
@@ -397,7 +397,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/api-v1-matches-group-decline-1969670024"
+              $ref: "#/components/schemas/api-v1-matches-group-join-1969670024"
             examples:
               group-match-decline:
                 value: |-
@@ -435,7 +435,7 @@ paths:
         content:
           application/json:
             schema:
-              $ref: "#/components/schemas/api-v1-matches-group-decline-1969670024"
+              $ref: "#/components/schemas/api-v1-matches-group-join-1969670024"
             examples:
               group-match-join:
                 value: |-
@@ -617,7 +617,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwNjY5NjExLCJleHAiOjE3ODA2NzMyMTF9.eOoaoQYYSqsSSXumWTQiKg-4j48UiD6NrxjMbnV52mt8yBVBuCW-UB05CxWqGFBeW4TzrRdXWuofCIOWPLbAdw"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwNjcyMTM4LCJleHAiOjE3ODA2NzU3Mzh9.BNtQR0i7PBOim8yw9sIybeohDsPuN7cv_xYGBD4wKEUygl7gZ0KHyD7Iif_DWsjMMh83p_h5VoX9AmKRGDS3Ag"
                       },
                       "error" : null
                     }
@@ -816,8 +816,53 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-06-05 23:26:54",
-                        "updatedAt" : "2026-06-05 23:26:54"
+                        "createdAt" : "2026-06-06 00:09:02",
+                        "updatedAt" : "2026-06-06 00:09:02"
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/users/{id}/profile:
+    get:
+      tags:
+      - Users
+      summary: 타인 공개 프로필 조회
+      description: 매칭이 성사된 상대(또는 같은 그룹채팅 참여자)의 공개 프로필을 조회합니다. 권한이 없으면 403. 민감정보(이메일·전화번호·실명)는
+        포함하지 않습니다.
+      operationId: user-public-profile
+      parameters:
+      - name: id
+        in: path
+        description: 대상 사용자 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-id-profile-829103765"
+              examples:
+                user-public-profile:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "userId" : 2,
+                        "nickname" : "디토러버",
+                        "gender" : "FEMALE",
+                        "age" : 27,
+                        "introduction" : "안녕하세요, 만나서 반가워요!",
+                        "profileImageUrl" : "/assets/avatar/f3.png",
+                        "location" : "seoul",
+                        "occupation" : "design",
+                        "interests" : [ "music", "travel", "workout" ],
+                        "rating" : null,
+                        "preferredMinAge" : null,
+                        "preferredMaxAge" : null
                       },
                       "error" : null
                     }
@@ -1057,7 +1102,225 @@ paths:
           description: "302"
 components:
   schemas:
-    api-v1-matches-group-decline-1969670024:
+    api-v1-matches-request-1327932902:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 생성된 매칭 ID
+            status:
+              type: string
+              description: 매칭 상태 (PENDING)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-quiz-sets-id-1569645469:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - totalCount
+          type: object
+          properties:
+            quizzes:
+              type: array
+              items:
+                required:
+                - createdAt
+                - id
+                - order
+                - question
+                - quizSetId
+                - updatedAt
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 생성일시
+                  userAnswer:
+                    type: number
+                    description: 사용자가 선택한 choiceId (미답변 시 null)
+                    nullable: true
+                  question:
+                    type: string
+                    description: 퀴즈 질문
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 퀴즈 ID
+                  choices:
+                    type: array
+                    items:
+                      required:
+                      - content
+                      - id
+                      - order
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                          description: 선택지 ID
+                        content:
+                          type: string
+                          description: 선택지 내용
+                        order:
+                          type: number
+                          description: 선택지 순서
+                  updatedAt:
+                    type: string
+                    description: 수정일시
+                  order:
+                    type: number
+                    description: 퀴즈 순서
+            totalCount:
+              type: number
+              description: 전체 퀴즈 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-logout-1831456372:
+      required:
+      - data
+      - error
+      - success
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-id-accept-2011455419:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 매칭 ID
+            status:
+              type: string
+              description: 변경된 매칭 상태 (ACCEPTED)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-social-login-provider-callback-272682272:
+      required:
+      - data
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: object
+          description: 빈 객체 (신규 사용자)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-2041696623:
+      required:
+      - caricature
+      - interests
+      - job
+      - location
+      type: object
+      properties:
+        caricature:
+          type: string
+          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
+        phoneNumber:
+          type: string
+          description: 전화번호 (010-0000-0000)
+          nullable: true
+        gender:
+          type: string
+          description: "성별 (MALE, FEMALE)"
+          nullable: true
+        nickname:
+          type: string
+          description: "닉네임 (2~10자, 한글·영문·숫자)"
+          nullable: true
+        name:
+          type: string
+          description: 이름
+          nullable: true
+        location:
+          type: string
+          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
+            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
+            \ jeonnam, gyeongbuk, gyeongnam, jeju"
+        job:
+          type: string
+          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
+            \ education, medical, finance, legal, manufacturing, distribution, service,\
+            \ construction, arts-media, research, public-admin, student, etc"
+        interests:
+          type: array
+          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
+            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
+            \ pets, etc"
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        age:
+          type: number
+          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
+          nullable: true
+    api-v1-matches-group-join-1969670024:
       required:
       - quizSetId
       type: object
@@ -1140,60 +1403,6 @@ components:
             roomId:
               type: number
               description: 배정된 그룹 방 ID
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-matches-request-1327932902:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - createdAt
-          - id
-          - quizSetId
-          - receiverId
-          - requesterId
-          - status
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 요청 생성일시
-            receiverId:
-              type: number
-              description: 수신자 ID
-            requesterId:
-              type: number
-              description: 요청자 ID
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            id:
-              type: number
-              description: 생성된 매칭 ID
-            status:
-              type: string
-              description: 매칭 상태 (PENDING)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-auth-refresh1774976609:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
         success:
           type: boolean
           description: 성공 여부
@@ -1320,6 +1529,23 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-matches-request-793255208:
       required:
       - quizSetId
@@ -1359,75 +1585,6 @@ components:
             email:
               type: string
               description: 이메일 (없으면 null)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-quiz-progress-quiz-sets-id-1569645469:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - totalCount
-          type: object
-          properties:
-            quizzes:
-              type: array
-              items:
-                required:
-                - createdAt
-                - id
-                - order
-                - question
-                - quizSetId
-                - updatedAt
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 생성일시
-                  userAnswer:
-                    type: number
-                    description: 사용자가 선택한 choiceId (미답변 시 null)
-                    nullable: true
-                  question:
-                    type: string
-                    description: 퀴즈 질문
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 퀴즈 ID
-                  choices:
-                    type: array
-                    items:
-                      required:
-                      - content
-                      - id
-                      - order
-                      type: object
-                      properties:
-                        id:
-                          type: number
-                          description: 선택지 ID
-                        content:
-                          type: string
-                          description: 선택지 내용
-                        order:
-                          type: number
-                          description: 선택지 순서
-                  updatedAt:
-                    type: string
-                    description: 수정일시
-                  order:
-                    type: number
-                    description: 퀴즈 순서
-            totalCount:
-              type: number
-              description: 전체 퀴즈 수
         success:
           type: boolean
           description: 성공 여부
@@ -1522,16 +1679,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-logout-1831456372:
-      required:
-      - data
-      - error
-      - success
-      type: object
-      properties:
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-users-1640911349:
       required:
       - error
@@ -1618,60 +1765,6 @@ components:
         quizId:
           type: number
           description: 퀴즈 ID
-    api-v1-matching-status-quizSetId-1585477117:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - groupMatchStatus
-          - quizSetId
-          type: object
-          properties:
-            groupMatchStatus:
-              type: string
-              description: 그룹 매칭 상태 (NONE / JOINED / DECLINED)
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            groupMatchRoomId:
-              type: number
-              description: 참여 중인 그룹 방 ID (JOINED 일 때만 존재)
-              nullable: true
-            personalMatch:
-              type: object
-              properties:
-                createdAt:
-                  type: string
-                  description: 요청 생성일시
-                  nullable: true
-                receiverId:
-                  type: number
-                  description: 수신자 ID
-                  nullable: true
-                requesterId:
-                  type: number
-                  description: 요청자 ID
-                  nullable: true
-                respondedAt:
-                  type: string
-                  description: 응답 일시 (없으면 null)
-                  nullable: true
-                id:
-                  type: number
-                  description: 매칭 ID
-                  nullable: true
-                status:
-                  type: string
-                  description: 매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED /
-                    EXPIRED)
-                  nullable: true
-              description: 1:1 매칭 정보 (없으면 null)
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-quiz-sets-id1440540832:
       required:
       - error
@@ -1731,6 +1824,97 @@ components:
             startDate:
               type: string
               description: 시작일시
+            updatedAt:
+              type: string
+              description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matching-status-quizSetId-1585477117:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - groupMatchStatus
+          - quizSetId
+          type: object
+          properties:
+            groupMatchStatus:
+              type: string
+              description: 그룹 매칭 상태 (NONE / JOINED / DECLINED)
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            groupMatchRoomId:
+              type: number
+              description: 참여 중인 그룹 방 ID (JOINED 일 때만 존재)
+              nullable: true
+            personalMatch:
+              type: object
+              properties:
+                createdAt:
+                  type: string
+                  description: 요청 생성일시
+                  nullable: true
+                receiverId:
+                  type: number
+                  description: 수신자 ID
+                  nullable: true
+                requesterId:
+                  type: number
+                  description: 요청자 ID
+                  nullable: true
+                respondedAt:
+                  type: string
+                  description: 응답 일시 (없으면 null)
+                  nullable: true
+                id:
+                  type: number
+                  description: 매칭 ID
+                  nullable: true
+                status:
+                  type: string
+                  description: 매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED /
+                    EXPIRED)
+                  nullable: true
+              description: 1:1 매칭 정보 (없으면 null)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-id-leave-1444522536:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - age
+          - birthDate
+          - createdAt
+          - email
+          - gender
+          - id
+          - joinedAt
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 생성일시
+            nickname:
+              type: string
+              description: 닉네임
+            id:
+              type: number
+              description: 사용자 ID
             updatedAt:
               type: string
               description: 수정일시
@@ -1814,7 +1998,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-id-leave-1444522536:
+    api-v1-users-id-profile-829103765:
       required:
       - error
       - success
@@ -1822,137 +2006,60 @@ components:
       properties:
         data:
           required:
-          - age
-          - birthDate
-          - createdAt
-          - email
-          - gender
-          - id
-          - joinedAt
-          - name
           - nickname
-          - phoneNumber
-          - role
-          - updatedAt
+          - userId
           type: object
           properties:
-            createdAt:
+            occupation:
               type: string
-              description: 생성일시
+              description: "직업 code. 가능한 값: it-tech, management, marketing, design,\
+                \ education, medical, finance, legal, manufacturing, distribution,\
+                \ service, construction, arts-media, research, public-admin, student,\
+                \ etc"
+              nullable: true
+            gender:
+              type: string
+              description: "성별 (MALE, FEMALE)"
+              nullable: true
             nickname:
               type: string
               description: 닉네임
-            id:
-              type: number
-              description: 사용자 ID
-            updatedAt:
+            location:
               type: string
-              description: 수정일시
+              description: "지역 code. 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
+                \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
+                \ jeonnam, gyeongbuk, gyeongnam, jeju"
+              nullable: true
+            interests:
+              type: array
+              description: "관심사 code 목록. 가능한 값: workout, movie-drama, performance,\
+                \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
+                \ pets, etc"
+              nullable: true
+              items:
+                oneOf:
+                - type: object
+                - type: boolean
+                - type: string
+                - type: number
+            profileImageUrl:
+              type: string
+              description: 프로필 이미지 경로
+              nullable: true
+            userId:
+              type: number
+              description: 대상 사용자 ID
+            introduction:
+              type: string
+              description: "자기소개 (소개노트 one-word 답변, 없으면 null)"
+              nullable: true
+            age:
+              type: number
+              description: 나이
+              nullable: true
         success:
           type: boolean
           description: 성공 여부
-    api-v1-matches-request-id-accept-2011455419:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - createdAt
-          - id
-          - quizSetId
-          - receiverId
-          - requesterId
-          - status
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 요청 생성일시
-            receiverId:
-              type: number
-              description: 수신자 ID
-            requesterId:
-              type: number
-              description: 요청자 ID
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            id:
-              type: number
-              description: 매칭 ID
-            status:
-              type: string
-              description: 변경된 매칭 상태 (ACCEPTED)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-social-login-provider-callback-272682272:
-      required:
-      - data
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          type: object
-          description: 빈 객체 (신규 사용자)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-2041696623:
-      required:
-      - caricature
-      - interests
-      - job
-      - location
-      type: object
-      properties:
-        caricature:
-          type: string
-          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
-        phoneNumber:
-          type: string
-          description: 전화번호 (010-0000-0000)
-          nullable: true
-        gender:
-          type: string
-          description: "성별 (MALE, FEMALE)"
-          nullable: true
-        nickname:
-          type: string
-          description: "닉네임 (2~10자, 한글·영문·숫자)"
-          nullable: true
-        name:
-          type: string
-          description: 이름
-          nullable: true
-        location:
-          type: string
-          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
-            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
-            \ jeonnam, gyeongbuk, gyeongnam, jeju"
-        job:
-          type: string
-          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
-            \ education, medical, finance, legal, manufacturing, distribution, service,\
-            \ construction, arts-media, research, public-admin, student, etc"
-        interests:
-          type: array
-          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
-            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
-            \ pets, etc"
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        age:
-          type: number
-          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
-          nullable: true
   securitySchemes:
     ApiKey:
       type: apiKey

--- a/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
@@ -5,6 +5,12 @@ import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
+import com.ditto.domain.intronote.entity.IntroNote
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.intronote.repository.IntroNoteRepository
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
 import com.ditto.domain.member.entity.Location
 import com.ditto.domain.member.entity.Member
 import com.ditto.domain.socialaccount.entity.SocialAccount
@@ -37,6 +43,12 @@ class UserControllerTest : RestDocsTest() {
 
     @Autowired
     private lateinit var socialAccountRepository: SocialAccountRepository
+
+    @Autowired
+    private lateinit var personalMatchRepository: PersonalMatchRepository
+
+    @Autowired
+    private lateinit var introNoteRepository: IntroNoteRepository
 
     @Test
     @DisplayName("회원가입에 성공한다")
@@ -161,6 +173,78 @@ class UserControllerTest : RestDocsTest() {
                                 fieldWithPath("data.name").description("이름 (미동의 시 null)"),
                                 fieldWithPath("data.phoneNumber").description("전화번호 010-XXXX-XXXX (미동의 시 null)"),
                                 fieldWithPath("data.gender").description("성별 MALE/FEMALE (미동의 시 null)"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("매칭된 상대의 공개 프로필을 조회한다")
+    fun getPublicProfile() {
+        val viewer = memberRepository.save(Member(nickname = "조회자").apply { activate() })
+        val target = memberRepository.save(
+            Member(
+                nickname = "디토러버",
+                gender = Gender.FEMALE,
+                age = 27,
+                interests = setOf(Interest.WORKOUT, Interest.TRAVEL, Interest.MUSIC),
+                location = Location.SEOUL,
+                job = Job.DESIGN,
+                caricature = "/assets/avatar/f3.png",
+            ).apply { activate() },
+        )
+        introNoteRepository.save(IntroNote.create(target.id, IntroQuestion.ONE_WORD, "안녕하세요, 만나서 반가워요!"))
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(
+                requesterId = viewer.id,
+                receiverId = target.id,
+                status = PersonalMatchStatus.ACCEPTED,
+            ),
+        )
+
+        mockMvc.perform(
+            get("/api/v1/users/{id}/profile", target.id)
+                .withApiKey()
+                .withBearerToken(viewer.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.nickname").value("디토러버"))
+            .andExpect(jsonPath("$.data.occupation").value("design"))
+            .andDo(
+                document(
+                    "user-public-profile",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Users")
+                            .summary("타인 공개 프로필 조회")
+                            .description(
+                                "매칭이 성사된 상대(또는 같은 그룹채팅 참여자)의 공개 프로필을 조회합니다. " +
+                                    "권한이 없으면 403. 민감정보(이메일·전화번호·실명)는 포함하지 않습니다.",
+                            )
+                            .pathParameters(
+                                parameterWithName("id").description("대상 사용자 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.userId").description("대상 사용자 ID"),
+                                fieldWithPath("data.nickname").description("닉네임"),
+                                fieldWithPath("data.gender").description("성별 (MALE, FEMALE)").optional(),
+                                fieldWithPath("data.age").description("나이").optional(),
+                                fieldWithPath("data.introduction")
+                                    .description("자기소개 (소개노트 one-word 답변, 없으면 null)").optional(),
+                                fieldWithPath("data.profileImageUrl").description("프로필 이미지 경로").optional(),
+                                fieldWithPath("data.location").description("지역 code. 가능한 값: $LOCATION_CODES").optional(),
+                                fieldWithPath("data.occupation").description("직업 code. 가능한 값: $JOB_CODES").optional(),
+                                fieldWithPath("data.interests[]").description("관심사 code 목록. 가능한 값: $INTEREST_CODES").optional(),
+                                fieldWithPath("data.rating").description("평점 (현재 미지원, null)").optional(),
+                                fieldWithPath("data.preferredMinAge").description("선호 최소 나이 (현재 미지원, null)").optional(),
+                                fieldWithPath("data.preferredMaxAge").description("선호 최대 나이 (현재 미지원, null)").optional(),
                                 fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),

--- a/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
@@ -7,6 +7,12 @@ import com.ditto.api.user.service.UserService
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
 import com.ditto.common.exception.WarnException
+import com.ditto.domain.intronote.entity.IntroNote
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.intronote.repository.IntroNoteRepository
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
 import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
@@ -40,6 +46,8 @@ class UserServiceTest(
     private val memberRepository: MemberRepository,
     private val socialAccountRepository: SocialAccountRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val introNoteRepository: IntroNoteRepository,
     dataSource: DataSource,
 ) : IntegrationTest(
     dataSource,
@@ -180,6 +188,106 @@ class UserServiceTest(
                     userService.getMe(99999L)
                 }
                 exception.errorCode shouldBe ErrorCode.NOT_FOUND
+            }
+        }
+
+        "타인 공개 프로필 조회" - {
+            fun saveFullMember(nickname: String) = memberRepository.save(
+                Member(
+                    nickname = nickname,
+                    name = "실명비공개",
+                    email = "secret@kakao.com",
+                    phoneNumber = "010-9999-8888",
+                    gender = Gender.FEMALE,
+                    age = 27,
+                    interests = setOf(Interest.WORKOUT, Interest.TRAVEL, Interest.MUSIC),
+                    location = Location.SEOUL,
+                    job = Job.DESIGN,
+                    caricature = "/assets/avatar/f3.png",
+                ).apply { activate() },
+            )
+
+            "매칭이 성사된 상대의 프로필을 조회한다 (introduction은 ONE_WORD 소개노트 답변)" {
+                val viewer = memberRepository.save(Member(nickname = "조회자").apply { activate() })
+                val target = saveFullMember("대상자")
+                introNoteRepository.save(IntroNote.create(target.id, IntroQuestion.ONE_WORD, "열정적인사람"))
+                personalMatchRepository.save(
+                    PersonalMatchFixture.create(
+                        requesterId = viewer.id,
+                        receiverId = target.id,
+                        status = PersonalMatchStatus.ACCEPTED,
+                    ),
+                )
+
+                val result = userService.getPublicProfile(viewer.id, target.id)
+
+                result.userId shouldBe target.id
+                result.nickname shouldBe "대상자"
+                result.gender shouldBe "FEMALE"
+                result.age shouldBe 27
+                result.introduction shouldBe "열정적인사람"
+                result.profileImageUrl shouldBe "/assets/avatar/f3.png"
+                result.location shouldBe "seoul"
+                result.occupation shouldBe "design"
+                result.interests.toSet() shouldBe setOf("workout", "travel", "music")
+                result.rating shouldBe null
+                result.preferredMinAge shouldBe null
+                result.preferredMaxAge shouldBe null
+            }
+
+            "소개노트 ONE_WORD가 없으면 introduction은 null이다" {
+                val viewer = memberRepository.save(Member(nickname = "조회자2").apply { activate() })
+                val target = saveFullMember("대상자2")
+                personalMatchRepository.save(
+                    PersonalMatchFixture.create(
+                        requesterId = viewer.id,
+                        receiverId = target.id,
+                        status = PersonalMatchStatus.ACCEPTED,
+                    ),
+                )
+
+                val result = userService.getPublicProfile(viewer.id, target.id)
+
+                result.introduction shouldBe null
+            }
+
+            "본인 프로필은 매칭 없이도 조회할 수 있다" {
+                val me = saveFullMember("본인")
+
+                val result = userService.getPublicProfile(me.id, me.id)
+
+                result.userId shouldBe me.id
+            }
+
+            "매칭이 성사되지 않은 상대면 FORBIDDEN 예외가 발생한다" {
+                val viewer = memberRepository.save(Member(nickname = "조회자3").apply { activate() })
+                val target = saveFullMember("대상자3")
+
+                val exception = shouldThrow<WarnException> {
+                    userService.getPublicProfile(viewer.id, target.id)
+                }
+                exception.errorCode shouldBe ErrorCode.FORBIDDEN
+            }
+
+            "본인 프로필 조회 시 회원이 존재하지 않으면 NOT_FOUND 예외가 발생한다" {
+                val exception = shouldThrow<WarnException> {
+                    userService.getPublicProfile(99999L, 99999L)
+                }
+                exception.errorCode shouldBe ErrorCode.NOT_FOUND
+            }
+
+            "프로필 항목이 비어있으면 null로, 공백 ONE_WORD 답변이면 introduction은 null로 반환한다" {
+                val target = memberRepository.save(Member(nickname = "빈프로필").apply { activate() })
+                introNoteRepository.save(IntroNote.create(target.id, IntroQuestion.ONE_WORD, "   "))
+
+                val result = userService.getPublicProfile(target.id, target.id)
+
+                result.introduction shouldBe null
+                result.gender shouldBe null
+                result.age shouldBe null
+                result.location shouldBe null
+                result.occupation shouldBe null
+                result.interests shouldBe emptyList()
             }
         }
 


### PR DESCRIPTION
## 개요
매칭 성사 후 상대방 프로필 화면(`/profile/{id}`)에서 호출하는 **타인 공개 프로필 조회** API. 민감정보(email·전화번호·실명)는 포함하지 않는다.

Closes #79

> ⚠️ **스택 PR**: IntroNote(#77, `feature/76`)에 의존하므로 base를 `feature/76`으로 둠. **#77 머지 후** main으로 재타깃/머지.

## 엔드포인트
`GET /api/v1/users/{id}/profile` (id: Long), 인증 필요

## 권한
- **매칭 성사(ACCEPTED) 또는 같은 그룹채팅 참여자만** 조회 가능, 아니면 **403**
- intro-notes 조회와 동일 조건 → 권한 로직을 **`MatchAccessChecker`**로 추출하고 `IntroNoteService`의 중복 `canView`를 제거(DRY)

## 응답 매핑 (PublicProfileResponse)
| 필드 | 소스 |
|------|------|
| userId | `member.id` |
| nickname / gender / age | `member.*` (gender는 MALE/FEMALE) |
| **introduction** | 소개노트 **ONE_WORD** 답변 (없거나 공백이면 null) |
| profileImageUrl | `member.caricature` |
| location / occupation / interests | `member.location/job/interests`의 **code** |
| rating | `null` (평가 도메인 별도 작업) |
| preferredMinAge / preferredMaxAge | `null` (FE 미사용) |

- **email·phoneNumber·실명(name)은 DTO에 아예 없음** (구조적으로 노출 불가)
- location/occupation/interests의 가능한 code 값은 REST Docs 설명에 enum 기반으로 노출

## 테스트
- `UserServiceTest`: 매칭 상대 조회·introduction=ONE_WORD·빈 항목 null·본인 조회·**미매칭 403**·NOT_FOUND
- `UserControllerTest`: REST Docs 문서화(코드 enum 노출)
- `./gradlew build check` 통과 (신규 코드 커버리지 충족)
