### PR TITLE
feat. 1:1 매칭 선발에 성별·나이 자격 하드 필터 추가

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/match/matching/MatchingModels.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/matching/MatchingModels.kt
@@ -1,14 +1,32 @@
 package com.ditto.api.match.matching
 
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.GenderPreference
+
 /**
- * 매칭 알고리즘 입력: 한 참여자와 그 답변.
+ * 매칭 알고리즘 입력: 한 참여자와 그 답변·성별·나이·성별선호.
+ *
+ * 성별/나이 미상(Member.gender/age == null) 회원은 성별·나이 기반 매칭이 불가하므로 후보 풀 구성 단계
+ * ([com.ditto.api.match.service.MatchmakingService])에서 제외된다. 따라서 여기서 gender·age 는 항상 존재한다.
  *
  * @property answers quizId -> choiceId (같은 quizId에 같은 choiceId 면 답변 일치)
+ * @property preferredGender 이 퀴즈에서의 매칭 성별 선호
  */
 data class MatchParticipant(
     val memberId: Long,
     val answers: Map<Long, Long>,
-)
+    val gender: Gender,
+    val age: Int,
+    val preferredGender: GenderPreference = GenderPreference.ANY,
+) {
+    /** 이 참여자가 [other]의 성별을 매칭 대상으로 받아들이는가. */
+    fun accepts(other: MatchParticipant): Boolean =
+        other.gender in preferredGender.targetGenders(gender)
+
+    /** 두 참여자가 서로의 성별 선호를 모두 충족하는가(상호 호환). 1:1 매칭 페어 성립 조건. */
+    fun isMutuallyCompatibleWith(other: MatchParticipant): Boolean =
+        accepts(other) && other.accepts(this)
+}
 
 /**
  * 매칭 점수 계산 결과. 점수와 그 근거(일치/전체 문항 수)를 함께 담는다.

--- a/api/src/main/kotlin/com/ditto/api/match/matching/OneToOneMatchingProcessor.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/matching/OneToOneMatchingProcessor.kt
@@ -1,14 +1,20 @@
 package com.ditto.api.match.matching
 
+import com.ditto.api.match.matching.OneToOneMatchingProcessor.Companion.MAX_AGE_GAP
 import com.ditto.domain.quiz.entity.MatchingType
 import org.springframework.stereotype.Component
+import kotlin.math.abs
 
 /**
  * 1:1 매칭 프로세스.
  *
- * 점수화(페어별 [MatchScoreCalculator]) → 상위 비율 + 동점 선발([TopRatioSelector])
+ * 매칭 자격(성별·나이) 페어만 점수화(페어별 [MatchScoreCalculator]) → 상위 비율 + 동점 선발([TopRatioSelector])
  * → 1인 제한([HardLimitApplier]) 순으로 실행한다. 각 단계는 순수 컴포넌트로 분리되어 독립 검증된다.
  *
+ * 후보 풀을 만드는 이 단계에서 하드 필터를 적용한다 — 자격 미달 페어는 아예 후보가 되지 않는다.
+ * - 성별: 서로의 성별 선호(이성/동성)를 모두 충족해야 함.
+ * - 나이: 나이차가 [MAX_AGE_GAP] 이내여야 함.
+ * 두 조건 모두 대칭이라 살아남는 페어는 항상 대칭이므로 [HardLimitApplier] 의 양방향 원칙도 그대로 보존된다.
  */
 @Component
 class OneToOneMatchingProcessor : MatchingProcessor {
@@ -25,7 +31,8 @@ class OneToOneMatchingProcessor : MatchingProcessor {
 
     private fun scoreAllDuos(participants: List<MatchParticipant>): List<ScoredDuo> =
         participants.flatMapIndexed { index, participant ->
-            participants.drop(index + 1).map { otherParticipant ->
+            participants.drop(index + 1).mapNotNull { otherParticipant ->
+                if (!isValidPair(participant, otherParticipant)) return@mapNotNull null
                 val matchScore = MatchScoreCalculator.calculate(participant, otherParticipant)
                 ScoredDuo.of(
                     memberA = participant.memberId,
@@ -37,8 +44,13 @@ class OneToOneMatchingProcessor : MatchingProcessor {
             }
         }
 
+    /** 매칭 자격: 성별 상호호환 + 나이차 [MAX_AGE_GAP] 이내. 둘 다 대칭이라 양방향 원칙을 깨지 않는다. */
+    private fun isValidPair(a: MatchParticipant, b: MatchParticipant): Boolean =
+        a.isMutuallyCompatibleWith(b) && abs(a.age - b.age) <= MAX_AGE_GAP
+
     companion object {
         private const val TOP_RATIO = 0.2 // 상위 20% 선발
         private const val HARD_LIMIT = 5 // 1인 최대 노출 5명
+        private const val MAX_AGE_GAP = 10 // 나이차 10 초과 페어 제외
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/match/service/MatchmakingService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/MatchmakingService.kt
@@ -8,7 +8,9 @@ import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
 import com.ditto.domain.match.entity.MatchCandidate
 import com.ditto.domain.match.repository.MatchCandidateRepository
+import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.quiz.entity.MatchingType
+import com.ditto.domain.quiz.entity.QuizProgress
 import com.ditto.domain.quiz.entity.QuizProgressStatus
 import com.ditto.domain.quiz.repository.QuizAnswerRepository
 import com.ditto.domain.quiz.repository.QuizProgressRepository
@@ -32,6 +34,7 @@ class MatchmakingService(
     private val quizProgressRepository: QuizProgressRepository,
     private val quizAnswerRepository: QuizAnswerRepository,
     private val matchCandidateRepository: MatchCandidateRepository,
+    private val memberRepository: MemberRepository,
     private val exclusionPolicies: List<MatchExclusionPolicy>,
     private val matchingProcessors: List<MatchingProcessor>,
 ) {
@@ -43,41 +46,66 @@ class MatchmakingService(
         val matchingType = quizSet.matchingType
         val processor = matchingProcessors.firstOrNull { it.matchingType == matchingType } ?: return
 
-        val availableMemberIds = findAvailableMembers(quizSetId, matchingType)
+        // 완료자 진행 기록을 한 번만 조회해 성별 선호까지 함께 활용한다.
+        val completedProgresses =
+            quizProgressRepository.findByQuizSetIdAndStatus(quizSetId, QuizProgressStatus.COMPLETED)
+        val availableMemberIds = availableMemberIds(quizSetId, matchingType, completedProgresses)
         if (availableMemberIds.size < 2) {
             matchCandidateRepository.deleteByQuizSetId(quizSetId)
             return
         }
 
-        val participants = loadParticipants(quizSetId, availableMemberIds)
+        val participants = loadParticipants(quizSetId, availableMemberIds, completedProgresses)
         val survivingDuos = processor.match(participants)
 
         matchCandidateRepository.deleteByQuizSetId(quizSetId)
         matchCandidateRepository.saveAll(toCandidates(quizSetId, survivingDuos))
     }
 
-    /** 퀴즈를 완료(COMPLETED)한 참여자 중, 해당 매칭 타입의 제외 정책에 걸리지 않은 회원 */
-    private fun findAvailableMembers(quizSetId: Long, matchingType: MatchingType): Set<Long> {
-        val participantIds = quizProgressRepository
-            .findByQuizSetIdAndStatus(quizSetId, QuizProgressStatus.COMPLETED)
-            .map { it.memberId }
-            .toSet()
-        if (participantIds.isEmpty()) return emptySet()
+    /** 완료자 중 해당 매칭 타입의 제외 정책에 걸리지 않은 회원 */
+    private fun availableMemberIds(
+        quizSetId: Long,
+        matchingType: MatchingType,
+        completedProgresses: List<QuizProgress>,
+    ): Set<Long> {
+        val participantMemberIds = completedProgresses.map { it.memberId }.toSet()
 
-        val excluded = exclusionPolicies
+        if (participantMemberIds.isEmpty()) return emptySet()
+
+        val excludedMemberIds = exclusionPolicies
             .firstOrNull { it.matchingType == matchingType }
-            ?.excludedMemberIds(quizSetId, participantIds)
+            ?.excludedMemberIds(quizSetId, participantMemberIds)
             ?: emptySet()
-        return participantIds - excluded
+
+        return participantMemberIds - excludedMemberIds
     }
 
-    private fun loadParticipants(quizSetId: Long, memberIds: Set<Long>): List<MatchParticipant> {
+    private fun loadParticipants(
+        quizSetId: Long,
+        memberIds: Set<Long>,
+        completedProgresses: List<QuizProgress>,
+    ): List<MatchParticipant> {
         val quizIds = quizRepository.findByQuizSetIdInOrderByDisplayOrderAsc(listOf(quizSetId)).map { it.id }
         val answersByMember = quizAnswerRepository
             .findByMemberIdInAndQuizIdIn(memberIds.toList(), quizIds)
             .groupBy { it.memberId }
             .mapValues { (_, answers) -> answers.associate { it.quizId to it.choiceId } }
-        return memberIds.map { memberId -> MatchParticipant(memberId, answersByMember[memberId].orEmpty()) }
+        val membersById = memberRepository.findAllById(memberIds).associateBy { it.id }
+        val preferenceByMember = completedProgresses.associate { it.memberId to it.preferredGender }
+        return memberIds.mapNotNull { memberId ->
+            // 성별·나이 미상 회원은 성별·나이 기반 매칭이 불가하므로 후보 풀에서 제외한다.
+            val member = membersById[memberId] ?: return@mapNotNull null
+            val gender = member.gender ?: return@mapNotNull null
+            val age = member.age ?: return@mapNotNull null
+            MatchParticipant(
+                memberId = memberId,
+                answers = answersByMember[memberId].orEmpty(),
+                gender = gender,
+                age = age,
+                // memberIds 는 completedProgresses 에서 유래하므로 선호값은 항상 존재한다(기본값은 QuizProgress 가 보유).
+                preferredGender = preferenceByMember.getValue(memberId),
+            )
+        }
     }
 
     /** 페어(A,B) 하나를 (A→B), (B→A) 두 방향 행으로 변환한다. */

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingSchedulerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingSchedulerTest.kt
@@ -5,6 +5,7 @@ import com.ditto.api.support.IntegrationTest
 import com.ditto.domain.match.MatchCandidateFixture
 import com.ditto.domain.match.repository.MatchCandidateRepository
 import com.ditto.domain.member.MemberFixture
+import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.MemberStatus
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.quiz.QuizAnswerFixture
@@ -32,8 +33,10 @@ class MatchingSchedulerTest(
     dataSource: DataSource,
 ) : IntegrationTest(dataSource, {
 
-    fun saveMember(nickname: String): Long =
-        memberRepository.save(MemberFixture.create(nickname = nickname, status = MemberStatus.ACTIVE)).id
+    fun saveMember(nickname: String, gender: Gender, age: Int = 25): Long =
+        memberRepository.save(
+            MemberFixture.create(nickname = nickname, status = MemberStatus.ACTIVE, gender = gender, age = age),
+        ).id
 
     fun saveOneToOneQuizSet(endDate: LocalDateTime): Long =
         quizSetRepository.save(QuizSetFixture.create(matchingType = MatchingType.ONE_TO_ONE, endDate = endDate)).id
@@ -42,8 +45,9 @@ class MatchingSchedulerTest(
     fun setupMatchingPair(quizSetId: Long): Pair<Long, Long> {
         val quizId1 = quizRepository.save(QuizFixture.create(quizSetId = quizSetId, displayOrder = 1)).id
         val quizId2 = quizRepository.save(QuizFixture.create(quizSetId = quizSetId, displayOrder = 2)).id
-        val a = saveMember("회원A")
-        val b = saveMember("회원B")
+        // 기본 선호(OPPOSITE)로 매칭되도록 이성 한 쌍으로 구성한다.
+        val a = saveMember("회원A", Gender.MALE)
+        val b = saveMember("회원B", Gender.FEMALE)
         listOf(a, b).forEach { memberId ->
             quizAnswerRepository.save(QuizAnswerFixture.create(memberId = memberId, quizId = quizId1, choiceId = 1L))
             quizAnswerRepository.save(QuizAnswerFixture.create(memberId = memberId, quizId = quizId2, choiceId = 1L))

--- a/api/src/test/kotlin/com/ditto/api/match/MatchmakingServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchmakingServiceTest.kt
@@ -7,6 +7,8 @@ import com.ditto.domain.match.entity.PersonalMatchStatus
 import com.ditto.domain.match.repository.MatchCandidateRepository
 import com.ditto.domain.match.repository.PersonalMatchRepository
 import com.ditto.domain.member.MemberFixture
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.GenderPreference
 import com.ditto.domain.member.entity.MemberStatus
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.quiz.QuizAnswerFixture
@@ -36,8 +38,16 @@ class MatchmakingServiceTest(
     dataSource,
     {
 
-        fun saveMember(nickname: String, status: MemberStatus = MemberStatus.ACTIVE): Long =
-            memberRepository.save(MemberFixture.create(nickname = nickname, status = status)).id
+        // 성별·나이 미상 회원은 매칭에서 제외되므로, 성별/나이 무관 점수 테스트의 기본 회원은 둘 다 갖게 둔다.
+        fun saveMember(
+            nickname: String,
+            status: MemberStatus = MemberStatus.ACTIVE,
+            gender: Gender? = Gender.MALE,
+            age: Int? = 25,
+        ): Long =
+            memberRepository.save(
+                MemberFixture.create(nickname = nickname, status = status, gender = gender, age = age),
+            ).id
 
         fun saveOneToOneQuizSetWithTwoQuizzes(): Triple<Long, Long, Long> {
             val quizSetId = quizSetRepository.save(QuizSetFixture.create(matchingType = MatchingType.ONE_TO_ONE)).id
@@ -58,9 +68,15 @@ class MatchmakingServiceTest(
             }
         }
 
-        fun saveCompletedProgress(memberId: Long, quizSetId: Long, total: Int) {
+        fun saveCompletedProgress(
+            memberId: Long,
+            quizSetId: Long,
+            total: Int,
+            preferredGender: GenderPreference = GenderPreference.ANY,
+        ) {
             val progress = QuizProgressFixture.create(memberId = memberId, quizSetId = quizSetId, totalCount = total)
             repeat(total) { progress.recordAnswer() } // COMPLETED 로 만든다
+            progress.selectPreferredGender(preferredGender)
             quizProgressRepository.save(progress)
         }
 
@@ -114,6 +130,80 @@ class MatchmakingServiceTest(
                 matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(a, quizSetId) shouldHaveSize 0
                 matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(b, quizSetId) shouldHaveSize 0
                 matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(c, quizSetId) shouldHaveSize 0
+            }
+
+            "성별 선호가 맞지 않는 페어는 후보에서 제외된다 (상호호환 하드 필터)" {
+                val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
+                val maleA = saveMember("남A", gender = Gender.MALE)
+                val femaleB = saveMember("여B", gender = Gender.FEMALE)
+                val maleC = saveMember("남C", gender = Gender.MALE)
+                // 모두 두 문항 일치(100점). 전부 이성 선호 → 남-남(A-C)은 비호환.
+                listOf(maleA, femaleB, maleC).forEach { saveAnswers(it, quizId1 to 1L, quizId2 to 1L) }
+                listOf(maleA, femaleB, maleC).forEach {
+                    saveCompletedProgress(it, quizSetId, total = 2, preferredGender = GenderPreference.OPPOSITE)
+                }
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                // A-B, B-C 만 상호호환 → 저장. A-C(남-남)는 제외.
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(maleA, quizSetId)
+                    .map { it.otherMemberId } shouldBe listOf(femaleB)
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(maleC, quizSetId)
+                    .map { it.otherMemberId } shouldBe listOf(femaleB)
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(femaleB, quizSetId)
+                    .map { it.otherMemberId }.toSet() shouldBe setOf(maleA, maleC)
+            }
+
+            "성별 미상(null) 회원은 매칭에서 제외된다 (성별 필수)" {
+                val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
+                val male = saveMember("남A", gender = Gender.MALE)
+                val female = saveMember("여B", gender = Gender.FEMALE)
+                val unknown = saveMember("성별미상", gender = null)
+                listOf(male, female, unknown).forEach { saveAnswers(it, quizId1 to 1L, quizId2 to 1L) }
+                listOf(male, female, unknown).forEach {
+                    saveCompletedProgress(it, quizSetId, total = 2, preferredGender = GenderPreference.OPPOSITE)
+                }
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                // 남-여만 매칭, 성별 미상 회원은 후보 풀에서 제외되어 어디에도 노출되지 않음
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(male, quizSetId)
+                    .map { it.otherMemberId } shouldBe listOf(female)
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(female, quizSetId)
+                    .map { it.otherMemberId } shouldBe listOf(male)
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(unknown, quizSetId) shouldHaveSize 0
+            }
+
+            "나이차가 10을 넘는 페어는 후보에서 제외된다" {
+                val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
+                val young = saveMember("남20", gender = Gender.MALE, age = 20)
+                val old = saveMember("여35", gender = Gender.FEMALE, age = 35) // 나이차 15
+                listOf(young, old).forEach { saveAnswers(it, quizId1 to 1L, quizId2 to 1L) }
+                listOf(young, old).forEach {
+                    saveCompletedProgress(it, quizSetId, total = 2, preferredGender = GenderPreference.OPPOSITE)
+                }
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(young, quizSetId) shouldHaveSize 0
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(old, quizSetId) shouldHaveSize 0
+            }
+
+            "나이 미상(null) 회원은 매칭에서 제외된다 (나이 필수)" {
+                val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
+                val male = saveMember("남A", gender = Gender.MALE, age = 25)
+                val female = saveMember("여B", gender = Gender.FEMALE, age = 25)
+                val ageUnknown = saveMember("나이미상", gender = Gender.FEMALE, age = null)
+                listOf(male, female, ageUnknown).forEach { saveAnswers(it, quizId1 to 1L, quizId2 to 1L) }
+                listOf(male, female, ageUnknown).forEach {
+                    saveCompletedProgress(it, quizSetId, total = 2, preferredGender = GenderPreference.OPPOSITE)
+                }
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(male, quizSetId)
+                    .map { it.otherMemberId } shouldBe listOf(female)
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(ageUnknown, quizSetId) shouldHaveSize 0
             }
 
             "ACTIVE 가 아닌(PENDING) 회원은 제외된다" {

--- a/api/src/test/kotlin/com/ditto/api/match/MatchmakingServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchmakingServiceTest.kt
@@ -108,6 +108,16 @@ class MatchmakingServiceTest(
                 abCandidate.totalQuestionCount shouldBe 2
             }
 
+            "완료한 참여자가 없으면 후보를 만들지 않는다" {
+                val (quizSetId, _, _) = saveOneToOneQuizSetWithTwoQuizzes()
+                val a = saveMember("회원A")
+                // 답변/완료 처리 없음 → 완료자 0명
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(a, quizSetId) shouldHaveSize 0
+            }
+
             "이미 ACCEPTED 매칭된 회원은 제외된다" {
                 val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
                 val a = saveMember("회원A")

--- a/api/src/test/kotlin/com/ditto/api/match/matching/MatchScoreCalculatorTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/matching/MatchScoreCalculatorTest.kt
@@ -1,15 +1,19 @@
 package com.ditto.api.match.matching
 
+import com.ditto.domain.member.entity.Gender
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.doubles.plusOrMinus
 import io.kotest.matchers.shouldBe
 
 class MatchScoreCalculatorTest : FreeSpec(
     {
+        // 점수 계산은 답변만 사용하므로 성별·나이는 임의값으로 둔다.
+        fun participant(id: Long, answers: Map<Long, Long>) = MatchParticipant(id, answers, Gender.MALE, age = 25)
+
         "calculate" - {
             "모든 문항의 답이 같으면 100.0 점, matched=total" {
-                val p1 = MatchParticipant(1L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
-                val p2 = MatchParticipant(2L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
+                val p1 = participant(1L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
+                val p2 = participant(2L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
 
                 val result = MatchScoreCalculator.calculate(p1, p2)
 
@@ -19,8 +23,8 @@ class MatchScoreCalculatorTest : FreeSpec(
             }
 
             "일부만 같으면 (같은 답 수 ÷ 문항 수) × 100, 소수점 1자리" {
-                val p1 = MatchParticipant(1L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
-                val p2 = MatchParticipant(2L, mapOf(101L to 1L, 102L to 1L, 103L to 2L)) // 3문항 중 2개 일치
+                val p1 = participant(1L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
+                val p2 = participant(2L, mapOf(101L to 1L, 102L to 1L, 103L to 2L)) // 3문항 중 2개 일치
 
                 val result = MatchScoreCalculator.calculate(p1, p2)
 
@@ -30,8 +34,8 @@ class MatchScoreCalculatorTest : FreeSpec(
             }
 
             "겹치는 답이 하나도 없으면 0.0 점, matched=0" {
-                val p1 = MatchParticipant(1L, mapOf(101L to 1L, 102L to 1L))
-                val p2 = MatchParticipant(2L, mapOf(101L to 2L, 102L to 2L))
+                val p1 = participant(1L, mapOf(101L to 1L, 102L to 1L))
+                val p2 = participant(2L, mapOf(101L to 2L, 102L to 2L))
 
                 val result = MatchScoreCalculator.calculate(p1, p2)
 
@@ -41,8 +45,8 @@ class MatchScoreCalculatorTest : FreeSpec(
             }
 
             "답변이 하나도 없으면 0.0 점 (문항 수 0 가드)" {
-                val p1 = MatchParticipant(1L, emptyMap())
-                val p2 = MatchParticipant(2L, emptyMap())
+                val p1 = participant(1L, emptyMap())
+                val p2 = participant(2L, emptyMap())
 
                 val result = MatchScoreCalculator.calculate(p1, p2)
 

--- a/api/src/test/kotlin/com/ditto/api/match/matching/OneToOneMatchingProcessorTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/matching/OneToOneMatchingProcessorTest.kt
@@ -1,6 +1,9 @@
 package com.ditto.api.match.matching
 
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.GenderPreference
 import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.collections.shouldBeEmpty
 import io.kotest.matchers.collections.shouldContainExactlyInAnyOrder
 import io.kotest.matchers.shouldBe
 
@@ -8,11 +11,19 @@ class OneToOneMatchingProcessorTest : FreeSpec(
     {
         val processor = OneToOneMatchingProcessor()
 
+        // 점수 파이프라인 검증용: 성별·나이 필터가 개입하지 않도록 모두 같은 성별·나이 + ANY 선호.
+        fun scored(id: Long, answers: Map<Long, Long>) =
+            MatchParticipant(id, answers, gender = Gender.MALE, age = 25, preferredGender = GenderPreference.ANY)
+
+        // 자격 필터 검증용: 두 문항 모두 일치(=100점)하는 답변에 성별/나이/선호만 달리한다.
+        fun participant(id: Long, gender: Gender, preferredGender: GenderPreference, age: Int = 25) =
+            MatchParticipant(id, mapOf(101L to 1L, 102L to 1L), gender = gender, age = age, preferredGender = preferredGender)
+
         "match() 종단 동작" - {
             "점수화 → 상위20%+동점 → 5명 제한 전체 파이프라인이 동작한다" {
-                val p1 = MatchParticipant(1L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
-                val p2 = MatchParticipant(2L, mapOf(101L to 1L, 102L to 1L, 103L to 2L)) // 1 과 2개 일치
-                val p3 = MatchParticipant(3L, mapOf(101L to 1L, 102L to 2L, 103L to 2L)) // 1 과 1개, 2 와 2개 일치
+                val p1 = scored(1L, mapOf(101L to 1L, 102L to 1L, 103L to 1L))
+                val p2 = scored(2L, mapOf(101L to 1L, 102L to 1L, 103L to 2L)) // 1 과 2개 일치
+                val p3 = scored(3L, mapOf(101L to 1L, 102L to 2L, 103L to 2L)) // 1 과 1개, 2 와 2개 일치
 
                 // 점수(3문항): (1,2)=66.7, (1,3)=33.3, (2,3)=66.7 → 상위20%+동점으로 66.7 두 쌍 선발
                 val result = processor.match(listOf(p1, p2, p3))
@@ -25,18 +36,66 @@ class OneToOneMatchingProcessorTest : FreeSpec(
 
             "참여자가 2명 미만이면 빈 결과 (7.1)" {
                 processor.match(emptyList()) shouldBe emptyList()
-                processor.match(
-                    listOf(MatchParticipant(1L, mapOf(101L to 1L))),
-                ) shouldBe emptyList()
+                processor.match(listOf(scored(1L, mapOf(101L to 1L)))) shouldBe emptyList()
             }
 
             "참여자가 정확히 2명이면 페어 1개가 결과로 나온다" {
-                val p1 = MatchParticipant(1L, mapOf(101L to 1L, 102L to 1L))
-                val p2 = MatchParticipant(2L, mapOf(101L to 1L, 102L to 2L)) // 2문항 중 1개 일치
+                val p1 = scored(1L, mapOf(101L to 1L, 102L to 1L))
+                val p2 = scored(2L, mapOf(101L to 1L, 102L to 2L)) // 2문항 중 1개 일치
 
                 val result = processor.match(listOf(p1, p2))
 
                 result.map { it.memberId1 to it.memberId2 } shouldContainExactlyInAnyOrder listOf(1L to 2L)
+            }
+        }
+
+        "성별 상호호환 하드 필터" - {
+            "서로의 성별 선호를 모두 충족하면 페어가 된다 (남↔여, 둘 다 이성 선호)" {
+                val male = participant(1L, Gender.MALE, GenderPreference.OPPOSITE)
+                val female = participant(2L, Gender.FEMALE, GenderPreference.OPPOSITE)
+
+                processor.match(listOf(male, female))
+                    .map { it.memberId1 to it.memberId2 } shouldContainExactlyInAnyOrder listOf(1L to 2L)
+            }
+
+            "한쪽 선호라도 어긋나면 페어에서 제외된다 (남(이성선호) ↔ 여(동성선호))" {
+                val male = participant(1L, Gender.MALE, GenderPreference.OPPOSITE) // 여성을 원함
+                val femaleWantingFemale = participant(2L, Gender.FEMALE, GenderPreference.SAME) // 여성을 원함 → 남성 거부
+
+                processor.match(listOf(male, femaleWantingFemale)).shouldBeEmpty()
+            }
+
+            "동성 선호끼리 같은 성별이면 페어가 된다 (남↔남, 둘 다 동성 선호)" {
+                val m1 = participant(1L, Gender.MALE, GenderPreference.SAME)
+                val m2 = participant(2L, Gender.MALE, GenderPreference.SAME)
+
+                processor.match(listOf(m1, m2))
+                    .map { it.memberId1 to it.memberId2 } shouldContainExactlyInAnyOrder listOf(1L to 2L)
+            }
+
+            "ANY 선호는 상대 성별과 무관하게 호환된다" {
+                val anyPref = participant(1L, Gender.MALE, GenderPreference.ANY)
+                val female = participant(2L, Gender.FEMALE, GenderPreference.ANY)
+
+                processor.match(listOf(anyPref, female))
+                    .map { it.memberId1 to it.memberId2 } shouldContainExactlyInAnyOrder listOf(1L to 2L)
+            }
+        }
+
+        "나이차 하드 필터" - {
+            "나이차가 10을 넘으면 페어에서 제외된다" {
+                val young = participant(1L, Gender.MALE, GenderPreference.ANY, age = 20)
+                val old = participant(2L, Gender.FEMALE, GenderPreference.ANY, age = 31) // 차이 11
+
+                processor.match(listOf(young, old)).shouldBeEmpty()
+            }
+
+            "나이차가 정확히 10이면 매칭된다 (경계 포함)" {
+                val a = participant(1L, Gender.MALE, GenderPreference.ANY, age = 20)
+                val b = participant(2L, Gender.FEMALE, GenderPreference.ANY, age = 30) // 차이 10
+
+                processor.match(listOf(a, b))
+                    .map { it.memberId1 to it.memberId2 } shouldContainExactlyInAnyOrder listOf(1L to 2L)
             }
         }
     },

--- a/domain/db/V20260608000000_퀴즈 진행 성별 선호 컬럼 추가.sql
+++ b/domain/db/V20260608000000_퀴즈 진행 성별 선호 컬럼 추가.sql
@@ -1,0 +1,2 @@
+ALTER TABLE quiz_progress
+    ADD COLUMN preferred_gender VARCHAR(20) NOT NULL DEFAULT 'OPPOSITE' COMMENT '매칭 성별 선호 (OPPOSITE, SAME, ANY)' AFTER total_count;

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Gender.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Gender.kt
@@ -3,4 +3,10 @@ package com.ditto.domain.member.entity
 enum class Gender(private val description: String) {
     MALE("남성"),
     FEMALE("여성"),
+    ;
+
+    fun opposite(): Gender = when (this) {
+        MALE -> FEMALE
+        FEMALE -> MALE
+    }
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/GenderPreference.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/GenderPreference.kt
@@ -1,0 +1,14 @@
+package com.ditto.domain.member.entity
+
+enum class GenderPreference {
+    OPPOSITE,
+    SAME,
+    ANY,
+    ;
+
+    fun targetGenders(ownerGender: Gender): Set<Gender> = when (this) {
+        ANY -> Gender.entries.toSet()
+        OPPOSITE -> setOf(ownerGender.opposite())
+        SAME -> setOf(ownerGender)
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizProgress.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/entity/QuizProgress.kt
@@ -1,6 +1,7 @@
 package com.ditto.domain.quiz.entity
 
 import com.ditto.domain.BaseEntity
+import com.ditto.domain.member.entity.GenderPreference
 import jakarta.persistence.Column
 import jakarta.persistence.Entity
 import jakarta.persistence.EnumType
@@ -38,6 +39,8 @@ class QuizProgress private constructor(
     val totalCount: Int,
     status: QuizProgressStatus = QuizProgressStatus.NOT_STARTED,
     answeredCount: Int = 0,
+    // 별도 선택 전 기본값은 이성(OPPOSITE) — 연애 매칭의 기본 동작.
+    preferredGender: GenderPreference = GenderPreference.OPPOSITE,
 ) : BaseEntity() {
 
     @Comment("진행 상태")
@@ -51,6 +54,12 @@ class QuizProgress private constructor(
     var answeredCount: Int = answeredCount
         protected set
 
+    @Comment("매칭 성별 선호 (OPPOSITE, SAME, ANY). 기본값 OPPOSITE")
+    @Enumerated(EnumType.STRING)
+    @Column(name = "preferred_gender", nullable = false, length = 20)
+    var preferredGender: GenderPreference = preferredGender
+        protected set
+
     fun recordAnswer() {
         answeredCount++
         if (answeredCount >= totalCount) {
@@ -58,6 +67,11 @@ class QuizProgress private constructor(
             return
         }
         status = QuizProgressStatus.IN_PROGRESS
+    }
+
+    /** 이 퀴즈에서의 매칭 성별 선호를 설정한다. (연애 퀴즈 참여 시 선택) */
+    fun selectPreferredGender(preferredGender: GenderPreference) {
+        this.preferredGender = preferredGender
     }
 
     companion object {

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/GenderPreferenceTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/GenderPreferenceTest.kt
@@ -1,0 +1,25 @@
+package com.ditto.domain.member.entity
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class GenderPreferenceTest : FreeSpec(
+    {
+        "targetGenders" - {
+            "OPPOSITE 는 owner 의 반대 성별만 대상으로 한다" {
+                GenderPreference.OPPOSITE.targetGenders(Gender.MALE) shouldBe setOf(Gender.FEMALE)
+                GenderPreference.OPPOSITE.targetGenders(Gender.FEMALE) shouldBe setOf(Gender.MALE)
+            }
+
+            "SAME 은 owner 와 같은 성별만 대상으로 한다" {
+                GenderPreference.SAME.targetGenders(Gender.MALE) shouldBe setOf(Gender.MALE)
+                GenderPreference.SAME.targetGenders(Gender.FEMALE) shouldBe setOf(Gender.FEMALE)
+            }
+
+            "ANY 는 모든 성별을 대상으로 한다" {
+                GenderPreference.ANY.targetGenders(Gender.MALE) shouldBe setOf(Gender.MALE, Gender.FEMALE)
+                GenderPreference.ANY.targetGenders(Gender.FEMALE) shouldBe setOf(Gender.MALE, Gender.FEMALE)
+            }
+        }
+    },
+)

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/GenderTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/GenderTest.kt
@@ -1,0 +1,13 @@
+package com.ditto.domain.member.entity
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class GenderTest : FreeSpec(
+    {
+        "opposite() 는 반대 성별을 반환한다" {
+            Gender.MALE.opposite() shouldBe Gender.FEMALE
+            Gender.FEMALE.opposite() shouldBe Gender.MALE
+        }
+    },
+)

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/entity/QuizProgressTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/entity/QuizProgressTest.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.quiz.entity
 
+import com.ditto.domain.member.entity.GenderPreference
 import com.ditto.domain.quiz.QuizProgressFixture
 import com.ditto.domain.quiz.QuizSetFixture
 import com.ditto.domain.quiz.repository.QuizProgressRepository
@@ -75,6 +76,30 @@ class QuizProgressTest(
             found shouldNotBe null
             found!!.answeredCount shouldBe 2
             found.status shouldBe QuizProgressStatus.COMPLETED
+        }
+    }
+
+    "매칭 성별 선호" - {
+        "기본값은 OPPOSITE(이성)이다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val progress = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id),
+            )
+
+            progress.preferredGender shouldBe GenderPreference.OPPOSITE
+        }
+
+        "selectPreferredGender 로 선호를 변경하고 저장할 수 있다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+            val progress = quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id),
+            )
+
+            progress.selectPreferredGender(GenderPreference.SAME)
+            quizProgressRepository.saveAndFlush(progress)
+
+            val found = quizProgressRepository.findByMemberIdAndQuizSetId(1L, quizSet.id)
+            found!!.preferredGender shouldBe GenderPreference.SAME
         }
     }
 

--- a/domain/src/testFixtures/kotlin/com/ditto/domain/member/MemberFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/ditto/domain/member/MemberFixture.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.member
 
+import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
 import com.ditto.domain.member.entity.Location
@@ -13,6 +14,8 @@ object MemberFixture {
         nickname: String = "테스트유저",
         email: String = "test@example.com",
         status: MemberStatus = MemberStatus.PENDING,
+        gender: Gender? = null,
+        age: Int? = null,
         interests: Set<Interest> = emptySet(),
         location: Location? = null,
         job: Job? = null,
@@ -21,6 +24,8 @@ object MemberFixture {
         nickname = nickname,
         email = email,
         status = status,
+        gender = gender,
+        age = age,
         interests = interests,
         location = location,
         job = job,


### PR DESCRIPTION
## 개요
1:1 연애 매칭 **후보 선발 단계**에 성별·나이 자격 하드 필터를 추가합니다. 기존 점수(답변 일치율) 기반 선발(상위 20% → 개인당 5명 양방향 hard limit)은 그대로 두고, 그 앞단에서 자격 미달 페어를 후보에서 제외합니다.

## 변경 사항
**자격 필터 (선발 단계, `OneToOneMatchingProcessor`)**
- **성별(상호호환)**: 페어 (A,B)는 A가 B의 성별을 원하고 ∧ B도 A의 성별을 원할 때만 후보 — 이성/동성/상관없음
- **나이**: 나이차 **±10 이내** 페어만 후보 (`MAX_AGE_GAP = 10`)
- 두 조건 모두 대칭이라 **양방향 원칙(A↔B 동시 노출)이 보존**됨

**성별·나이 필수**
- 성별 또는 나이가 미상(null)인 회원은 `MatchmakingService`의 후보 풀 구성에서 제외 → `MatchParticipant.gender/age` 비널

**데이터 모델**
- 신규 enum `GenderPreference { OPPOSITE, SAME, ANY }` + `Gender.opposite()`
- `QuizProgress.preferredGender` 추가 (**기본값 OPPOSITE = 이성**) + 마이그레이션 SQL

## 동작
별도 선호 입력 전에는 기본 이성 매칭으로 동작합니다(기본값 OPPOSITE). 선호를 SAME/ANY로 바꾸는 입력 API와, 선발된 후보를 조회하는 노출 API는 **별도 작업**으로 분리했습니다.

## 테스트
- 단위: `OneToOneMatchingProcessorTest`(성별 호환 5케이스 + 나이차 경계 ±10 포함), `MatchScoreCalculatorTest`
- 통합: `MatchmakingServiceTest`(나이차 초과 제외·성별/나이 미상 제외·성별 선호 불일치 제외), `MatchingSchedulerTest`
- `./gradlew build` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)