### PR TITLE
feat. 1:1 추천 후보 조회 + 매칭 상태 조회 + 퀴즈셋 매칭 재실행 admin API

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/match/controller/MatchAdminController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/MatchAdminController.kt
@@ -1,0 +1,29 @@
+package com.ditto.api.match.controller
+
+import com.ditto.api.match.service.MatchmakingService
+import com.ditto.common.response.ApiResponse
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 매칭 운영용(admin) API.
+ *
+ * admin 전용 인가는 후속 작업이다. 현재는 공통 인증(API Key + JWT)만 적용되어 인증된 회원이면 호출할 수 있다.
+ * admin 경로 접두사(api/v1/admin)는 추후 전용 SecurityFilterChain 부착용이다.
+ */
+@RestController
+class MatchAdminController(
+    private val matchmakingService: MatchmakingService,
+) {
+
+    /**
+     * 특정 퀴즈셋의 1:1 매칭 후보를 재생성한다. 기존 후보를 모두 삭제하고 다시 계산한다(멱등).
+     * 스케줄러와 달리 마감·후보 존재 여부와 무관하게 무조건 실행한다.
+     */
+    @PostMapping("/api/v1/admin/quiz-sets/{quizSetId}/matching/regenerate")
+    fun regenerateMatching(@PathVariable quizSetId: Long): ApiResponse<Unit> {
+        matchmakingService.generateMatchingCandidates(quizSetId)
+        return ApiResponse(success = true)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/match/controller/MatchCandidateController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/MatchCandidateController.kt
@@ -1,0 +1,22 @@
+package com.ditto.api.match.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.match.dto.MatchCandidateResponse
+import com.ditto.api.match.service.MatchCandidateService
+import com.ditto.common.response.ApiResponse
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+class MatchCandidateController(
+    private val matchCandidateService: MatchCandidateService,
+) {
+
+    /** 회원이 최근 완료한 1:1 퀴즈셋의 추천 후보 목록 조회. 대상 퀴즈셋은 서버가 결정한다. */
+    @GetMapping("/api/v1/matches/1on1")
+    fun getMatchCandidates(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<MatchCandidateResponse> =
+        ApiResponse.ok(matchCandidateService.getMatchCandidates(principal.memberId))
+}

--- a/api/src/main/kotlin/com/ditto/api/match/controller/PersonalMatchController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/PersonalMatchController.kt
@@ -1,30 +1,20 @@
 package com.ditto.api.match.controller
 
 import com.ditto.api.config.auth.MemberPrincipal
-import com.ditto.api.match.dto.PersonalMatchListResponse
 import com.ditto.api.match.dto.PersonalMatchRequest
 import com.ditto.api.match.dto.PersonalMatchResponse
 import com.ditto.api.match.service.PersonalMatchService
 import com.ditto.common.response.ApiResponse
 import org.springframework.security.core.annotation.AuthenticationPrincipal
-import org.springframework.web.bind.annotation.GetMapping
 import org.springframework.web.bind.annotation.PathVariable
 import org.springframework.web.bind.annotation.PostMapping
 import org.springframework.web.bind.annotation.RequestBody
-import org.springframework.web.bind.annotation.RequestParam
 import org.springframework.web.bind.annotation.RestController
 
 @RestController
 class PersonalMatchController(
     private val personalMatchService: PersonalMatchService,
 ) {
-
-    @GetMapping("/api/v1/matches/1on1")
-    fun getPersonalMatches(
-        @AuthenticationPrincipal principal: MemberPrincipal,
-        @RequestParam quizSetId: Long,
-    ): ApiResponse<PersonalMatchListResponse> =
-        ApiResponse.ok(personalMatchService.getPersonalMatches(principal.memberId, quizSetId))
 
     @PostMapping("/api/v1/matches/request")
     fun requestMatch(

--- a/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchStatus.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/GroupMatchStatus.kt
@@ -1,7 +1,0 @@
-package com.ditto.api.match.dto
-
-enum class GroupMatchStatus {
-    NONE,
-    JOINED,
-    DECLINED,
-}

--- a/api/src/main/kotlin/com/ditto/api/match/dto/MatchCandidateResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/MatchCandidateResponse.kt
@@ -1,0 +1,39 @@
+package com.ditto.api.match.dto
+
+import com.ditto.domain.quiz.entity.MatchingType
+
+/**
+ * 1:1 매칭 추천 후보 목록 응답.
+ * 회원이 최근 완료한 1:1 퀴즈셋에서 노출받는 후보들을 매칭 점수 내림차순으로 담는다.
+ */
+data class MatchCandidateResponse(
+    val quizSetId: Long,
+    val matchingType: MatchingType,
+    val algorithmVersion: String,
+    val candidates: List<Candidate>,
+)
+
+data class Candidate(
+    val userId: Long,
+    val nickname: String,
+    // gender·age 는 소셜 로그인(카카오) 동의 항목이라 가입 시 필수가 아니다 → null 가능
+    val gender: String?,
+    val age: Int?,
+    /** 자기소개는 소개노트 ONE_WORD 답변으로 채운다. 미작성/공백이면 null */
+    val introduction: String?,
+    // location·profileImageUrl(캐리커쳐)은 가입 완료 시 필수값이라 항상 존재한다
+    val location: String,
+    val profileImageUrl: String,
+    /** 매칭 점수 (0~100) */
+    val matchRate: Double,
+    val scoreBreakdown: ScoreSummary,
+)
+
+data class ScoreSummary(
+    /** 퀴즈 답변 일치율 (0~100). 현재는 matchRate 와 동일 값 */
+    val quizMatchRate: Double,
+    val matchedQuestions: Int,
+    val totalQuestions: Int,
+    /** 매칭 사유 문구. 현재는 일치 문항 수 기반 합성 문장 */
+    val reasons: List<String>,
+)

--- a/api/src/main/kotlin/com/ditto/api/match/dto/MatchingStatusResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/dto/MatchingStatusResponse.kt
@@ -1,35 +1,21 @@
 package com.ditto.api.match.dto
 
-import com.ditto.domain.match.entity.PersonalMatch
-import com.ditto.domain.match.entity.PersonalMatchStatus
-import java.time.LocalDateTime
-
+/**
+ * 매칭 상태 조회 응답.
+ * 1:1 보낸/받은 요청 목록과 수락 여부, 그룹 매칭 참여/거절 상태를 함께 담는다.
+ */
 data class MatchingStatusResponse(
     val quizSetId: Long,
-    /** ACCEPTED > PENDING 순으로 우선 노출. 매칭이 없으면 null */
-    val personalMatch: PersonalMatchSummary?,
-    /** NONE / JOINED / DECLINED */
-    val groupMatchStatus: GroupMatchStatus,
-    /** groupMatchStatus == JOINED 일 때 설정 */
-    val groupMatchRoomId: Long?,
+    val sentRequests: List<PersonalMatchResponse>,
+    val receivedRequests: List<PersonalMatchResponse>,
+    /** ACCEPTED 1:1 매칭 보유 여부 */
+    val hasAcceptedMatch: Boolean,
+    /** 수락된 매칭 상대 회원 ID. 없으면 null */
+    val acceptedMatchUserId: Long?,
+    /** 그룹 매칭 거절 여부 */
+    val groupDeclined: Boolean,
+    /** 활성화된(참가자 3명 이상) 그룹 방 참여 여부 */
+    val groupJoined: Boolean,
+    /** 그룹 방에 참여했으나 아직 비활성(인원 대기) 여부 */
+    val groupJoinPending: Boolean,
 )
-
-data class PersonalMatchSummary(
-    val id: Long,
-    val requesterId: Long,
-    val receiverId: Long,
-    val status: PersonalMatchStatus,
-    val createdAt: LocalDateTime,
-    val respondedAt: LocalDateTime?,
-) {
-    companion object {
-        fun from(match: PersonalMatch): PersonalMatchSummary = PersonalMatchSummary(
-            id = match.id,
-            requesterId = match.requesterId,
-            receiverId = match.receiverId(),
-            status = match.status,
-            createdAt = match.createdAt,
-            respondedAt = match.respondedAt,
-        )
-    }
-}

--- a/api/src/main/kotlin/com/ditto/api/match/service/MatchCandidateService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/MatchCandidateService.kt
@@ -1,0 +1,108 @@
+package com.ditto.api.match.service
+
+import com.ditto.api.match.dto.Candidate
+import com.ditto.api.match.dto.MatchCandidateResponse
+import com.ditto.api.match.dto.ScoreSummary
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.ErrorException
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.intronote.repository.IntroNoteRepository
+import com.ditto.domain.match.entity.MatchCandidate
+import com.ditto.domain.match.repository.MatchCandidateRepository
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.entity.MatchingType
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+@Service
+@Transactional(readOnly = true)
+class MatchCandidateService(
+    private val quizSetRepository: QuizSetRepository,
+    private val matchCandidateRepository: MatchCandidateRepository,
+    private val memberRepository: MemberRepository,
+    private val introNoteRepository: IntroNoteRepository,
+) {
+
+    /**
+     * 회원의 1:1 추천 후보 목록 조회.
+     * 후보는 마감된 퀴즈셋에만 생성되므로, 회원이 최근 완료(COMPLETED)한 1:1 퀴즈셋을 기준으로 후보를 조회한다.
+     * 참여한 1:1 퀴즈셋이 없으면 NOT_FOUND.
+     */
+    fun getMatchCandidates(memberId: Long): MatchCandidateResponse {
+        val quizSet = quizSetRepository.findLatestCompletedQuizSet(memberId, MatchingType.ONE_TO_ONE)
+            ?: throw WarnException(ErrorCode.NOT_FOUND)
+
+        val matchCandidates = matchCandidateRepository
+            .findByOwnerMemberIdAndQuizSetId(memberId, quizSet.id)
+            // 점수 내림차순, 동점이면 otherMemberId 오름차순으로 노출 순서를 결정적으로 고정
+            .sortedWith(compareByDescending<MatchCandidate> { it.score }.thenBy { it.otherMemberId })
+
+        return MatchCandidateResponse(
+            quizSetId = quizSet.id,
+            matchingType = quizSet.matchingType,
+            algorithmVersion = ALGORITHM_VERSION,
+            candidates = toCandidates(matchCandidates),
+        )
+    }
+
+    private fun toCandidates(matchCandidates: List<MatchCandidate>): List<Candidate> {
+        if (matchCandidates.isEmpty()) return emptyList()
+
+        val otherMemberIds = matchCandidates.map { it.otherMemberId }
+        val membersById = memberRepository.findAllById(otherMemberIds).associateBy { it.id }
+        val introductionsByMemberId = loadOneWordIntroductions(otherMemberIds)
+
+        return matchCandidates.mapNotNull { matchCandidate ->
+            val member = membersById[matchCandidate.otherMemberId] ?: return@mapNotNull null
+            toCandidate(matchCandidate, member, introductionsByMemberId[matchCandidate.otherMemberId])
+        }
+    }
+
+    /** 후보들의 소개노트 ONE_WORD 답변을 한 번에 조회해 회원ID로 매핑한다. 공백 답변은 제외. */
+    private fun loadOneWordIntroductions(memberIds: List<Long>): Map<Long, String> =
+        introNoteRepository
+            .findByMemberIdInAndQuestion(memberIds, IntroQuestion.ONE_WORD)
+            .mapNotNull { note -> note.answer.ifBlank { null }?.let { note.memberId to it } }
+            .toMap()
+
+    private fun toCandidate(
+        matchCandidate: MatchCandidate,
+        member: Member,
+        introduction: String?,
+    ): Candidate {
+        // location·caricature 는 가입 완료 시 필수값이라 후보(ACTIVE 회원)에는 항상 존재해야 한다.
+        // 없으면 데이터 정합성 오류이므로 명시적으로 예외를 던진다.
+        val location = member.location
+            ?: throw ErrorException(ErrorCode.INTERNAL_ERROR, "후보 회원의 사는곳이 비어 있습니다: memberId=${member.id}")
+        val profileImage = member.caricature
+            ?: throw ErrorException(ErrorCode.INTERNAL_ERROR, "후보 회원의 캐리커쳐가 비어 있습니다: memberId=${member.id}")
+
+        return Candidate(
+            userId = member.id,
+            nickname = member.nickname,
+            gender = member.gender?.name,
+            age = member.age,
+            introduction = introduction,
+            location = location.code,
+            profileImageUrl = profileImage,
+            matchRate = matchCandidate.score,
+            scoreBreakdown = ScoreSummary(
+                quizMatchRate = matchCandidate.score,
+                matchedQuestions = matchCandidate.matchedQuestionCount,
+                totalQuestions = matchCandidate.totalQuestionCount,
+                reasons = listOf(reasonOf(matchCandidate)),
+            ),
+        )
+    }
+
+    private fun reasonOf(matchCandidate: MatchCandidate): String =
+        "전체 ${matchCandidate.totalQuestionCount}문항 중 ${matchCandidate.matchedQuestionCount}문항이 일치했어요"
+
+    companion object {
+        // TODO: 알고리즘 버전이 match_candidate 에 영속화되면 그 값을 사용한다. 현재는 고정 상수.
+        private const val ALGORITHM_VERSION = "1.0"
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/match/service/MatchingStatusService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/MatchingStatusService.kt
@@ -1,9 +1,8 @@
 package com.ditto.api.match.service
 
-import com.ditto.api.match.dto.GroupMatchStatus
 import com.ditto.api.match.dto.MatchingStatusResponse
-import com.ditto.api.match.dto.PersonalMatchSummary
-import com.ditto.domain.match.entity.PersonalMatch
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.ErrorException
 import com.ditto.domain.match.entity.PersonalMatchStatus
 import com.ditto.domain.match.repository.GroupMatchDeclineRepository
 import com.ditto.domain.match.repository.GroupMatchMemberRepository
@@ -15,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 @Transactional(readOnly = true)
 class MatchingStatusService(
+    private val personalMatchService: PersonalMatchService,
     private val personalMatchRepository: PersonalMatchRepository,
     private val groupMatchRepository: GroupMatchRepository,
     private val groupMatchMemberRepository: GroupMatchMemberRepository,
@@ -22,39 +22,49 @@ class MatchingStatusService(
 ) {
 
     fun getMatchingStatus(memberId: Long, quizSetId: Long): MatchingStatusResponse {
-        val personalMatch = resolvePersonalMatch(memberId, quizSetId)
-        val (groupMatchStatus, groupMatchRoomId) = resolveGroupMatchStatus(memberId, quizSetId)
+        val personalMatches = personalMatchService.getPersonalMatches(memberId, quizSetId)
+        val acceptedMatchUserId = findAcceptedMatchUserId(memberId, quizSetId)
+        val group = groupFlags(memberId, quizSetId)
 
         return MatchingStatusResponse(
             quizSetId = quizSetId,
-            personalMatch = personalMatch?.let { PersonalMatchSummary.from(it) },
-            groupMatchStatus = groupMatchStatus,
-            groupMatchRoomId = groupMatchRoomId,
+            sentRequests = personalMatches.sent,
+            receivedRequests = personalMatches.received,
+            hasAcceptedMatch = acceptedMatchUserId != null,
+            acceptedMatchUserId = acceptedMatchUserId,
+            groupDeclined = group.declined,
+            groupJoined = group.joined,
+            groupJoinPending = group.pending,
         )
     }
 
-    /** ACCEPTED 매칭 우선, 없으면 PENDING 반환 */
-    private fun resolvePersonalMatch(memberId: Long, quizSetId: Long): PersonalMatch? {
-        return personalMatchRepository.findMatchByQuizSetIdAndStatusAndMemberId(
+    /** ACCEPTED 1:1 매칭이 있으면 상대 회원 ID, 없으면 null */
+    private fun findAcceptedMatchUserId(memberId: Long, quizSetId: Long): Long? {
+        val accepted = personalMatchRepository.findMatchByQuizSetIdAndStatusAndMemberId(
             quizSetId, PersonalMatchStatus.ACCEPTED, memberId,
-        ) ?: personalMatchRepository.findMatchByQuizSetIdAndStatusAndMemberId(
-            quizSetId, PersonalMatchStatus.PENDING, memberId,
-        )
+        ) ?: return null
+        return accepted.counterpartOf(memberId)
     }
 
-    /** 그룹 매칭 상태: DECLINED > JOINED > NONE 순으로 판단 */
-    private fun resolveGroupMatchStatus(memberId: Long, quizSetId: Long): Pair<GroupMatchStatus, Long?> {
+    /** 그룹 매칭 상태: 거절 > (활성 방=joined / 비활성 방=pending) > 미참여 */
+    private fun groupFlags(memberId: Long, quizSetId: Long): GroupFlags {
         if (groupMatchDeclineRepository.existsByQuizSetIdAndMemberId(quizSetId, memberId)) {
-            return Pair(GroupMatchStatus.DECLINED, null)
+            return GroupFlags(declined = true, joined = false, pending = false)
         }
 
-        val memberships = groupMatchMemberRepository.findByMemberIdAndQuizSetId(memberId, quizSetId)
-        if (memberships.isNotEmpty()) {
-            // 여러 방에 참여했을 경우 가장 최근 방 반환
-            val latestMembership = memberships.maxByOrNull { it.createdAt }!!
-            return Pair(GroupMatchStatus.JOINED, latestMembership.roomId)
-        }
+        val latestMembership = groupMatchMemberRepository.findByMemberIdAndQuizSetId(memberId, quizSetId)
+            .maxByOrNull { it.createdAt }
+            ?: return GroupFlags(declined = false, joined = false, pending = false)
 
-        return Pair(GroupMatchStatus.NONE, null)
+        val room = groupMatchRepository.findById(latestMembership.roomId).orElseThrow {
+            ErrorException(ErrorCode.INTERNAL_ERROR, "참여 기록의 그룹 방이 없습니다: roomId=${latestMembership.roomId}")
+        }
+        return GroupFlags(declined = false, joined = room.isActive, pending = !room.isActive)
     }
+
+    private data class GroupFlags(
+        val declined: Boolean,
+        val joined: Boolean,
+        val pending: Boolean,
+    )
 }

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -71,10 +71,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-06-08 23:07:25",
+                        "joinedAt" : "2026-06-09 11:08:41",
                         "role" : null,
-                        "createdAt" : "2026-06-08 23:07:25",
-                        "updatedAt" : "2026-06-08 23:07:25"
+                        "createdAt" : "2026-06-09 11:08:41",
+                        "updatedAt" : "2026-06-09 11:08:41"
                       },
                       "error" : null
                     }
@@ -84,50 +84,18 @@ paths:
     get:
       tags:
       - Matching
-      summary: 1:1 매칭 요청 목록 조회
-      description: 퀴즈셋에 대한 내가 보낸/받은 1:1 매칭 요청 목록을 조회합니다.
-      operationId: match-candidate-listpersonal-match-list
-      parameters:
-      - name: quizSetId
-        in: query
-        description: 퀴즈 세트 ID
-        required: true
-        schema:
-          type: string
+      summary: 1:1 매칭 추천 후보 목록 조회
+      description: "회원이 최근 완료한 1:1 퀴즈셋의 추천 후보를 매칭 점수 내림차순으로 조회합니다. 대상 퀴즈셋은 서버가 결정하\
+        며, 응답의 quizSetId 로 확인합니다."
+      operationId: match-candidate-list
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-matches-1on1-1796185400"
+                $ref: "#/components/schemas/api-v1-matches-1on1-1115011008"
               examples:
-                personal-match-list:
-                  value: |-
-                    {
-                      "success" : true,
-                      "data" : {
-                        "sent" : [ {
-                          "id" : 1,
-                          "quizSetId" : 10,
-                          "requesterId" : 1,
-                          "receiverId" : 2,
-                          "status" : "PENDING",
-                          "createdAt" : "2026-05-01 12:00:00",
-                          "respondedAt" : null
-                        } ],
-                        "received" : [ {
-                          "id" : 2,
-                          "quizSetId" : 10,
-                          "requesterId" : 3,
-                          "receiverId" : 1,
-                          "status" : "PENDING",
-                          "createdAt" : "2026-05-01 12:00:00",
-                          "respondedAt" : null
-                        } ]
-                      },
-                      "error" : null
-                    }
                 match-candidate-list:
                   value: |-
                     {
@@ -313,8 +281,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-06-07 23:07:25",
-                          "endDate" : "2026-06-09 23:07:25",
+                          "startDate" : "2026-06-08 11:08:41",
+                          "endDate" : "2026-06-10 11:08:41",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -331,8 +299,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-06-08 23:07:25",
-                            "updatedAt" : "2026-06-08 23:07:25"
+                            "createdAt" : "2026-06-09 11:08:41",
+                            "updatedAt" : "2026-06-09 11:08:41"
                           } ]
                         } ]
                       },
@@ -378,8 +346,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-06-08 23:07:25",
-                        "updatedAt" : "2026-06-08 23:07:25"
+                        "createdAt" : "2026-06-09 11:08:41",
+                        "updatedAt" : "2026-06-09 11:08:41"
                       },
                       "error" : null
                     }
@@ -500,8 +468,9 @@ paths:
       description: |-
         퀴즈셋에 대한 나의 매칭 현황을 조회합니다.
 
-        - **personalMatch**: ACCEPTED > PENDING 우선 반환. 없으면 null
-        - **groupMatchStatus**: DECLINED > JOINED > NONE 순으로 판단
+        - **sentRequests / receivedRequests**: 내가 보낸/받은 1:1 매칭 요청 목록
+        - **hasAcceptedMatch / acceptedMatchUserId**: 수락된 1:1 매칭 보유 여부와 상대 ID
+        - **groupDeclined / groupJoined / groupJoinPending**: 그룹 매칭 거절 / 활성 방 참여 / 인원 대기 상태
       operationId: matching-status
       parameters:
       - name: quizSetId
@@ -516,7 +485,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-matching-status-quizSetId-1585477117"
+                $ref: "#/components/schemas/api-v1-matching-status-quizSetId414593137"
               examples:
                 matching-status:
                   value: |-
@@ -524,16 +493,29 @@ paths:
                       "success" : true,
                       "data" : {
                         "quizSetId" : 10,
-                        "personalMatch" : {
+                        "sentRequests" : [ {
                           "id" : 1,
+                          "quizSetId" : 10,
                           "requesterId" : 1,
                           "receiverId" : 2,
                           "status" : "ACCEPTED",
                           "createdAt" : "2026-05-01 12:00:00",
                           "respondedAt" : "2026-05-01 12:30:00"
-                        },
-                        "groupMatchStatus" : "JOINED",
-                        "groupMatchRoomId" : 5
+                        } ],
+                        "receivedRequests" : [ {
+                          "id" : 2,
+                          "quizSetId" : 10,
+                          "requesterId" : 3,
+                          "receiverId" : 1,
+                          "status" : "PENDING",
+                          "createdAt" : "2026-05-01 12:00:00",
+                          "respondedAt" : null
+                        } ],
+                        "hasAcceptedMatch" : true,
+                        "acceptedMatchUserId" : 2,
+                        "groupDeclined" : false,
+                        "groupJoined" : true,
+                        "groupJoinPending" : false
                       },
                       "error" : null
                     }
@@ -647,7 +629,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwOTI3NjQyLCJleHAiOjE3ODA5MzEyNDJ9.TIAPrnr5nGrgqocSoiZb-lcaDLGsVWn9RCai10o-Iq6V1cUSfWZ7cJj00pP2W1iG-cSmpXJbioKMWWvzf5AaPA"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwOTcwOTE4LCJleHAiOjE3ODA5NzQ1MTh9.CYcw_yEYF-hkxYtalBjJPNUVzjOyTxmSIIknDo4CtSp0y5P3tFTB5RtY8cmbEADQXIij06vpoR0VcrbZfGUMbw"
                       },
                       "error" : null
                     }
@@ -846,8 +828,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-06-08 23:07:25",
-                        "updatedAt" : "2026-06-08 23:07:25"
+                        "createdAt" : "2026-06-09 11:08:41",
+                        "updatedAt" : "2026-06-09 11:08:41"
                       },
                       "error" : null
                     }
@@ -1242,6 +1224,111 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-matching-status-quizSetId414593137:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - groupDeclined
+          - groupJoinPending
+          - groupJoined
+          - hasAcceptedMatch
+          - quizSetId
+          - receivedRequests
+          - sentRequests
+          type: object
+          properties:
+            acceptedMatchUserId:
+              type: number
+              description: 수락된 매칭 상대 회원 ID (없으면 null)
+              nullable: true
+            hasAcceptedMatch:
+              type: boolean
+              description: 수락된 1:1 매칭 보유 여부
+            groupJoined:
+              type: boolean
+              description: 활성화된(3명 이상) 그룹 방 참여 여부
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            groupJoinPending:
+              type: boolean
+              description: 그룹 방 참여했으나 인원 대기(비활성) 여부
+            receivedRequests:
+              type: array
+              description: 내가 받은 1:1 매칭 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태
+            groupDeclined:
+              type: boolean
+              description: 그룹 매칭 거절 여부
+            sentRequests:
+              type: array
+              description: 내가 보낸 1:1 매칭 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  respondedAt:
+                    type: string
+                    description: 응답 일시 (없으면 null)
+                    nullable: true
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-users-me861338172:
       required:
       - error
@@ -1272,23 +1359,6 @@ components:
             email:
               type: string
               description: 이메일 (없으면 null)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-auth-refresh1774976609:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
         success:
           type: boolean
           description: 성공 여부
@@ -1412,6 +1482,116 @@ components:
                   startDate:
                     type: string
                     description: 시작일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-1on1-1115011008:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - algorithmVersion
+          - candidates
+          - matchingType
+          - quizSetId
+          type: object
+          properties:
+            candidates:
+              type: array
+              description: 추천 후보 목록 (매칭 점수 내림차순)
+              items:
+                required:
+                - location
+                - matchRate
+                - nickname
+                - profileImageUrl
+                - scoreBreakdown
+                - userId
+                type: object
+                properties:
+                  scoreBreakdown:
+                    required:
+                    - matchedQuestions
+                    - quizMatchRate
+                    - reasons
+                    - totalQuestions
+                    type: object
+                    properties:
+                      totalQuestions:
+                        type: number
+                        description: 전체 비교 문항 수
+                      reasons:
+                        type: array
+                        description: 매칭 사유 문구
+                        items:
+                          oneOf:
+                          - type: object
+                          - type: boolean
+                          - type: string
+                          - type: number
+                      quizMatchRate:
+                        type: number
+                        description: 퀴즈 답변 일치율 (0~100)
+                      matchedQuestions:
+                        type: number
+                        description: 일치한 문항 수
+                    description: 매칭 점수 상세
+                  gender:
+                    type: string
+                    description: "성별 (MALE / FEMALE, 없으면 null)"
+                    nullable: true
+                  nickname:
+                    type: string
+                    description: 닉네임
+                  location:
+                    type: string
+                    description: 사는 곳 코드
+                  matchRate:
+                    type: number
+                    description: 매칭 점수 (0~100)
+                  profileImageUrl:
+                    type: string
+                    description: 프로필 이미지 (캐리커쳐)
+                  userId:
+                    type: number
+                    description: 후보 회원 ID
+                  introduction:
+                    type: string
+                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
+                    nullable: true
+                  age:
+                    type: number
+                    description: 나이 (없으면 null)
+                    nullable: true
+            algorithmVersion:
+              type: string
+              description: 매칭 알고리즘 버전
+            quizSetId:
+              type: number
+              description: 후보가 속한 퀴즈 세트 ID
+            matchingType:
+              type: string
+              description: 매칭 타입 (ONE_TO_ONE / GROUP)
         success:
           type: boolean
           description: 성공 여부
@@ -1579,163 +1759,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-matches-1on1-1796185400:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - algorithmVersion
-          - candidates
-          - matchingType
-          - quizSetId
-          - received
-          - sent
-          type: object
-          properties:
-            candidates:
-              type: array
-              description: 추천 후보 목록 (매칭 점수 내림차순)
-              items:
-                required:
-                - location
-                - matchRate
-                - nickname
-                - profileImageUrl
-                - scoreBreakdown
-                - userId
-                type: object
-                properties:
-                  scoreBreakdown:
-                    required:
-                    - matchedQuestions
-                    - quizMatchRate
-                    - reasons
-                    - totalQuestions
-                    type: object
-                    properties:
-                      totalQuestions:
-                        type: number
-                        description: 전체 비교 문항 수
-                      reasons:
-                        type: array
-                        description: 매칭 사유 문구
-                        items:
-                          oneOf:
-                          - type: object
-                          - type: boolean
-                          - type: string
-                          - type: number
-                      quizMatchRate:
-                        type: number
-                        description: 퀴즈 답변 일치율 (0~100)
-                      matchedQuestions:
-                        type: number
-                        description: 일치한 문항 수
-                    description: 매칭 점수 상세
-                  gender:
-                    type: string
-                    description: "성별 (MALE / FEMALE, 없으면 null)"
-                    nullable: true
-                  nickname:
-                    type: string
-                    description: 닉네임
-                  location:
-                    type: string
-                    description: 사는 곳 코드
-                  matchRate:
-                    type: number
-                    description: 매칭 점수 (0~100)
-                  profileImageUrl:
-                    type: string
-                    description: 프로필 이미지 (캐리커쳐)
-                  userId:
-                    type: number
-                    description: 후보 회원 ID
-                  introduction:
-                    type: string
-                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
-                    nullable: true
-                  age:
-                    type: number
-                    description: 나이 (없으면 null)
-                    nullable: true
-            algorithmVersion:
-              type: string
-              description: 매칭 알고리즘 버전
-            quizSetId:
-              type: number
-              description: 후보가 속한 퀴즈 세트 ID
-            received:
-              type: array
-              description: 내가 받은 요청 목록
-              items:
-                required:
-                - createdAt
-                - id
-                - quizSetId
-                - receiverId
-                - requesterId
-                - status
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 요청 생성일시
-                  receiverId:
-                    type: number
-                    description: 수신자 ID
-                  requesterId:
-                    type: number
-                    description: 요청자 ID
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 매칭 ID
-                  status:
-                    type: string
-                    description: 상태
-            matchingType:
-              type: string
-              description: 매칭 타입 (ONE_TO_ONE / GROUP)
-            sent:
-              type: array
-              description: 내가 보낸 요청 목록
-              items:
-                required:
-                - createdAt
-                - id
-                - quizSetId
-                - receiverId
-                - requesterId
-                - status
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 요청 생성일시
-                  receiverId:
-                    type: number
-                    description: 수신자 ID
-                  requesterId:
-                    type: number
-                    description: 요청자 ID
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 매칭 ID
-                  status:
-                    type: string
-                    description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-users-nickname-nickname-availability-125958969:
       required:
       - error
@@ -1750,6 +1773,16 @@ components:
             available:
               type: boolean
               description: 닉네임 사용 가능 여부
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-logout-1831456372:
+      required:
+      - data
+      - error
+      - success
+      type: object
+      properties:
         success:
           type: boolean
           description: 성공 여부
@@ -1827,16 +1860,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-logout-1831456372:
-      required:
-      - data
-      - error
-      - success
-      type: object
-      properties:
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-quiz-progress-answers-1062387050:
       required:
       - choiceId
@@ -1911,60 +1934,6 @@ components:
             updatedAt:
               type: string
               description: 수정일시
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-matching-status-quizSetId-1585477117:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - groupMatchStatus
-          - quizSetId
-          type: object
-          properties:
-            groupMatchStatus:
-              type: string
-              description: 그룹 매칭 상태 (NONE / JOINED / DECLINED)
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            groupMatchRoomId:
-              type: number
-              description: 참여 중인 그룹 방 ID (JOINED 일 때만 존재)
-              nullable: true
-            personalMatch:
-              type: object
-              properties:
-                createdAt:
-                  type: string
-                  description: 요청 생성일시
-                  nullable: true
-                receiverId:
-                  type: number
-                  description: 수신자 ID
-                  nullable: true
-                requesterId:
-                  type: number
-                  description: 요청자 ID
-                  nullable: true
-                respondedAt:
-                  type: string
-                  description: 응답 일시 (없으면 null)
-                  nullable: true
-                id:
-                  type: number
-                  description: 매칭 ID
-                  nullable: true
-                status:
-                  type: string
-                  description: 매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED /
-                    EXPIRED)
-                  nullable: true
-              description: 1:1 매칭 정보 (없으면 null)
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -71,10 +71,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-06-06 00:09:02",
+                        "joinedAt" : "2026-06-08 23:07:25",
                         "role" : null,
-                        "createdAt" : "2026-06-06 00:09:02",
-                        "updatedAt" : "2026-06-06 00:09:02"
+                        "createdAt" : "2026-06-08 23:07:25",
+                        "updatedAt" : "2026-06-08 23:07:25"
                       },
                       "error" : null
                     }
@@ -86,7 +86,7 @@ paths:
       - Matching
       summary: 1:1 매칭 요청 목록 조회
       description: 퀴즈셋에 대한 내가 보낸/받은 1:1 매칭 요청 목록을 조회합니다.
-      operationId: personal-match-list
+      operationId: match-candidate-listpersonal-match-list
       parameters:
       - name: quizSetId
         in: query
@@ -100,7 +100,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-matches-1on1-795708692"
+                $ref: "#/components/schemas/api-v1-matches-1on1-1796185400"
               examples:
                 personal-match-list:
                   value: |-
@@ -124,6 +124,33 @@ paths:
                           "status" : "PENDING",
                           "createdAt" : "2026-05-01 12:00:00",
                           "respondedAt" : null
+                        } ]
+                      },
+                      "error" : null
+                    }
+                match-candidate-list:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "quizSetId" : 10,
+                        "matchingType" : "ONE_TO_ONE",
+                        "algorithmVersion" : "1.0",
+                        "candidates" : [ {
+                          "userId" : 2,
+                          "nickname" : "디토",
+                          "gender" : "FEMALE",
+                          "age" : 27,
+                          "introduction" : "한 단어로 표현하면 디토",
+                          "location" : "seoul",
+                          "profileImageUrl" : "f1",
+                          "matchRate" : 87.5,
+                          "scoreBreakdown" : {
+                            "quizMatchRate" : 87.5,
+                            "matchedQuestions" : 7,
+                            "totalQuestions" : 8,
+                            "reasons" : [ "전체 8문항 중 7문항이 일치했어요" ]
+                          }
                         } ]
                       },
                       "error" : null
@@ -277,7 +304,7 @@ paths:
                       "data" : {
                         "year" : 2026,
                         "month" : 6,
-                        "week" : 1,
+                        "week" : 2,
                         "quizSets" : [ {
                           "id" : 1,
                           "year" : 2026,
@@ -286,8 +313,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-06-05 00:09:02",
-                          "endDate" : "2026-06-07 00:09:02",
+                          "startDate" : "2026-06-07 23:07:25",
+                          "endDate" : "2026-06-09 23:07:25",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -304,8 +331,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-06-06 00:09:02",
-                            "updatedAt" : "2026-06-06 00:09:02"
+                            "createdAt" : "2026-06-08 23:07:25",
+                            "updatedAt" : "2026-06-08 23:07:25"
                           } ]
                         } ]
                       },
@@ -351,8 +378,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-06-06 00:09:02",
-                        "updatedAt" : "2026-06-06 00:09:02"
+                        "createdAt" : "2026-06-08 23:07:25",
+                        "updatedAt" : "2026-06-08 23:07:25"
                       },
                       "error" : null
                     }
@@ -363,8 +390,8 @@ paths:
       tags:
       - Users
       summary: 가입 정보 조회
-      description: "소셜 로그인에서 받아온 가입 정보(이메일·생년월일)를 조회합니다. 온보딩 화면 prefill 용도이며, 가입 미\
-        완료(PENDING) 회원도 접근할 수 있습니다."
+      description: "소셜 로그인에서 받아온 가입 정보(이메일·생년월일·이름·전화번호·성별)를 조회합니다. 온보딩 화면 prefill\
+        \ 용도이며, 가입 미완료(PENDING) 회원도 접근할 수 있습니다."
       operationId: user-me
       responses:
         "200":
@@ -372,7 +399,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-me506188890"
+                $ref: "#/components/schemas/api-v1-users-me861338172"
               examples:
                 user-me:
                   value: |-
@@ -380,7 +407,10 @@ paths:
                       "success" : true,
                       "data" : {
                         "email" : "user@kakao.com",
-                        "birthDate" : "1995-03-15"
+                        "birthDate" : "1995-03-15",
+                        "name" : "홍길동",
+                        "phoneNumber" : "010-1234-5678",
+                        "gender" : "MALE"
                       },
                       "error" : null
                     }
@@ -617,7 +647,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwNjcyMTM4LCJleHAiOjE3ODA2NzU3Mzh9.BNtQR0i7PBOim8yw9sIybeohDsPuN7cv_xYGBD4wKEUygl7gZ0KHyD7Iif_DWsjMMh83p_h5VoX9AmKRGDS3Ag"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwOTI3NjQyLCJleHAiOjE3ODA5MzEyNDJ9.TIAPrnr5nGrgqocSoiZb-lcaDLGsVWn9RCai10o-Iq6V1cUSfWZ7cJj00pP2W1iG-cSmpXJbioKMWWvzf5AaPA"
                       },
                       "error" : null
                     }
@@ -816,8 +846,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-06-06 00:09:02",
-                        "updatedAt" : "2026-06-06 00:09:02"
+                        "createdAt" : "2026-06-08 23:07:25",
+                        "updatedAt" : "2026-06-08 23:07:25"
                       },
                       "error" : null
                     }
@@ -1068,7 +1098,8 @@ paths:
       tags:
       - OAuth
       summary: 소셜 로그인 콜백
-      description: 신규 사용자는 토큰을 발급하지 않습니다. 회원가입이 필요합니다.
+      description: "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트한다. accessToken과 회\
+        원가입 필요 여부(signupRequired)는 쿼리 파라미터로, refreshToken은 HttpOnly 쿠키로 전달된다."
       operationId: oauth-callback
       parameters:
       - name: provider
@@ -1084,242 +1115,10 @@ paths:
         schema:
           type: string
       responses:
-        "200":
-          description: "200"
-          content:
-            application/json:
-              schema:
-                $ref: "#/components/schemas/api-v1-users-social-login-provider-callback-272682272"
-              examples:
-                oauth-callback-new-user:
-                  value: |-
-                    {
-                      "success" : true,
-                      "data" : { },
-                      "error" : null
-                    }
         "302":
           description: "302"
 components:
   schemas:
-    api-v1-matches-request-1327932902:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - createdAt
-          - id
-          - quizSetId
-          - receiverId
-          - requesterId
-          - status
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 요청 생성일시
-            receiverId:
-              type: number
-              description: 수신자 ID
-            requesterId:
-              type: number
-              description: 요청자 ID
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            id:
-              type: number
-              description: 생성된 매칭 ID
-            status:
-              type: string
-              description: 매칭 상태 (PENDING)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-quiz-progress-quiz-sets-id-1569645469:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - totalCount
-          type: object
-          properties:
-            quizzes:
-              type: array
-              items:
-                required:
-                - createdAt
-                - id
-                - order
-                - question
-                - quizSetId
-                - updatedAt
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 생성일시
-                  userAnswer:
-                    type: number
-                    description: 사용자가 선택한 choiceId (미답변 시 null)
-                    nullable: true
-                  question:
-                    type: string
-                    description: 퀴즈 질문
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 퀴즈 ID
-                  choices:
-                    type: array
-                    items:
-                      required:
-                      - content
-                      - id
-                      - order
-                      type: object
-                      properties:
-                        id:
-                          type: number
-                          description: 선택지 ID
-                        content:
-                          type: string
-                          description: 선택지 내용
-                        order:
-                          type: number
-                          description: 선택지 순서
-                  updatedAt:
-                    type: string
-                    description: 수정일시
-                  order:
-                    type: number
-                    description: 퀴즈 순서
-            totalCount:
-              type: number
-              description: 전체 퀴즈 수
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-auth-logout-1831456372:
-      required:
-      - data
-      - error
-      - success
-      type: object
-      properties:
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-matches-request-id-accept-2011455419:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - createdAt
-          - id
-          - quizSetId
-          - receiverId
-          - requesterId
-          - status
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 요청 생성일시
-            receiverId:
-              type: number
-              description: 수신자 ID
-            requesterId:
-              type: number
-              description: 요청자 ID
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            id:
-              type: number
-              description: 매칭 ID
-            status:
-              type: string
-              description: 변경된 매칭 상태 (ACCEPTED)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-social-login-provider-callback-272682272:
-      required:
-      - data
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          type: object
-          description: 빈 객체 (신규 사용자)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-2041696623:
-      required:
-      - caricature
-      - interests
-      - job
-      - location
-      type: object
-      properties:
-        caricature:
-          type: string
-          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
-        phoneNumber:
-          type: string
-          description: 전화번호 (010-0000-0000)
-          nullable: true
-        gender:
-          type: string
-          description: "성별 (MALE, FEMALE)"
-          nullable: true
-        nickname:
-          type: string
-          description: "닉네임 (2~10자, 한글·영문·숫자)"
-          nullable: true
-        name:
-          type: string
-          description: 이름
-          nullable: true
-        location:
-          type: string
-          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
-            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
-            \ jeonnam, gyeongbuk, gyeongnam, jeju"
-        job:
-          type: string
-          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
-            \ education, medical, finance, legal, manufacturing, distribution, service,\
-            \ construction, arts-media, research, public-admin, student, etc"
-        interests:
-          type: array
-          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
-            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
-            \ pets, etc"
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        age:
-          type: number
-          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
-          nullable: true
     api-v1-matches-group-join-1969670024:
       required:
       - quizSetId
@@ -1403,6 +1202,93 @@ components:
             roomId:
               type: number
               description: 배정된 그룹 방 ID
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-1327932902:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 생성된 매칭 ID
+            status:
+              type: string
+              description: 매칭 상태 (PENDING)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me861338172:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - birthDate
+          - email
+          - gender
+          - name
+          - phoneNumber
+          type: object
+          properties:
+            phoneNumber:
+              type: string
+              description: 전화번호 010-XXXX-XXXX (미동의 시 null)
+            gender:
+              type: string
+              description: 성별 MALE/FEMALE (미동의 시 null)
+            name:
+              type: string
+              description: 이름 (미동의 시 null)
+            birthDate:
+              type: string
+              description: 생년월일 (없거나 음력이면 null)
+            email:
+              type: string
+              description: 이메일 (없으면 null)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
         success:
           type: boolean
           description: 성공 여부
@@ -1529,23 +1415,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-refresh1774976609:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-request-793255208:
       required:
       - quizSetId
@@ -1567,7 +1436,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-me506188890:
+    api-v1-quiz-progress-quiz-sets-id-1569645469:
       required:
       - error
       - success
@@ -1575,16 +1444,64 @@ components:
       properties:
         data:
           required:
-          - birthDate
-          - email
+          - totalCount
           type: object
           properties:
-            birthDate:
-              type: string
-              description: 생년월일 (없거나 음력이면 null)
-            email:
-              type: string
-              description: 이메일 (없으면 null)
+            quizzes:
+              type: array
+              items:
+                required:
+                - createdAt
+                - id
+                - order
+                - question
+                - quizSetId
+                - updatedAt
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 생성일시
+                  userAnswer:
+                    type: number
+                    description: 사용자가 선택한 choiceId (미답변 시 null)
+                    nullable: true
+                  question:
+                    type: string
+                    description: 퀴즈 질문
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 퀴즈 ID
+                  choices:
+                    type: array
+                    items:
+                      required:
+                      - content
+                      - id
+                      - order
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                          description: 선택지 ID
+                        content:
+                          type: string
+                          description: 선택지 내용
+                        order:
+                          type: number
+                          description: 선택지 순서
+                  updatedAt:
+                    type: string
+                    description: 수정일시
+                  order:
+                    type: number
+                    description: 퀴즈 순서
+            totalCount:
+              type: number
+              description: 전체 퀴즈 수
         success:
           type: boolean
           description: 성공 여부
@@ -1659,6 +1576,163 @@ components:
             status:
               type: string
               description: "진행 상태 (NOT_STARTED, IN_PROGRESS, COMPLETED)"
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-1on1-1796185400:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - algorithmVersion
+          - candidates
+          - matchingType
+          - quizSetId
+          - received
+          - sent
+          type: object
+          properties:
+            candidates:
+              type: array
+              description: 추천 후보 목록 (매칭 점수 내림차순)
+              items:
+                required:
+                - location
+                - matchRate
+                - nickname
+                - profileImageUrl
+                - scoreBreakdown
+                - userId
+                type: object
+                properties:
+                  scoreBreakdown:
+                    required:
+                    - matchedQuestions
+                    - quizMatchRate
+                    - reasons
+                    - totalQuestions
+                    type: object
+                    properties:
+                      totalQuestions:
+                        type: number
+                        description: 전체 비교 문항 수
+                      reasons:
+                        type: array
+                        description: 매칭 사유 문구
+                        items:
+                          oneOf:
+                          - type: object
+                          - type: boolean
+                          - type: string
+                          - type: number
+                      quizMatchRate:
+                        type: number
+                        description: 퀴즈 답변 일치율 (0~100)
+                      matchedQuestions:
+                        type: number
+                        description: 일치한 문항 수
+                    description: 매칭 점수 상세
+                  gender:
+                    type: string
+                    description: "성별 (MALE / FEMALE, 없으면 null)"
+                    nullable: true
+                  nickname:
+                    type: string
+                    description: 닉네임
+                  location:
+                    type: string
+                    description: 사는 곳 코드
+                  matchRate:
+                    type: number
+                    description: 매칭 점수 (0~100)
+                  profileImageUrl:
+                    type: string
+                    description: 프로필 이미지 (캐리커쳐)
+                  userId:
+                    type: number
+                    description: 후보 회원 ID
+                  introduction:
+                    type: string
+                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
+                    nullable: true
+                  age:
+                    type: number
+                    description: 나이 (없으면 null)
+                    nullable: true
+            algorithmVersion:
+              type: string
+              description: 매칭 알고리즘 버전
+            quizSetId:
+              type: number
+              description: 후보가 속한 퀴즈 세트 ID
+            received:
+              type: array
+              description: 내가 받은 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태
+            matchingType:
+              type: string
+              description: 매칭 타입 (ONE_TO_ONE / GROUP)
+            sent:
+              type: array
+              description: 내가 보낸 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
         success:
           type: boolean
           description: 성공 여부
@@ -1750,6 +1824,16 @@ components:
             updatedAt:
               type: string
               description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-logout-1831456372:
+      required:
+      - data
+      - error
+      - success
+      type: object
+      properties:
         success:
           type: boolean
           description: 성공 여부
@@ -1884,6 +1968,43 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-matches-request-id-accept-2011455419:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 매칭 ID
+            status:
+              type: string
+              description: 변경된 매칭 상태 (ACCEPTED)
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-users-id-leave-1444522536:
       required:
       - error
@@ -1921,83 +2042,58 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-matches-1on1-795708692:
+    api-v1-users-2041696623:
       required:
-      - error
-      - success
+      - caricature
+      - interests
+      - job
+      - location
       type: object
       properties:
-        data:
-          required:
-          - received
-          - sent
-          type: object
-          properties:
-            received:
-              type: array
-              description: 내가 받은 요청 목록
-              items:
-                required:
-                - createdAt
-                - id
-                - quizSetId
-                - receiverId
-                - requesterId
-                - status
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 요청 생성일시
-                  receiverId:
-                    type: number
-                    description: 수신자 ID
-                  requesterId:
-                    type: number
-                    description: 요청자 ID
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 매칭 ID
-                  status:
-                    type: string
-                    description: 상태
-            sent:
-              type: array
-              description: 내가 보낸 요청 목록
-              items:
-                required:
-                - createdAt
-                - id
-                - quizSetId
-                - receiverId
-                - requesterId
-                - status
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 요청 생성일시
-                  receiverId:
-                    type: number
-                    description: 수신자 ID
-                  requesterId:
-                    type: number
-                    description: 요청자 ID
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 매칭 ID
-                  status:
-                    type: string
-                    description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
-        success:
-          type: boolean
-          description: 성공 여부
+        caricature:
+          type: string
+          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
+        phoneNumber:
+          type: string
+          description: 전화번호 (010-0000-0000)
+          nullable: true
+        gender:
+          type: string
+          description: "성별 (MALE, FEMALE)"
+          nullable: true
+        nickname:
+          type: string
+          description: "닉네임 (2~10자, 한글·영문·숫자)"
+          nullable: true
+        name:
+          type: string
+          description: 이름
+          nullable: true
+        location:
+          type: string
+          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
+            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
+            \ jeonnam, gyeongbuk, gyeongnam, jeju"
+        job:
+          type: string
+          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
+            \ education, medical, finance, legal, manufacturing, distribution, service,\
+            \ construction, arts-media, research, public-admin, student, etc"
+        interests:
+          type: array
+          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
+            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
+            \ pets, etc"
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        age:
+          type: number
+          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
+          nullable: true
     api-v1-users-id-profile-829103765:
       required:
       - error

--- a/api/src/test/kotlin/com/ditto/api/match/MatchAdminControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchAdminControllerTest.kt
@@ -1,0 +1,65 @@
+package com.ditto.api.match
+
+import com.ditto.api.match.controller.MatchAdminController
+import com.ditto.api.match.service.MatchmakingService
+import com.ditto.api.support.ControllerUnitTest
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import io.mockk.justRun
+import io.mockk.mockk
+import io.mockk.verify
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
+import org.springframework.restdocs.request.RequestDocumentation.pathParameters
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class MatchAdminControllerTest : ControllerUnitTest() {
+
+    private val matchmakingService: MatchmakingService = mockk()
+
+    override val controller = MatchAdminController(matchmakingService)
+
+    @Test
+    @DisplayName("특정 퀴즈셋의 매칭 후보를 재생성한다")
+    fun regenerateMatching() {
+        justRun { matchmakingService.generateMatchingCandidates(any()) }
+
+        mockMvc.perform(post("/api/v1/admin/quiz-sets/{quizSetId}/matching/regenerate", 10L))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andDo(
+                document(
+                    "admin-match-regenerate",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    pathParameters(parameterWithName("quizSetId").description("퀴즈 세트 ID")),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("[Admin] 퀴즈셋 매칭 재생성")
+                            .description(
+                                "특정 퀴즈셋의 1:1 매칭 후보를 재생성합니다(기존 후보 삭제 후 재계산). " +
+                                    "마감·후보 존재 여부와 무관하게 실행됩니다.",
+                            )
+                            .pathParameters(parameterWithName("quizSetId").description("퀴즈 세트 ID"))
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data").description("응답 데이터 (없음)").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)").optional(),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+
+        verify { matchmakingService.generateMatchingCandidates(10L) }
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/MatchCandidateControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchCandidateControllerTest.kt
@@ -1,0 +1,103 @@
+package com.ditto.api.match
+
+import com.ditto.api.match.controller.MatchCandidateController
+import com.ditto.api.match.dto.Candidate
+import com.ditto.api.match.dto.MatchCandidateResponse
+import com.ditto.api.match.dto.ScoreSummary
+import com.ditto.api.match.service.MatchCandidateService
+import com.ditto.api.support.ControllerUnitTest
+import com.ditto.domain.quiz.entity.MatchingType
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import io.mockk.every
+import io.mockk.mockk
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class MatchCandidateControllerTest : ControllerUnitTest() {
+
+    private val matchCandidateService: MatchCandidateService = mockk()
+
+    override val controller = MatchCandidateController(matchCandidateService)
+
+    @Test
+    @DisplayName("1:1 매칭 추천 후보 목록을 조회한다")
+    fun getMatchCandidates() {
+        every { matchCandidateService.getMatchCandidates(any()) } returns MatchCandidateResponse(
+            quizSetId = 10L,
+            matchingType = MatchingType.ONE_TO_ONE,
+            algorithmVersion = "1.0",
+            candidates = listOf(
+                Candidate(
+                    userId = 2L,
+                    nickname = "디토",
+                    gender = "FEMALE",
+                    age = 27,
+                    introduction = "한 단어로 표현하면 디토",
+                    location = "seoul",
+                    profileImageUrl = "f1",
+                    matchRate = 87.5,
+                    scoreBreakdown = ScoreSummary(
+                        quizMatchRate = 87.5,
+                        matchedQuestions = 7,
+                        totalQuestions = 8,
+                        reasons = listOf("전체 8문항 중 7문항이 일치했어요"),
+                    ),
+                ),
+            ),
+        )
+
+        mockMvc.perform(get("/api/v1/matches/1on1"))
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.quizSetId").value(10))
+            .andExpect(jsonPath("$.data.candidates.length()").value(1))
+            .andExpect(jsonPath("$.data.candidates[0].userId").value(2))
+            .andDo(
+                document(
+                    "match-candidate-list",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Matching")
+                            .summary("1:1 매칭 추천 후보 목록 조회")
+                            .description(
+                                "회원이 최근 완료한 1:1 퀴즈셋의 추천 후보를 매칭 점수 내림차순으로 조회합니다. " +
+                                    "대상 퀴즈셋은 서버가 결정하며, 응답의 quizSetId 로 확인합니다.",
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.quizSetId").description("후보가 속한 퀴즈 세트 ID"),
+                                fieldWithPath("data.matchingType").description("매칭 타입 (ONE_TO_ONE / GROUP)"),
+                                fieldWithPath("data.algorithmVersion").description("매칭 알고리즘 버전"),
+                                fieldWithPath("data.candidates[]").description("추천 후보 목록 (매칭 점수 내림차순)"),
+                                fieldWithPath("data.candidates[].userId").description("후보 회원 ID"),
+                                fieldWithPath("data.candidates[].nickname").description("닉네임"),
+                                fieldWithPath("data.candidates[].gender").description("성별 (MALE / FEMALE, 없으면 null)").optional(),
+                                fieldWithPath("data.candidates[].age").description("나이 (없으면 null)").optional(),
+                                fieldWithPath("data.candidates[].introduction").description("자기소개 (소개노트 한 단어, 없으면 null)").optional(),
+                                fieldWithPath("data.candidates[].location").description("사는 곳 코드"),
+                                fieldWithPath("data.candidates[].profileImageUrl").description("프로필 이미지 (캐리커쳐)"),
+                                fieldWithPath("data.candidates[].matchRate").description("매칭 점수 (0~100)"),
+                                fieldWithPath("data.candidates[].scoreBreakdown").description("매칭 점수 상세"),
+                                fieldWithPath("data.candidates[].scoreBreakdown.quizMatchRate").description("퀴즈 답변 일치율 (0~100)"),
+                                fieldWithPath("data.candidates[].scoreBreakdown.matchedQuestions").description("일치한 문항 수"),
+                                fieldWithPath("data.candidates[].scoreBreakdown.totalQuestions").description("전체 비교 문항 수"),
+                                fieldWithPath("data.candidates[].scoreBreakdown.reasons[]").description("매칭 사유 문구"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+}

--- a/api/src/test/kotlin/com/ditto/api/match/MatchCandidateServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchCandidateServiceTest.kt
@@ -1,0 +1,208 @@
+package com.ditto.api.match
+
+import com.ditto.api.match.service.MatchCandidateService
+import com.ditto.api.support.IntegrationTest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.ErrorException
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.intronote.entity.IntroNote
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.intronote.repository.IntroNoteRepository
+import com.ditto.domain.match.MatchCandidateFixture
+import com.ditto.domain.match.repository.MatchCandidateRepository
+import com.ditto.domain.member.MemberFixture
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.Location
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.QuizProgressFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.entity.MatchingType
+import com.ditto.domain.quiz.entity.QuizSet
+import com.ditto.domain.quiz.repository.QuizProgressRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+class MatchCandidateServiceTest(
+    private val matchCandidateService: MatchCandidateService,
+    private val quizSetRepository: QuizSetRepository,
+    private val quizProgressRepository: QuizProgressRepository,
+    private val matchCandidateRepository: MatchCandidateRepository,
+    private val memberRepository: MemberRepository,
+    private val introNoteRepository: IntroNoteRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    fun saveMember(
+        nickname: String,
+        gender: Gender? = Gender.FEMALE,
+        age: Int? = 27,
+        location: Location? = Location.SEOUL,
+        caricature: String? = "c1",
+    ): Member = memberRepository.save(
+        MemberFixture.create(
+            nickname = nickname,
+            status = MemberStatus.ACTIVE,
+            gender = gender,
+            age = age,
+            location = location,
+            caricature = caricature,
+        ),
+    )
+
+    // 회원이 완료(COMPLETED)한 1:1 퀴즈셋을 만든다. 후보는 마감된 셋에만 생기므로 노출 기준이 된다.
+    fun completeOneToOneQuizSet(ownerId: Long): QuizSet {
+        val quizSet = quizSetRepository.save(QuizSetFixture.create(matchingType = MatchingType.ONE_TO_ONE))
+        val progress = QuizProgressFixture.create(memberId = ownerId, quizSetId = quizSet.id, totalCount = 1)
+        progress.recordAnswer() // NOT_STARTED -> COMPLETED
+        quizProgressRepository.save(progress)
+        return quizSet
+    }
+
+    fun saveCandidate(quizSetId: Long, ownerId: Long, otherId: Long, score: Double, matched: Int = 7, total: Int = 8) {
+        matchCandidateRepository.save(
+            MatchCandidateFixture.create(
+                ownerMemberId = ownerId,
+                otherMemberId = otherId,
+                quizSetId = quizSetId,
+                score = score,
+                matchedQuestionCount = matched,
+                totalQuestionCount = total,
+            ),
+        )
+    }
+
+    "참여(완료)한 1:1 퀴즈셋이 없으면 NOT_FOUND 를 던진다" {
+        shouldThrow<WarnException> {
+            matchCandidateService.getMatchCandidates(memberId = 999L)
+        }.errorCode shouldBe ErrorCode.NOT_FOUND
+    }
+
+    "후보를 score 내림차순, 동점이면 otherMemberId 오름차순으로 반환한다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val a = saveMember("후보A") // a.id < b.id
+        val b = saveMember("후보B")
+        val c = saveMember("후보C")
+        // 동점(90)인 a·b 의 후보 행을 b 먼저 저장해 DB 자연 반환순서를 b→a 로 만든다.
+        // 안정 정렬 특성상 in-memory thenBy{otherMemberId} 가 있어야만 a(작은 id)가 앞으로 재정렬되며,
+        // thenBy 가 빠지면 [b, a, c] 가 되어 아래 단언이 실패한다 → 2차 정렬을 실제로 검증한다.
+        saveCandidate(quizSet.id, owner.id, b.id, score = 90.0)
+        saveCandidate(quizSet.id, owner.id, a.id, score = 90.0)
+        saveCandidate(quizSet.id, owner.id, c.id, score = 70.0)
+
+        val result = matchCandidateService.getMatchCandidates(owner.id)
+
+        result.quizSetId shouldBe quizSet.id
+        result.matchingType shouldBe MatchingType.ONE_TO_ONE
+        result.algorithmVersion shouldBe "1.0"
+        result.candidates.map { it.userId } shouldBe listOf(a.id, b.id, c.id)
+        result.candidates.first().matchRate shouldBe 90.0
+    }
+
+    "멤버 프로필과 소개노트(ONE_WORD)를 후보 응답에 매핑한다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val member = saveMember("디토", gender = Gender.FEMALE, age = 27, location = Location.SEOUL, caricature = "f1")
+        introNoteRepository.save(
+            IntroNote.create(memberId = member.id, question = IntroQuestion.ONE_WORD, answer = "한 단어로 표현하면 디토"),
+        )
+        saveCandidate(quizSet.id, owner.id, member.id, score = 87.5, matched = 7, total = 8)
+
+        val candidate = matchCandidateService.getMatchCandidates(owner.id).candidates.single()
+
+        candidate.userId shouldBe member.id
+        candidate.nickname shouldBe "디토"
+        candidate.gender shouldBe "FEMALE"
+        candidate.age shouldBe 27
+        candidate.location shouldBe "seoul"
+        candidate.profileImageUrl shouldBe "f1"
+        candidate.introduction shouldBe "한 단어로 표현하면 디토"
+        candidate.matchRate shouldBe 87.5
+        candidate.scoreBreakdown.quizMatchRate shouldBe 87.5
+        candidate.scoreBreakdown.matchedQuestions shouldBe 7
+        candidate.scoreBreakdown.totalQuestions shouldBe 8
+        candidate.scoreBreakdown.reasons shouldBe listOf("전체 8문항 중 7문항이 일치했어요")
+    }
+
+    "gender·age 가 없는 후보는 null 로 매핑한다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val member = saveMember("미상", gender = null, age = null)
+        saveCandidate(quizSet.id, owner.id, member.id, score = 80.0)
+
+        val candidate = matchCandidateService.getMatchCandidates(owner.id).candidates.single()
+
+        candidate.gender shouldBe null
+        candidate.age shouldBe null
+    }
+
+    "소개노트가 없으면 introduction 은 null 이다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val member = saveMember("무소개")
+        saveCandidate(quizSet.id, owner.id, member.id, score = 80.0)
+
+        matchCandidateService.getMatchCandidates(owner.id).candidates.single().introduction shouldBe null
+    }
+
+    "후보 회원의 사는곳(location)이 없으면 INTERNAL_ERROR 를 던진다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val member = saveMember("노로케이션", location = null, caricature = "c1")
+        saveCandidate(quizSet.id, owner.id, member.id, score = 80.0)
+
+        shouldThrow<ErrorException> {
+            matchCandidateService.getMatchCandidates(owner.id)
+        }.errorCode shouldBe ErrorCode.INTERNAL_ERROR
+    }
+
+    "후보 회원의 캐리커쳐(profileImageUrl)가 없으면 INTERNAL_ERROR 를 던진다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val member = saveMember("노캐리커쳐", location = Location.SEOUL, caricature = null)
+        saveCandidate(quizSet.id, owner.id, member.id, score = 80.0)
+
+        shouldThrow<ErrorException> {
+            matchCandidateService.getMatchCandidates(owner.id)
+        }.errorCode shouldBe ErrorCode.INTERNAL_ERROR
+    }
+
+    "완료한 1:1 퀴즈셋은 있으나 후보가 없으면 빈 목록을 반환한다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+
+        val result = matchCandidateService.getMatchCandidates(owner.id)
+
+        result.quizSetId shouldBe quizSet.id
+        result.matchingType shouldBe MatchingType.ONE_TO_ONE
+        result.candidates.size shouldBe 0
+    }
+
+    "프로필(회원)이 존재하지 않는 후보는 목록에서 제외한다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val present = saveMember("정상후보")
+        saveCandidate(quizSet.id, owner.id, present.id, score = 80.0)
+        saveCandidate(quizSet.id, owner.id, otherId = 9_999_999L, score = 90.0) // 회원 레코드 없음
+
+        val result = matchCandidateService.getMatchCandidates(owner.id)
+
+        result.candidates.map { it.userId } shouldBe listOf(present.id)
+    }
+
+    "소개노트 답변이 공백이면 introduction 은 null 이다" {
+        val owner = saveMember("주인")
+        val quizSet = completeOneToOneQuizSet(owner.id)
+        val member = saveMember("공백소개")
+        introNoteRepository.save(
+            IntroNote.create(memberId = member.id, question = IntroQuestion.ONE_WORD, answer = "   "),
+        )
+        saveCandidate(quizSet.id, owner.id, member.id, score = 80.0)
+
+        matchCandidateService.getMatchCandidates(owner.id).candidates.single().introduction shouldBe null
+    }
+})

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingStatusControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingStatusControllerTest.kt
@@ -1,9 +1,8 @@
 package com.ditto.api.match
 
 import com.ditto.api.match.controller.MatchingStatusController
-import com.ditto.api.match.dto.GroupMatchStatus
 import com.ditto.api.match.dto.MatchingStatusResponse
-import com.ditto.api.match.dto.PersonalMatchSummary
+import com.ditto.api.match.dto.PersonalMatchResponse
 import com.ditto.api.match.service.MatchingStatusService
 import com.ditto.api.support.ControllerUnitTest
 import com.ditto.domain.match.entity.PersonalMatchStatus
@@ -30,30 +29,53 @@ class MatchingStatusControllerTest : ControllerUnitTest() {
 
     override val controller = MatchingStatusController(matchingStatusService)
 
+    private fun sampleRequest(
+        id: Long,
+        requesterId: Long,
+        receiverId: Long,
+        status: PersonalMatchStatus,
+        respondedAt: LocalDateTime? = null,
+    ) = PersonalMatchResponse(
+        id = id,
+        quizSetId = 10L,
+        requesterId = requesterId,
+        receiverId = receiverId,
+        status = status,
+        createdAt = LocalDateTime.of(2026, 5, 1, 12, 0),
+        respondedAt = respondedAt,
+    )
+
     @Test
-    @DisplayName("매칭 상태를 조회한다 — 1:1 ACCEPTED, 그룹 JOINED")
-    fun getMatchingStatus_withAllStatuses() {
+    @DisplayName("매칭 상태를 조회한다 — 보낸/받은 요청, 수락 매칭, 그룹 참여")
+    fun getMatchingStatus() {
         every { matchingStatusService.getMatchingStatus(any(), any()) } returns MatchingStatusResponse(
             quizSetId = 10L,
-            personalMatch = PersonalMatchSummary(
-                id = 1L,
-                requesterId = 1L,
-                receiverId = 2L,
-                status = PersonalMatchStatus.ACCEPTED,
-                createdAt = LocalDateTime.of(2026, 5, 1, 12, 0),
-                respondedAt = LocalDateTime.of(2026, 5, 1, 12, 30),
+            sentRequests = listOf(
+                sampleRequest(
+                    id = 1L, requesterId = 1L, receiverId = 2L,
+                    status = PersonalMatchStatus.ACCEPTED,
+                    respondedAt = LocalDateTime.of(2026, 5, 1, 12, 30),
+                ),
             ),
-            groupMatchStatus = GroupMatchStatus.JOINED,
-            groupMatchRoomId = 5L,
+            receivedRequests = listOf(
+                sampleRequest(id = 2L, requesterId = 3L, receiverId = 1L, status = PersonalMatchStatus.PENDING),
+            ),
+            hasAcceptedMatch = true,
+            acceptedMatchUserId = 2L,
+            groupDeclined = false,
+            groupJoined = true,
+            groupJoinPending = false,
         )
 
         mockMvc.perform(get("/api/v1/matching/status/{quizSetId}", 10L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
             .andExpect(jsonPath("$.data.quizSetId").value(10))
-            .andExpect(jsonPath("$.data.personalMatch.status").value("ACCEPTED"))
-            .andExpect(jsonPath("$.data.groupMatchStatus").value("JOINED"))
-            .andExpect(jsonPath("$.data.groupMatchRoomId").value(5))
+            .andExpect(jsonPath("$.data.sentRequests.length()").value(1))
+            .andExpect(jsonPath("$.data.receivedRequests.length()").value(1))
+            .andExpect(jsonPath("$.data.hasAcceptedMatch").value(true))
+            .andExpect(jsonPath("$.data.acceptedMatchUserId").value(2))
+            .andExpect(jsonPath("$.data.groupJoined").value(true))
             .andDo(
                 document(
                     "matching-status",
@@ -65,8 +87,9 @@ class MatchingStatusControllerTest : ControllerUnitTest() {
                             .summary("매칭 상태 조회")
                             .description(
                                 "퀴즈셋에 대한 나의 매칭 현황을 조회합니다.\n\n" +
-                                    "- **personalMatch**: ACCEPTED > PENDING 우선 반환. 없으면 null\n" +
-                                    "- **groupMatchStatus**: DECLINED > JOINED > NONE 순으로 판단",
+                                    "- **sentRequests / receivedRequests**: 내가 보낸/받은 1:1 매칭 요청 목록\n" +
+                                    "- **hasAcceptedMatch / acceptedMatchUserId**: 수락된 1:1 매칭 보유 여부와 상대 ID\n" +
+                                    "- **groupDeclined / groupJoined / groupJoinPending**: 그룹 매칭 거절 / 활성 방 참여 / 인원 대기 상태",
                             )
                             .pathParameters(
                                 parameterWithName("quizSetId").description("퀴즈 세트 ID"),
@@ -74,15 +97,27 @@ class MatchingStatusControllerTest : ControllerUnitTest() {
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),
                                 fieldWithPath("data.quizSetId").description("퀴즈 세트 ID"),
-                                fieldWithPath("data.personalMatch").description("1:1 매칭 정보 (없으면 null)").optional(),
-                                fieldWithPath("data.personalMatch.id").description("매칭 ID").optional(),
-                                fieldWithPath("data.personalMatch.requesterId").description("요청자 ID").optional(),
-                                fieldWithPath("data.personalMatch.receiverId").description("수신자 ID").optional(),
-                                fieldWithPath("data.personalMatch.status").description("매칭 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)").optional(),
-                                fieldWithPath("data.personalMatch.createdAt").description("요청 생성일시").optional(),
-                                fieldWithPath("data.personalMatch.respondedAt").description("응답 일시 (없으면 null)").optional(),
-                                fieldWithPath("data.groupMatchStatus").description("그룹 매칭 상태 (NONE / JOINED / DECLINED)"),
-                                fieldWithPath("data.groupMatchRoomId").description("참여 중인 그룹 방 ID (JOINED 일 때만 존재)").optional(),
+                                fieldWithPath("data.sentRequests[]").description("내가 보낸 1:1 매칭 요청 목록"),
+                                fieldWithPath("data.sentRequests[].id").description("매칭 ID"),
+                                fieldWithPath("data.sentRequests[].quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.sentRequests[].requesterId").description("요청자 ID"),
+                                fieldWithPath("data.sentRequests[].receiverId").description("수신자 ID"),
+                                fieldWithPath("data.sentRequests[].status").description("상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)"),
+                                fieldWithPath("data.sentRequests[].createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.sentRequests[].respondedAt").description("응답 일시 (없으면 null)").optional(),
+                                fieldWithPath("data.receivedRequests[]").description("내가 받은 1:1 매칭 요청 목록"),
+                                fieldWithPath("data.receivedRequests[].id").description("매칭 ID"),
+                                fieldWithPath("data.receivedRequests[].quizSetId").description("퀴즈 세트 ID"),
+                                fieldWithPath("data.receivedRequests[].requesterId").description("요청자 ID"),
+                                fieldWithPath("data.receivedRequests[].receiverId").description("수신자 ID"),
+                                fieldWithPath("data.receivedRequests[].status").description("상태"),
+                                fieldWithPath("data.receivedRequests[].createdAt").description("요청 생성일시"),
+                                fieldWithPath("data.receivedRequests[].respondedAt").description("응답 일시 (없으면 null)").optional(),
+                                fieldWithPath("data.hasAcceptedMatch").description("수락된 1:1 매칭 보유 여부"),
+                                fieldWithPath("data.acceptedMatchUserId").description("수락된 매칭 상대 회원 ID (없으면 null)").optional(),
+                                fieldWithPath("data.groupDeclined").description("그룹 매칭 거절 여부"),
+                                fieldWithPath("data.groupJoined").description("활성화된(3명 이상) 그룹 방 참여 여부"),
+                                fieldWithPath("data.groupJoinPending").description("그룹 방 참여했으나 인원 대기(비활성) 여부"),
                                 fieldWithPath("error").description("에러 정보 (성공 시 null)"),
                             )
                             .build(),
@@ -92,36 +127,25 @@ class MatchingStatusControllerTest : ControllerUnitTest() {
     }
 
     @Test
-    @DisplayName("매칭이 없으면 personalMatch=null, groupMatchStatus=NONE 을 반환한다")
-    fun getMatchingStatus_noMatches() {
+    @DisplayName("매칭 이력이 없으면 빈 목록과 false 플래그를 반환한다")
+    fun getMatchingStatus_empty() {
         every { matchingStatusService.getMatchingStatus(any(), any()) } returns MatchingStatusResponse(
             quizSetId = 10L,
-            personalMatch = null,
-            groupMatchStatus = GroupMatchStatus.NONE,
-            groupMatchRoomId = null,
+            sentRequests = emptyList(),
+            receivedRequests = emptyList(),
+            hasAcceptedMatch = false,
+            acceptedMatchUserId = null,
+            groupDeclined = false,
+            groupJoined = false,
+            groupJoinPending = false,
         )
 
         mockMvc.perform(get("/api/v1/matching/status/{quizSetId}", 10L))
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.personalMatch").doesNotExist())
-            .andExpect(jsonPath("$.data.groupMatchStatus").value("NONE"))
-            .andExpect(jsonPath("$.data.groupMatchRoomId").doesNotExist())
-    }
-
-    @Test
-    @DisplayName("그룹 매칭을 거절한 경우 DECLINED 를 반환한다")
-    fun getMatchingStatus_declined() {
-        every { matchingStatusService.getMatchingStatus(any(), any()) } returns MatchingStatusResponse(
-            quizSetId = 10L,
-            personalMatch = null,
-            groupMatchStatus = GroupMatchStatus.DECLINED,
-            groupMatchRoomId = null,
-        )
-
-        mockMvc.perform(get("/api/v1/matching/status/{quizSetId}", 10L))
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.groupMatchStatus").value("DECLINED"))
+            .andExpect(jsonPath("$.data.sentRequests.length()").value(0))
+            .andExpect(jsonPath("$.data.hasAcceptedMatch").value(false))
+            .andExpect(jsonPath("$.data.acceptedMatchUserId").doesNotExist())
+            .andExpect(jsonPath("$.data.groupJoinPending").value(false))
     }
 }

--- a/api/src/test/kotlin/com/ditto/api/match/MatchingStatusServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchingStatusServiceTest.kt
@@ -1,6 +1,5 @@
 package com.ditto.api.match
 
-import com.ditto.api.match.dto.GroupMatchStatus
 import com.ditto.api.match.service.MatchingStatusService
 import com.ditto.api.support.IntegrationTest
 import com.ditto.domain.match.GroupMatchFixture
@@ -13,7 +12,6 @@ import com.ditto.domain.match.repository.GroupMatchMemberRepository
 import com.ditto.domain.match.repository.GroupMatchRepository
 import com.ditto.domain.match.repository.PersonalMatchRepository
 import io.kotest.matchers.shouldBe
-import io.kotest.matchers.shouldNotBe
 import javax.sql.DataSource
 
 class MatchingStatusServiceTest(
@@ -28,113 +26,109 @@ class MatchingStatusServiceTest(
     val memberId = 1L
     val quizSetId = 10L
 
-    "아무 매칭도 없으면 personalMatch 가 null 로 반환된다" {
-        // when
+    "아무 매칭도 없으면 빈 목록과 false 플래그를 반환한다" {
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.personalMatch shouldBe null
         result.quizSetId shouldBe quizSetId
+        result.sentRequests.size shouldBe 0
+        result.receivedRequests.size shouldBe 0
+        result.hasAcceptedMatch shouldBe false
+        result.acceptedMatchUserId shouldBe null
+        result.groupDeclined shouldBe false
+        result.groupJoined shouldBe false
+        result.groupJoinPending shouldBe false
     }
 
-    "PENDING 1:1 매칭이 있으면 해당 매칭을 반환한다" {
-        // given
+    "내가 보낸 PENDING 요청은 sentRequests 에 담기고 hasAcceptedMatch 는 false 다" {
         personalMatchRepository.save(
-            PersonalMatchFixture.create(requesterId = memberId, receiverId = 2L, quizSetId = quizSetId)
+            PersonalMatchFixture.create(requesterId = memberId, receiverId = 2L, quizSetId = quizSetId),
         )
 
-        // when
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.personalMatch shouldNotBe null
-        result.personalMatch!!.status shouldBe PersonalMatchStatus.PENDING
+        result.sentRequests.size shouldBe 1
+        result.sentRequests[0].requesterId shouldBe memberId
+        result.sentRequests[0].status shouldBe PersonalMatchStatus.PENDING
+        result.hasAcceptedMatch shouldBe false
     }
 
-    "PENDING 과 ACCEPTED 매칭이 모두 있을 때 ACCEPTED 가 우선 반환된다" {
-        // given
-        personalMatchRepository.save(
-            PersonalMatchFixture.create(
-                requesterId = memberId, receiverId = 2L, quizSetId = quizSetId,
-                status = PersonalMatchStatus.PENDING,
-            )
-        )
+    "내가 요청자인 ACCEPTED 매칭이 있으면 hasAcceptedMatch=true, 상대 ID를 반환한다" {
         personalMatchRepository.save(
             PersonalMatchFixture.create(
                 requesterId = memberId, receiverId = 3L, quizSetId = quizSetId,
                 status = PersonalMatchStatus.ACCEPTED,
-            )
+            ),
         )
 
-        // when
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
+        result.hasAcceptedMatch shouldBe true
+        result.acceptedMatchUserId shouldBe 3L
     }
 
-    "수신자 입장에서도 ACCEPTED 매칭이 반환된다" {
-        // given
+    "내가 수신자인 ACCEPTED 매칭도 hasAcceptedMatch=true, 요청자 ID를 반환한다" {
         personalMatchRepository.save(
             PersonalMatchFixture.create(
                 requesterId = 2L, receiverId = memberId, quizSetId = quizSetId,
                 status = PersonalMatchStatus.ACCEPTED,
-            )
+            ),
         )
 
-        // when
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.personalMatch shouldNotBe null
-        result.personalMatch!!.status shouldBe PersonalMatchStatus.ACCEPTED
-        result.personalMatch!!.receiverId shouldBe memberId
+        result.hasAcceptedMatch shouldBe true
+        result.acceptedMatchUserId shouldBe 2L
+        result.receivedRequests.size shouldBe 1
+        result.receivedRequests[0].requesterId shouldBe 2L
     }
 
-    "그룹 매칭 이력이 없으면 NONE 이 반환된다" {
-        // when
+    "그룹 이력이 없으면 declined/joined/pending 모두 false 다" {
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.groupMatchStatus shouldBe GroupMatchStatus.NONE
-        result.groupMatchRoomId shouldBe null
+        result.groupDeclined shouldBe false
+        result.groupJoined shouldBe false
+        result.groupJoinPending shouldBe false
     }
 
-    "그룹 매칭을 거절하면 DECLINED 가 반환된다" {
-        // given
+    "그룹 매칭을 거절하면 groupDeclined=true 다" {
         groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
 
-        // when
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
-        result.groupMatchRoomId shouldBe null
+        result.groupDeclined shouldBe true
+        result.groupJoined shouldBe false
+        result.groupJoinPending shouldBe false
     }
 
-    "그룹 방에 참여하면 JOINED 와 roomId 가 반환된다" {
-        // given
-        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+    "활성화된 방에 참여하면 groupJoined=true, groupJoinPending=false 다" {
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId, isActive = true))
         groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
 
-        // when
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.groupMatchStatus shouldBe GroupMatchStatus.JOINED
-        result.groupMatchRoomId shouldBe room.id
+        result.groupJoined shouldBe true
+        result.groupJoinPending shouldBe false
     }
 
-    "거절 이력과 참여 이력이 모두 있으면 DECLINED 가 우선 반환된다" {
-        // given
-        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId))
+    "비활성(인원 대기) 방에 참여하면 groupJoinPending=true, groupJoined=false 다" {
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId, isActive = false))
+        groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+
+        val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
+
+        result.groupJoinPending shouldBe true
+        result.groupJoined shouldBe false
+    }
+
+    "거절 이력과 참여 이력이 모두 있으면 groupDeclined 가 우선이다" {
+        val room = groupMatchRepository.save(GroupMatchFixture.create(quizSetId = quizSetId, isActive = true))
         groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
         groupMatchDeclineRepository.save(GroupMatchDecline.of(quizSetId, memberId))
 
-        // when
         val result = matchingStatusService.getMatchingStatus(memberId, quizSetId)
 
-        // then
-        result.groupMatchStatus shouldBe GroupMatchStatus.DECLINED
+        result.groupDeclined shouldBe true
+        result.groupJoined shouldBe false
+        result.groupJoinPending shouldBe false
     }
 })

--- a/api/src/test/kotlin/com/ditto/api/match/PersonalMatchControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/PersonalMatchControllerTest.kt
@@ -1,7 +1,6 @@
 package com.ditto.api.match
 
 import com.ditto.api.match.controller.PersonalMatchController
-import com.ditto.api.match.dto.PersonalMatchListResponse
 import com.ditto.api.match.dto.PersonalMatchRequest
 import com.ditto.api.match.dto.PersonalMatchResponse
 import com.ditto.api.match.service.PersonalMatchService
@@ -21,8 +20,6 @@ import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPri
 import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
 import org.springframework.restdocs.request.RequestDocumentation.parameterWithName
 import org.springframework.restdocs.request.RequestDocumentation.pathParameters
-import org.springframework.restdocs.request.RequestDocumentation.queryParameters
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
@@ -48,60 +45,6 @@ class PersonalMatchControllerTest : ControllerUnitTest() {
         createdAt = LocalDateTime.of(2026, 5, 1, 12, 0),
         respondedAt = null,
     )
-
-    @Test
-    @DisplayName("보낸/받은 1:1 매칭 요청 목록을 조회한다")
-    fun getPersonalMatches() {
-        every { personalMatchService.getPersonalMatches(any(), any()) } returns PersonalMatchListResponse(
-            sent = listOf(sampleResponse(requesterId = 1L, receiverId = 2L)),
-            received = listOf(sampleResponse(id = 2L, requesterId = 3L, receiverId = 1L)),
-        )
-
-        mockMvc.perform(
-            get("/api/v1/matches/1on1").param("quizSetId", "10"),
-        )
-            .andExpect(status().isOk)
-            .andExpect(jsonPath("$.success").value(true))
-            .andExpect(jsonPath("$.data.sent.length()").value(1))
-            .andExpect(jsonPath("$.data.received.length()").value(1))
-            .andDo(
-                document(
-                    "personal-match-list",
-                    preprocessRequest(prettyPrint()),
-                    preprocessResponse(prettyPrint()),
-                    resource(
-                        ResourceSnippetParameters.builder()
-                            .tag("Matching")
-                            .summary("1:1 매칭 요청 목록 조회")
-                            .description("퀴즈셋에 대한 내가 보낸/받은 1:1 매칭 요청 목록을 조회합니다.")
-                            .queryParameters(
-                                parameterWithName("quizSetId").description("퀴즈 세트 ID"),
-                            )
-                            .responseFields(
-                                fieldWithPath("success").description("성공 여부"),
-                                fieldWithPath("data.sent[]").description("내가 보낸 요청 목록"),
-                                fieldWithPath("data.sent[].id").description("매칭 ID"),
-                                fieldWithPath("data.sent[].quizSetId").description("퀴즈 세트 ID"),
-                                fieldWithPath("data.sent[].requesterId").description("요청자 ID"),
-                                fieldWithPath("data.sent[].receiverId").description("수신자 ID"),
-                                fieldWithPath("data.sent[].status").description("상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)"),
-                                fieldWithPath("data.sent[].createdAt").description("요청 생성일시"),
-                                fieldWithPath("data.sent[].respondedAt").description("응답 일시 (없으면 null)").optional(),
-                                fieldWithPath("data.received[]").description("내가 받은 요청 목록"),
-                                fieldWithPath("data.received[].id").description("매칭 ID"),
-                                fieldWithPath("data.received[].quizSetId").description("퀴즈 세트 ID"),
-                                fieldWithPath("data.received[].requesterId").description("요청자 ID"),
-                                fieldWithPath("data.received[].receiverId").description("수신자 ID"),
-                                fieldWithPath("data.received[].status").description("상태"),
-                                fieldWithPath("data.received[].createdAt").description("요청 생성일시"),
-                                fieldWithPath("data.received[].respondedAt").description("응답 일시 (없으면 null)").optional(),
-                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
-                            )
-                            .build(),
-                    ),
-                ),
-            )
-    }
 
     @Test
     @DisplayName("1:1 매칭을 요청한다")

--- a/domain/src/main/kotlin/com/ditto/domain/intronote/repository/IntroNoteRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/intronote/repository/IntroNoteRepository.kt
@@ -9,4 +9,7 @@ interface IntroNoteRepository : JpaRepository<IntroNote, Long> {
     fun findAllByMemberId(memberId: Long): List<IntroNote>
 
     fun findByMemberIdAndQuestion(memberId: Long, question: IntroQuestion): IntroNote?
+
+    /** 여러 회원의 특정 질문 답변을 한 번에 조회 (후보 목록 프로필 조인 시 N+1 방지) */
+    fun findByMemberIdInAndQuestion(memberIds: List<Long>, question: IntroQuestion): List<IntroNote>
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/entity/PersonalMatch.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/entity/PersonalMatch.kt
@@ -71,6 +71,9 @@ class PersonalMatch private constructor(
     /** 요청을 받은 상대방 ID */
     fun receiverId(): Long = if (requesterId == memberId1) memberId2 else memberId1
 
+    /** memberId 기준 페어의 상대방 ID. memberId 는 이 매칭의 페어(memberId1/memberId2)에 속해야 한다. */
+    fun counterpartOf(memberId: Long): Long = if (memberId == memberId1) memberId2 else memberId1
+
     fun isPending(): Boolean = status == PersonalMatchStatus.PENDING
 
     fun accept() {

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryCustom.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.quiz.repository.querydsl
 
+import com.ditto.domain.quiz.entity.MatchingType
 import com.ditto.domain.quiz.entity.QuizSet
 import java.time.LocalDateTime
 
@@ -8,4 +9,6 @@ interface QuizSetRepositoryCustom {
 
     /** 마감(endDate < now)됐고 아직 매칭 후보가 없는 퀴즈셋 — 매칭 배치 대상 (match_candidate anti-join) */
     fun findEndedQuizSetsWithoutCandidates(now: LocalDateTime): List<QuizSet>
+
+    fun findLatestCompletedQuizSet(memberId: Long, matchingType: MatchingType): QuizSet?
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/querydsl/QuizSetRepositoryImpl.kt
@@ -1,7 +1,10 @@
 package com.ditto.domain.quiz.repository.querydsl
 
 import com.ditto.domain.match.entity.QMatchCandidate.matchCandidate
+import com.ditto.domain.quiz.entity.MatchingType
+import com.ditto.domain.quiz.entity.QQuizProgress.quizProgress
 import com.ditto.domain.quiz.entity.QQuizSet.quizSet
+import com.ditto.domain.quiz.entity.QuizProgressStatus
 import com.ditto.domain.quiz.entity.QuizSet
 import com.querydsl.jpa.impl.JPAQueryFactory
 import java.time.LocalDateTime
@@ -29,4 +32,17 @@ class QuizSetRepositoryImpl(
                 matchCandidate.id.isNull, // 후보가 하나도 없는(아직 계산 안 된) 셋만
             )
             .fetch()
+
+    override fun findLatestCompletedQuizSet(memberId: Long, matchingType: MatchingType): QuizSet? =
+        queryFactory
+            .select(quizSet)
+            .from(quizProgress)
+            .join(quizSet).on(quizProgress.quizSetId.eq(quizSet.id))
+            .where(
+                quizProgress.memberId.eq(memberId),
+                quizProgress.status.eq(QuizProgressStatus.COMPLETED),
+                quizSet.matchingType.eq(matchingType),
+            )
+            .orderBy(quizSet.endDate.desc())
+            .fetchFirst()
 }

--- a/domain/src/test/kotlin/com/ditto/domain/match/entity/PersonalMatchTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/match/entity/PersonalMatchTest.kt
@@ -80,6 +80,19 @@ class MatchRequestTest(
         }
     }
 
+    "counterpartOf — memberId 기준 상대방 ID" - {
+        "given: requester=5, receiver=2 (memberId1=2, memberId2=5) 페어일 때" - {
+            "when: counterpartOf 를 호출하면" - {
+                "then: 요청자/수신자 방향과 무관하게 페어의 상대방 ID를 반환한다" {
+                    val match = PersonalMatchFixture.create(requesterId = 5L, receiverId = 2L, quizSetId = 1L)
+
+                    match.counterpartOf(2L) shouldBe 5L
+                    match.counterpartOf(5L) shouldBe 2L
+                }
+            }
+        }
+    }
+
     "PersonalMatch 상태 전이" - {
         "given: PENDING 상태의 요청이 있을 때" - {
             "when: accept() 하면" - {

--- a/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizSetRepositoryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/quiz/repository/QuizSetRepositoryTest.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.quiz.repository
 
+import com.ditto.domain.quiz.QuizProgressFixture
 import com.ditto.domain.quiz.QuizSetFixture
 import com.ditto.domain.quiz.entity.MatchingType
 import com.ditto.domain.support.IntegrationTest
@@ -9,6 +10,7 @@ import javax.sql.DataSource
 
 class QuizSetRepositoryTest(
     private val quizSetRepository: QuizSetRepository,
+    private val quizProgressRepository: QuizProgressRepository,
     dataSource: DataSource,
 ) : IntegrationTest(dataSource, {
 
@@ -92,6 +94,66 @@ class QuizSetRepositoryTest(
             val result = quizSetRepository.findCurrentWeekActive(now)
 
             result.size shouldBe 2
+        }
+    }
+
+    "findLatestCompletedQuizSet" - {
+        fun saveCompletedProgress(memberId: Long, quizSetId: Long) {
+            val progress = QuizProgressFixture.create(memberId = memberId, quizSetId = quizSetId, totalCount = 1)
+            progress.recordAnswer() // NOT_STARTED -> COMPLETED
+            quizProgressRepository.save(progress)
+        }
+
+        "완료한 해당 타입 퀴즈셋이 여러 개면 endDate 가 가장 최근인 것을 반환한다" {
+            val older = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(14), endDate = now.minusDays(8)),
+            )
+            val latest = quizSetRepository.save(
+                QuizSetFixture.create(startDate = now.minusDays(7), endDate = now.minusDays(1)),
+            )
+            saveCompletedProgress(memberId = 1L, quizSetId = older.id)
+            saveCompletedProgress(memberId = 1L, quizSetId = latest.id)
+
+            val result = quizSetRepository.findLatestCompletedQuizSet(1L, MatchingType.ONE_TO_ONE)
+
+            result?.id shouldBe latest.id
+        }
+
+        "완료(COMPLETED)하지 않은 진행 기록만 있으면 제외된다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create(endDate = now.minusDays(1)))
+            quizProgressRepository.save(
+                QuizProgressFixture.create(memberId = 1L, quizSetId = quizSet.id, totalCount = 5),
+            )
+
+            val result = quizSetRepository.findLatestCompletedQuizSet(1L, MatchingType.ONE_TO_ONE)
+
+            result shouldBe null
+        }
+
+        "요청한 매칭 타입과 다른 퀴즈셋은 제외된다" {
+            val groupSet = quizSetRepository.save(
+                QuizSetFixture.create(endDate = now.minusDays(1), matchingType = MatchingType.GROUP),
+            )
+            saveCompletedProgress(memberId = 1L, quizSetId = groupSet.id)
+
+            val result = quizSetRepository.findLatestCompletedQuizSet(1L, MatchingType.ONE_TO_ONE)
+
+            result shouldBe null
+        }
+
+        "다른 회원의 완료 기록은 제외된다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create(endDate = now.minusDays(1)))
+            saveCompletedProgress(memberId = 2L, quizSetId = quizSet.id)
+
+            val result = quizSetRepository.findLatestCompletedQuizSet(1L, MatchingType.ONE_TO_ONE)
+
+            result shouldBe null
+        }
+
+        "완료한 퀴즈셋이 없으면 null 을 반환한다" {
+            val result = quizSetRepository.findLatestCompletedQuizSet(1L, MatchingType.ONE_TO_ONE)
+
+            result shouldBe null
         }
     }
 })

--- a/domain/src/testFixtures/kotlin/com/ditto/domain/member/MemberFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/ditto/domain/member/MemberFixture.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.member
 
+import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
 import com.ditto.domain.member.entity.Location
@@ -13,17 +14,23 @@ object MemberFixture {
         nickname: String = "테스트유저",
         email: String = "test@example.com",
         status: MemberStatus = MemberStatus.PENDING,
+        gender: Gender? = null,
+        age: Int? = null,
         interests: Set<Interest> = emptySet(),
         location: Location? = null,
         job: Job? = null,
+        caricature: String? = null,
         id: Long = 0L,
     ): Member = Member(
         nickname = nickname,
         email = email,
         status = status,
+        gender = gender,
+        age = age,
         interests = interests,
         location = location,
         job = job,
+        caricature = caricature,
         id = id,
     ).withId(id)
 }


### PR DESCRIPTION
## 개요
이슈 #66 — 1:1 매칭 조회 2개 엔드포인트를 FE 계약에 맞춰 정합 (#67 통합) + 운영용 퀴즈셋 매칭 재실행 엔드포인트. 후보/상태 두 조회는 sent/received 데이터가 이동하는 커플링이 있어 함께 처리.

## (1) 1:1 추천 후보 조회 — `GET /api/v1/matches/1on1`
- 기존 보낸/받은 요청(`PersonalMatchListResponse`) 대신 **추천 후보 목록(`MatchCandidateResponse`)** 반환 (FE 실제 호출과 정합: 파라미터 없음, 응답에서 quizSetId 추출)
- 대상 퀴즈셋은 서버가 결정: **회원이 최근 COMPLETED 한 ONE_TO_ONE 퀴즈셋**(`QuizSetRepository.findLatestCompletedQuizSet`), 없으면 404
- `match_candidate` + 멤버 프로필(IntroNote ONE_WORD 포함) **배치 조인**(N+1 방지), score 내림차순(동점 시 otherMemberId)
- `Candidate`: gender/age/introduction nullable, location/profileImageUrl 은 가입 필수라 non-null(누락 시 `ErrorException`)
- `ScoreSummary`: quizMatchRate/matchedQuestions/totalQuestions/reasons(현재 count 합성 문장), algorithmVersion 상수 "1.0"

## (2) 매칭 상태 조회 응답 정합 — `GET /api/v1/matching/status/{quizSetId}`
- `MatchingStatusResponse` 재구성: `sentRequests[]`, `receivedRequests[]`, `hasAcceptedMatch`, `acceptedMatchUserId?`, `groupDeclined`, `groupJoined`, `groupJoinPending`
- sent/received 는 기존 `PersonalMatchResponse` 재사용 (FE `toMatchRequest` 가 score 계열을 읽지 않음 확인)
- 그룹 상태는 boolean 3개: declined / joined(활성 방 3명↑) / pending(비활성 대기) — FE가 각 플래그를 서로 다른 분기점에서 독립 소비
- 수락 상대 ID 도출은 `PersonalMatch.counterpartOf(memberId)` 도메인 메서드
- 기존 `personalMatch` 단건 / `PersonalMatchSummary` / `GroupMatchStatus` enum 제거

## (3) 퀴즈셋 매칭 재실행 (admin) — `POST /api/v1/admin/quiz-sets/{quizSetId}/matching/regenerate`
- 운영자가 특정 퀴즈셋의 1:1 매칭 후보를 **강제 재계산**(기존 후보 삭제 후 재생성, 멱등). 스케줄러("마감 + 후보 없음" 자동)와 달리 **조건 없이 무조건 실행**.
- `MatchmakingService.generateMatchingCandidates(quizSetId)` 를 호출하는 얇은 트리거(`MatchAdminController`). quizSet 미존재 → `WarnException(NOT_FOUND)`.
- ⚠️ **admin 전용 인가는 후속 작업** — 현재는 `/api/**` 공통 인증(API Key + JWT)만 적용되어 인증된 회원이면 호출 가능. `/api/v1/admin/` 접두사는 추후 전용 SecurityFilterChain 부착용.

## 테스트
- 도메인: `QuizSetRepositoryTest`(findLatestCompletedQuizSet 5케이스), `PersonalMatchTest`(counterpartOf)
- API: `MatchCandidateControllerTest`·`MatchingStatusControllerTest`·`MatchAdminControllerTest`(RestDocs 문서화), `MatchCandidateServiceTest`(통합 10케이스), `MatchingStatusServiceTest`(통합 9케이스)
- 커버리지: 전 모듈 50% 게이트 통과(api 97% / domain 82% / infra 92%), `MatchCandidateService` INSTR·BRANCH·LINE 100%
- `./gradlew build` 통과

## 비고
- gender/age 는 카카오 동의 항목이라 가입 필수가 아님 → nullable 유지 (#81 성별·나이 필터 머지 시 non-null 검토 가능)
- FE 잔재(`ExternalMatchList`의 sent/received, 목 fixture)는 FE 레포 정리 권장 (BE는 quizSetId 항상 전송이라 현재도 안전)
- **admin 재실행 후속**: ① openapi.yaml 은 재생성 시 정렬 노이즈가 커 이번 커밋에서 제외(별도 재생성 예정) ② admin 전용 인가(별도 admin key 또는 회원 role) 부착

Closes #66

🤖 Generated with [Claude Code](https://claude.com/claude-code)