### PR TITLE
feat. 어드민 인가 (Member role + JWT role 클레임 + admin 경로 보호)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/facade/OAuthFacade.kt
@@ -32,7 +32,7 @@ class OAuthFacade(
             gender = userInfo.gender,
         )
 
-        val accessToken = jwtTokenProvider.generateAccessToken(member.id)
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id, member.role)
         val refreshToken = authService.createRefreshToken(member.id)
         val redirectUrl = oAuthService.getAuthCallbackUrl(accessToken, signupRequired = member.isPending())
 

--- a/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
@@ -5,6 +5,7 @@ import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
 import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.refreshtoken.entity.RefreshToken
 import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
 import org.springframework.stereotype.Service
@@ -14,6 +15,7 @@ import org.springframework.transaction.annotation.Transactional
 class AuthService(
     private val jwtTokenProvider: JwtTokenProvider,
     private val refreshTokenRepository: RefreshTokenRepository,
+    private val memberRepository: MemberRepository,
 ) {
 
     @Transactional
@@ -44,8 +46,11 @@ class AuthService(
 
         refreshTokenRepository.delete(existedRefreshToken)
 
-        val newAccessToken = jwtTokenProvider.generateAccessToken(existedRefreshToken.memberId)
-        val newRefreshToken = createRefreshToken(existedRefreshToken.memberId)
+        val member = memberRepository.findById(existedRefreshToken.memberId)
+            .orElseThrow { ErrorException(ErrorCode.UNAUTHORIZED_ERROR) }
+
+        val newAccessToken = jwtTokenProvider.generateAccessToken(member.id, member.role)
+        val newRefreshToken = createRefreshToken(member.id)
 
         return TokenRefreshResult(
             accessToken = newAccessToken,

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
@@ -42,6 +42,11 @@ class JwtAuthenticationFilter(
             return
         }
 
+        if (request.requestURI.startsWith(ADMIN_PATH_PREFIX) && !member.isAdmin()) {
+            sendError(response, ErrorCode.FORBIDDEN)
+            return
+        }
+
         setAuthentication(memberId)
 
         filterChain.doFilter(request, response)
@@ -78,6 +83,7 @@ class JwtAuthenticationFilter(
     companion object {
         private const val AUTHORIZATION_HEADER = "Authorization"
         private const val BEARER_PREFIX = "Bearer "
+        private const val ADMIN_PATH_PREFIX = "/api/v1/admin"
         private val objectMapper = ObjectMapperFactory.create()
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtTokenProvider.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtTokenProvider.kt
@@ -1,5 +1,6 @@
 package com.ditto.api.config.auth
 
+import com.ditto.domain.member.entity.MemberRole
 import io.jsonwebtoken.Jwts
 import io.jsonwebtoken.security.Keys
 import org.springframework.stereotype.Component
@@ -20,9 +21,10 @@ class JwtTokenProvider(
         Jwts.parser().verifyWith(key).build()
     }
 
-    fun generateAccessToken(memberId: Long, now: Date = Date()): String {
+    fun generateAccessToken(memberId: Long, role: MemberRole, now: Date = Date()): String {
         return Jwts.builder()
             .subject(memberId.toString())
+            .claim("role", role.name)
             .issuedAt(now)
             .expiration(Date(now.time + jwtProperties.expirationMs))
             .signWith(key)

--- a/api/src/main/kotlin/com/ditto/api/match/controller/MatchAdminController.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/controller/MatchAdminController.kt
@@ -9,8 +9,7 @@ import org.springframework.web.bind.annotation.RestController
 /**
  * 매칭 운영용(admin) API.
  *
- * admin 전용 인가는 후속 작업이다. 현재는 공통 인증(API Key + JWT)만 적용되어 인증된 회원이면 호출할 수 있다.
- * admin 경로 접두사(api/v1/admin)는 추후 전용 SecurityFilterChain 부착용이다.
+ * admin 경로(`/api/v1/admin` 하위 전체)는 JwtAuthenticationFilter에서 role=ADMIN 회원만 접근할 수 있다.
  */
 @RestController
 class MatchAdminController(

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -71,10 +71,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-06-09 11:08:41",
+                        "joinedAt" : "2026-06-10 21:11:03",
                         "role" : null,
-                        "createdAt" : "2026-06-09 11:08:41",
-                        "updatedAt" : "2026-06-09 11:08:41"
+                        "createdAt" : "2026-06-10 21:11:03",
+                        "updatedAt" : "2026-06-10 21:11:03"
                       },
                       "error" : null
                     }
@@ -281,8 +281,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-06-08 11:08:41",
-                          "endDate" : "2026-06-10 11:08:41",
+                          "startDate" : "2026-06-09 21:11:03",
+                          "endDate" : "2026-06-11 21:11:03",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -299,8 +299,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-06-09 11:08:41",
-                            "updatedAt" : "2026-06-09 11:08:41"
+                            "createdAt" : "2026-06-10 21:11:03",
+                            "updatedAt" : "2026-06-10 21:11:03"
                           } ]
                         } ]
                       },
@@ -346,8 +346,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-06-09 11:08:41",
-                        "updatedAt" : "2026-06-09 11:08:41"
+                        "createdAt" : "2026-06-10 21:11:03",
+                        "updatedAt" : "2026-06-10 21:11:03"
                       },
                       "error" : null
                     }
@@ -629,7 +629,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwiaWF0IjoxNzgwOTcwOTE4LCJleHAiOjE3ODA5NzQ1MTh9.CYcw_yEYF-hkxYtalBjJPNUVzjOyTxmSIIknDo4CtSp0y5P3tFTB5RtY8cmbEADQXIij06vpoR0VcrbZfGUMbw"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODEwOTM0NjAsImV4cCI6MTc4MTA5NzA2MH0.5F0dst_NMQuYlLjWSZxoqJO8fPnUv4rDrv1ZdJGKAwmbq4SsiFBDU_UdbuDeu52plk0vzX_96ZDUNfaGc1KeuQ"
                       },
                       "error" : null
                     }
@@ -828,8 +828,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-06-09 11:08:41",
-                        "updatedAt" : "2026-06-09 11:08:41"
+                        "createdAt" : "2026-06-10 21:11:03",
+                        "updatedAt" : "2026-06-10 21:11:03"
                       },
                       "error" : null
                     }
@@ -1099,94 +1099,37 @@ paths:
       responses:
         "302":
           description: "302"
+  /api/v1/admin/quiz-sets/{quizSetId}/matching/regenerate:
+    post:
+      tags:
+      - Matching
+      summary: "[Admin] 퀴즈셋 매칭 재생성"
+      description: 특정 퀴즈셋의 1:1 매칭 후보를 재생성합니다(기존 후보 삭제 후 재계산). 마감·후보 존재 여부와 무관하게 실행됩니다.
+      operationId: admin-match-regenerate
+      parameters:
+      - name: quizSetId
+        in: path
+        description: 퀴즈 세트 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-admin-quiz-sets-quizSetId-matching-regenerate-1319553622"
+              examples:
+                admin-match-regenerate:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : null,
+                      "error" : null
+                    }
 components:
   schemas:
-    api-v1-matches-group-join-1969670024:
-      required:
-      - quizSetId
-      type: object
-      properties:
-        quizSetId:
-          type: number
-          description: 퀴즈 세트 ID
-    api-v1-users-me-intro-notes-questionCode-1298820809:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - completedCount
-          type: object
-          properties:
-            answers:
-              type: array
-              items:
-                required:
-                - answer
-                - question
-                - questionCode
-                type: object
-                properties:
-                  answer:
-                    type: string
-                    description: 답변 (미작성 시 빈 문자열)
-                  question:
-                    type: string
-                    description: 질문 문구
-                  questionCode:
-                    type: string
-                    description: "질문 code (가능한 값: travel-items(여행갈 때 꼭 챙겨야 하는 3가지는\
-                      ?), weekend-morning(주말 아침 10시, 나는 주로 뭐하고 있을까?), friends-say(친\
-                      구들이 나한테 제일 많이 하는 말은?), stress-relief(스트레스 받을 때 나만의 해소법은?), best-choice(최\
-                      근 1년 내 가장 잘한 선택은?), happiest-moment(나를 가장 행복하게 만드는 순간은?), most-used-apps(요\
-                      즘 내가 가장 많이 쓰는 앱 3개는?), favorite-time(하루 중 가장 좋아하는 시간대는? 그때 주\
-                      로 뭐해?), non-negotiable(내가 절대 양보 못하는 것은?), one-word(나를 한 단어로\
-                      \ 표현한다면?))"
-            completedCount:
-              type: number
-              description: 작성 완료된 답변 수
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-me-intro-notes-questionCode974133747:
-      required:
-      - answer
-      type: object
-      properties:
-        answer:
-          type: string
-          description: "답변 (빈 문자열 허용, 최대 500자)"
-    api-v1-matches-group-join-2080112672:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - isActive
-          - participantCount
-          - quizSetId
-          - roomId
-          type: object
-          properties:
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            participantCount:
-              type: number
-              description: 현재 참여자 수
-            isActive:
-              type: boolean
-              description: 방 활성화 여부 (참여자 3명 이상이면 true)
-            roomId:
-              type: number
-              description: 배정된 그룹 방 ID
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-request-1327932902:
       required:
       - error
@@ -1329,6 +1272,353 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-matches-1on1-1115011008:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - algorithmVersion
+          - candidates
+          - matchingType
+          - quizSetId
+          type: object
+          properties:
+            candidates:
+              type: array
+              description: 추천 후보 목록 (매칭 점수 내림차순)
+              items:
+                required:
+                - location
+                - matchRate
+                - nickname
+                - profileImageUrl
+                - scoreBreakdown
+                - userId
+                type: object
+                properties:
+                  scoreBreakdown:
+                    required:
+                    - matchedQuestions
+                    - quizMatchRate
+                    - reasons
+                    - totalQuestions
+                    type: object
+                    properties:
+                      totalQuestions:
+                        type: number
+                        description: 전체 비교 문항 수
+                      reasons:
+                        type: array
+                        description: 매칭 사유 문구
+                        items:
+                          oneOf:
+                          - type: object
+                          - type: boolean
+                          - type: string
+                          - type: number
+                      quizMatchRate:
+                        type: number
+                        description: 퀴즈 답변 일치율 (0~100)
+                      matchedQuestions:
+                        type: number
+                        description: 일치한 문항 수
+                    description: 매칭 점수 상세
+                  gender:
+                    type: string
+                    description: "성별 (MALE / FEMALE, 없으면 null)"
+                    nullable: true
+                  nickname:
+                    type: string
+                    description: 닉네임
+                  location:
+                    type: string
+                    description: 사는 곳 코드
+                  matchRate:
+                    type: number
+                    description: 매칭 점수 (0~100)
+                  profileImageUrl:
+                    type: string
+                    description: 프로필 이미지 (캐리커쳐)
+                  userId:
+                    type: number
+                    description: 후보 회원 ID
+                  introduction:
+                    type: string
+                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
+                    nullable: true
+                  age:
+                    type: number
+                    description: 나이 (없으면 null)
+                    nullable: true
+            algorithmVersion:
+              type: string
+              description: 매칭 알고리즘 버전
+            quizSetId:
+              type: number
+              description: 후보가 속한 퀴즈 세트 ID
+            matchingType:
+              type: string
+              description: 매칭 타입 (ONE_TO_ONE / GROUP)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-quiz-sets-id-1569645469:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - totalCount
+          type: object
+          properties:
+            quizzes:
+              type: array
+              items:
+                required:
+                - createdAt
+                - id
+                - order
+                - question
+                - quizSetId
+                - updatedAt
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 생성일시
+                  userAnswer:
+                    type: number
+                    description: 사용자가 선택한 choiceId (미답변 시 null)
+                    nullable: true
+                  question:
+                    type: string
+                    description: 퀴즈 질문
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 퀴즈 ID
+                  choices:
+                    type: array
+                    items:
+                      required:
+                      - content
+                      - id
+                      - order
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                          description: 선택지 ID
+                        content:
+                          type: string
+                          description: 선택지 내용
+                        order:
+                          type: number
+                          description: 선택지 순서
+                  updatedAt:
+                    type: string
+                    description: 수정일시
+                  order:
+                    type: number
+                    description: 퀴즈 순서
+            totalCount:
+              type: number
+              description: 전체 퀴즈 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-logout-1831456372:
+      required:
+      - data
+      - error
+      - success
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-request-id-accept-2011455419:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - createdAt
+          - id
+          - quizSetId
+          - receiverId
+          - requesterId
+          - status
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 요청 생성일시
+            receiverId:
+              type: number
+              description: 수신자 ID
+            requesterId:
+              type: number
+              description: 요청자 ID
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            id:
+              type: number
+              description: 매칭 ID
+            status:
+              type: string
+              description: 변경된 매칭 상태 (ACCEPTED)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-2041696623:
+      required:
+      - caricature
+      - interests
+      - job
+      - location
+      type: object
+      properties:
+        caricature:
+          type: string
+          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
+        phoneNumber:
+          type: string
+          description: 전화번호 (010-0000-0000)
+          nullable: true
+        gender:
+          type: string
+          description: "성별 (MALE, FEMALE)"
+          nullable: true
+        nickname:
+          type: string
+          description: "닉네임 (2~10자, 한글·영문·숫자)"
+          nullable: true
+        name:
+          type: string
+          description: 이름
+          nullable: true
+        location:
+          type: string
+          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
+            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
+            \ jeonnam, gyeongbuk, gyeongnam, jeju"
+        job:
+          type: string
+          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
+            \ education, medical, finance, legal, manufacturing, distribution, service,\
+            \ construction, arts-media, research, public-admin, student, etc"
+        interests:
+          type: array
+          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
+            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
+            \ pets, etc"
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        age:
+          type: number
+          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
+          nullable: true
+    api-v1-matches-group-join-1969670024:
+      required:
+      - quizSetId
+      type: object
+      properties:
+        quizSetId:
+          type: number
+          description: 퀴즈 세트 ID
+    api-v1-users-me-intro-notes-questionCode-1298820809:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - completedCount
+          type: object
+          properties:
+            answers:
+              type: array
+              items:
+                required:
+                - answer
+                - question
+                - questionCode
+                type: object
+                properties:
+                  answer:
+                    type: string
+                    description: 답변 (미작성 시 빈 문자열)
+                  question:
+                    type: string
+                    description: 질문 문구
+                  questionCode:
+                    type: string
+                    description: "질문 code (가능한 값: travel-items(여행갈 때 꼭 챙겨야 하는 3가지는\
+                      ?), weekend-morning(주말 아침 10시, 나는 주로 뭐하고 있을까?), friends-say(친\
+                      구들이 나한테 제일 많이 하는 말은?), stress-relief(스트레스 받을 때 나만의 해소법은?), best-choice(최\
+                      근 1년 내 가장 잘한 선택은?), happiest-moment(나를 가장 행복하게 만드는 순간은?), most-used-apps(요\
+                      즘 내가 가장 많이 쓰는 앱 3개는?), favorite-time(하루 중 가장 좋아하는 시간대는? 그때 주\
+                      로 뭐해?), non-negotiable(내가 절대 양보 못하는 것은?), one-word(나를 한 단어로\
+                      \ 표현한다면?))"
+            completedCount:
+              type: number
+              description: 작성 완료된 답변 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-intro-notes-questionCode974133747:
+      required:
+      - answer
+      type: object
+      properties:
+        answer:
+          type: string
+          description: "답변 (빈 문자열 허용, 최대 500자)"
+    api-v1-matches-group-join-2080112672:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - isActive
+          - participantCount
+          - quizSetId
+          - roomId
+          type: object
+          properties:
+            quizSetId:
+              type: number
+              description: 퀴즈 세트 ID
+            participantCount:
+              type: number
+              description: 현재 참여자 수
+            isActive:
+              type: boolean
+              description: 방 활성화 여부 (참여자 3명 이상이면 true)
+            roomId:
+              type: number
+              description: 배정된 그룹 방 ID
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-users-me861338172:
       required:
       - error
@@ -1359,6 +1649,23 @@ components:
             email:
               type: string
               description: 이메일 (없으면 null)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
         success:
           type: boolean
           description: 성공 여부
@@ -1485,116 +1792,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-refresh1774976609:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-matches-1on1-1115011008:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - algorithmVersion
-          - candidates
-          - matchingType
-          - quizSetId
-          type: object
-          properties:
-            candidates:
-              type: array
-              description: 추천 후보 목록 (매칭 점수 내림차순)
-              items:
-                required:
-                - location
-                - matchRate
-                - nickname
-                - profileImageUrl
-                - scoreBreakdown
-                - userId
-                type: object
-                properties:
-                  scoreBreakdown:
-                    required:
-                    - matchedQuestions
-                    - quizMatchRate
-                    - reasons
-                    - totalQuestions
-                    type: object
-                    properties:
-                      totalQuestions:
-                        type: number
-                        description: 전체 비교 문항 수
-                      reasons:
-                        type: array
-                        description: 매칭 사유 문구
-                        items:
-                          oneOf:
-                          - type: object
-                          - type: boolean
-                          - type: string
-                          - type: number
-                      quizMatchRate:
-                        type: number
-                        description: 퀴즈 답변 일치율 (0~100)
-                      matchedQuestions:
-                        type: number
-                        description: 일치한 문항 수
-                    description: 매칭 점수 상세
-                  gender:
-                    type: string
-                    description: "성별 (MALE / FEMALE, 없으면 null)"
-                    nullable: true
-                  nickname:
-                    type: string
-                    description: 닉네임
-                  location:
-                    type: string
-                    description: 사는 곳 코드
-                  matchRate:
-                    type: number
-                    description: 매칭 점수 (0~100)
-                  profileImageUrl:
-                    type: string
-                    description: 프로필 이미지 (캐리커쳐)
-                  userId:
-                    type: number
-                    description: 후보 회원 ID
-                  introduction:
-                    type: string
-                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
-                    nullable: true
-                  age:
-                    type: number
-                    description: 나이 (없으면 null)
-                    nullable: true
-            algorithmVersion:
-              type: string
-              description: 매칭 알고리즘 버전
-            quizSetId:
-              type: number
-              description: 후보가 속한 퀴즈 세트 ID
-            matchingType:
-              type: string
-              description: 매칭 타입 (ONE_TO_ONE / GROUP)
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-request-793255208:
       required:
       - quizSetId
@@ -1613,75 +1810,6 @@ components:
       - success
       type: object
       properties:
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-quiz-progress-quiz-sets-id-1569645469:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - totalCount
-          type: object
-          properties:
-            quizzes:
-              type: array
-              items:
-                required:
-                - createdAt
-                - id
-                - order
-                - question
-                - quizSetId
-                - updatedAt
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 생성일시
-                  userAnswer:
-                    type: number
-                    description: 사용자가 선택한 choiceId (미답변 시 null)
-                    nullable: true
-                  question:
-                    type: string
-                    description: 퀴즈 질문
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 퀴즈 ID
-                  choices:
-                    type: array
-                    items:
-                      required:
-                      - content
-                      - id
-                      - order
-                      type: object
-                      properties:
-                        id:
-                          type: number
-                          description: 선택지 ID
-                        content:
-                          type: string
-                          description: 선택지 내용
-                        order:
-                          type: number
-                          description: 선택지 순서
-                  updatedAt:
-                    type: string
-                    description: 수정일시
-                  order:
-                    type: number
-                    description: 퀴즈 순서
-            totalCount:
-              type: number
-              description: 전체 퀴즈 수
         success:
           type: boolean
           description: 성공 여부
@@ -1719,6 +1847,14 @@ components:
             status:
               type: string
               description: 변경된 매칭 상태 (REJECTED)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-admin-quiz-sets-quizSetId-matching-regenerate-1319553622:
+      required:
+      - success
+      type: object
+      properties:
         success:
           type: boolean
           description: 성공 여부
@@ -1773,16 +1909,6 @@ components:
             available:
               type: boolean
               description: 닉네임 사용 가능 여부
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-auth-logout-1831456372:
-      required:
-      - data
-      - error
-      - success
-      type: object
-      properties:
         success:
           type: boolean
           description: 성공 여부
@@ -1937,43 +2063,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-matches-request-id-accept-2011455419:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - createdAt
-          - id
-          - quizSetId
-          - receiverId
-          - requesterId
-          - status
-          type: object
-          properties:
-            createdAt:
-              type: string
-              description: 요청 생성일시
-            receiverId:
-              type: number
-              description: 수신자 ID
-            requesterId:
-              type: number
-              description: 요청자 ID
-            quizSetId:
-              type: number
-              description: 퀴즈 세트 ID
-            id:
-              type: number
-              description: 매칭 ID
-            status:
-              type: string
-              description: 변경된 매칭 상태 (ACCEPTED)
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-users-id-leave-1444522536:
       required:
       - error
@@ -2011,58 +2100,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-2041696623:
-      required:
-      - caricature
-      - interests
-      - job
-      - location
-      type: object
-      properties:
-        caricature:
-          type: string
-          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
-        phoneNumber:
-          type: string
-          description: 전화번호 (010-0000-0000)
-          nullable: true
-        gender:
-          type: string
-          description: "성별 (MALE, FEMALE)"
-          nullable: true
-        nickname:
-          type: string
-          description: "닉네임 (2~10자, 한글·영문·숫자)"
-          nullable: true
-        name:
-          type: string
-          description: 이름
-          nullable: true
-        location:
-          type: string
-          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
-            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
-            \ jeonnam, gyeongbuk, gyeongnam, jeju"
-        job:
-          type: string
-          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
-            \ education, medical, finance, legal, manufacturing, distribution, service,\
-            \ construction, arts-media, research, public-admin, student, etc"
-        interests:
-          type: array
-          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
-            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
-            \ pets, etc"
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        age:
-          type: number
-          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
-          nullable: true
     api-v1-users-id-profile-829103765:
       required:
       - error

--- a/api/src/test/kotlin/com/ditto/api/auth/AuthControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/auth/AuthControllerTest.kt
@@ -100,7 +100,7 @@ class AuthControllerTest : RestDocsTest() {
         val member = memberRepository.save(Member(nickname = "테스트유저").apply { activate() })
         socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "test-user"))
         authService.createRefreshToken(member.id)
-        val accessToken = jwtTokenProvider.generateAccessToken(member.id)
+        val accessToken = jwtTokenProvider.generateAccessToken(member.id, member.role)
 
         mockMvc.perform(
             post("/api/v1/users/auth/logout")

--- a/api/src/test/kotlin/com/ditto/api/config/TestExceptionController.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/TestExceptionController.kt
@@ -33,6 +33,11 @@ class TestExceptionController {
     @GetMapping("/api/test/me")
     fun getMe(@AuthenticationPrincipal principal: MemberPrincipal): ApiResponse<MemberPrincipal> =
         ApiResponse.ok(principal)
+
+    /** admin 경로 인가(JwtAuthenticationFilter) 테스트용 — 서비스 의존 없이 게이트 통과 여부만 확인한다. */
+    @GetMapping("/api/v1/admin/test/me")
+    fun getAdminMe(@AuthenticationPrincipal principal: MemberPrincipal): ApiResponse<MemberPrincipal> =
+        ApiResponse.ok(principal)
 }
 
 data class TestRequest(

--- a/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilterTest.kt
@@ -3,6 +3,7 @@ package com.ditto.api.config.auth
 import com.ditto.api.config.TestExceptionController
 import com.ditto.api.support.RestDocsTest
 import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberRole
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -19,7 +20,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     @DisplayName("유효한 Bearer 토큰이고 ACTIVE 회원이면 MemberPrincipal을 받을 수 있다")
     fun validBearerToken() {
         val member = memberRepository.save(Member(nickname = "활성유저").apply { activate() })
-        val token = jwtTokenProvider.generateAccessToken(member.id)
+        val token = jwtTokenProvider.generateAccessToken(member.id, member.role)
 
         mockMvc.perform(
             get("/api/test/me")
@@ -35,7 +36,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     @DisplayName("PENDING 회원이 보호 API에 접근하면 403과 에러 정보를 반환한다")
     fun pendingMemberForbidden() {
         val member = memberRepository.save(Member(nickname = "대기유저"))
-        val token = jwtTokenProvider.generateAccessToken(member.id)
+        val token = jwtTokenProvider.generateAccessToken(member.id, member.role)
 
         mockMvc.perform(
             get("/api/test/me")
@@ -51,7 +52,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     @DisplayName("PENDING 회원은 로그아웃 경로도 차단된다(403)")
     fun pendingMemberCannotLogout() {
         val member = memberRepository.save(Member(nickname = "대기유저-logout"))
-        val token = jwtTokenProvider.generateAccessToken(member.id)
+        val token = jwtTokenProvider.generateAccessToken(member.id, member.role)
 
         mockMvc.perform(
             post("/api/v1/users/auth/logout")
@@ -63,9 +64,57 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     }
 
     @Test
+    @DisplayName("ADMIN 회원은 admin 경로에 접근할 수 있다")
+    fun adminPathWithAdminMember() {
+        val member = memberRepository.save(Member(nickname = "관리자", role = MemberRole.ADMIN).apply { activate() })
+        val token = jwtTokenProvider.generateAccessToken(member.id, member.role)
+
+        mockMvc.perform(
+            get("/api/v1/admin/test/me")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.memberId").value(member.id))
+    }
+
+    @Test
+    @DisplayName("USER 회원이 admin 경로에 접근하면 403과 에러 정보를 반환한다")
+    fun adminPathWithUserMember() {
+        val member = memberRepository.save(Member(nickname = "일반유저").apply { activate() })
+        val token = jwtTokenProvider.generateAccessToken(member.id, member.role)
+
+        mockMvc.perform(
+            get("/api/v1/admin/test/me")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("0003"))
+    }
+
+    @Test
+    @DisplayName("USER 회원이 매칭 재생성 admin API를 호출하면 403과 에러 정보를 반환한다")
+    fun adminMatchingApiWithUserMember() {
+        val member = memberRepository.save(Member(nickname = "일반유저-매칭").apply { activate() })
+        val token = jwtTokenProvider.generateAccessToken(member.id, member.role)
+
+        mockMvc.perform(
+            post("/api/v1/admin/quiz-sets/1/matching/regenerate")
+                .withApiKey()
+                .header("Authorization", "Bearer $token"),
+        )
+            .andExpect(status().isForbidden)
+            .andExpect(jsonPath("$.success").value(false))
+            .andExpect(jsonPath("$.error.code").value("0003"))
+    }
+
+    @Test
     @DisplayName("토큰은 유효하지만 존재하지 않는 회원이면 401과 에러 정보를 반환한다")
     fun unknownMember() {
-        val token = jwtTokenProvider.generateAccessToken(99999L)
+        val token = jwtTokenProvider.generateAccessToken(99999L, MemberRole.USER)
 
         mockMvc.perform(
             get("/api/test/me")
@@ -106,7 +155,7 @@ class JwtAuthenticationFilterTest : RestDocsTest() {
     @Test
     @DisplayName("API Key 없이 Bearer 토큰만 보내면 401과 에러 정보를 반환한다")
     fun bearerTokenWithoutApiKey() {
-        val token = jwtTokenProvider.generateAccessToken(1L)
+        val token = jwtTokenProvider.generateAccessToken(1L, MemberRole.USER)
 
         mockMvc.perform(
             get("/api/test/me")

--- a/api/src/test/kotlin/com/ditto/api/config/auth/JwtTokenProviderTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/config/auth/JwtTokenProviderTest.kt
@@ -1,8 +1,11 @@
 package com.ditto.api.config.auth
 
+import com.ditto.domain.member.entity.MemberRole
 import io.kotest.core.spec.style.FreeSpec
 import io.kotest.matchers.shouldBe
+import io.kotest.matchers.string.shouldContain
 import io.kotest.matchers.string.shouldNotBeBlank
+import java.util.Base64
 
 class JwtTokenProviderTest : FreeSpec(
     {
@@ -16,13 +19,13 @@ class JwtTokenProviderTest : FreeSpec(
 
         "토큰 생성" - {
             "유효한 JWT 문자열을 반환한다" {
-                val token = jwtTokenProvider.generateAccessToken(1L)
+                val token = jwtTokenProvider.generateAccessToken(1L, MemberRole.USER)
 
                 token.shouldNotBeBlank()
             }
 
             "생성된 토큰은 유효하다" {
-                val token = jwtTokenProvider.generateAccessToken(1L)
+                val token = jwtTokenProvider.generateAccessToken(1L, MemberRole.USER)
 
                 jwtTokenProvider.isValid(token) shouldBe true
             }
@@ -31,9 +34,16 @@ class JwtTokenProviderTest : FreeSpec(
         "토큰에서 claim 추출" - {
             "올바른 memberId를 추출한다" {
                 val memberId = 42L
-                val token = jwtTokenProvider.generateAccessToken(memberId)
+                val token = jwtTokenProvider.generateAccessToken(memberId, MemberRole.USER)
 
                 jwtTokenProvider.getMemberId(token) shouldBe memberId
+            }
+
+            "role 클레임을 포함한다" {
+                val token = jwtTokenProvider.generateAccessToken(1L, MemberRole.ADMIN)
+
+                val payload = String(Base64.getUrlDecoder().decode(token.split(".")[1]))
+                payload shouldContain "\"role\":\"ADMIN\""
             }
         }
 
@@ -42,7 +52,7 @@ class JwtTokenProviderTest : FreeSpec(
                 val expiredProvider = JwtTokenProvider(
                     JwtProperties(secret = jwtProperties.secret, expirationMs = 0L, refreshExpirationMs = 1209600000L),
                 )
-                val token = expiredProvider.generateAccessToken(1L)
+                val token = expiredProvider.generateAccessToken(1L, MemberRole.USER)
 
                 Thread.sleep(10)
                 jwtTokenProvider.isValid(token) shouldBe false
@@ -60,7 +70,7 @@ class JwtTokenProviderTest : FreeSpec(
                         refreshExpirationMs = 1209600000L,
                     ),
                 )
-                val token = otherProvider.generateAccessToken(1L)
+                val token = otherProvider.generateAccessToken(1L, MemberRole.USER)
 
                 jwtTokenProvider.isValid(token) shouldBe false
             }

--- a/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/support/RestDocsTest.kt
@@ -3,6 +3,7 @@ package com.ditto.api.support
 import com.ditto.api.config.auth.JwtTokenProvider
 import com.ditto.common.serialization.ObjectMapperFactory
 import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberRole
 import com.ditto.domain.member.repository.MemberRepository
 import com.fasterxml.jackson.databind.ObjectMapper
 import org.junit.jupiter.api.extension.ExtendWith
@@ -48,7 +49,15 @@ abstract class RestDocsTest {
 
     /** 지정한 회원 id의 Bearer 토큰을 헤더에 추가한다. */
     protected fun MockHttpServletRequestBuilder.withBearerToken(memberId: Long): MockHttpServletRequestBuilder {
-        return this.header("Authorization", "Bearer ${jwtTokenProvider.generateAccessToken(memberId)}")
+        return this.header("Authorization", "Bearer ${jwtTokenProvider.generateAccessToken(memberId, MemberRole.USER)}")
+    }
+
+    /** ACTIVE + ADMIN 회원을 새로 만들어 그 회원의 Bearer 토큰을 헤더에 추가한다. */
+    protected fun MockHttpServletRequestBuilder.withAdminBearerToken(): MockHttpServletRequestBuilder {
+        val member = memberRepository.save(
+            Member(nickname = "admin-${memberSeq.incrementAndGet()}", role = MemberRole.ADMIN).apply { activate() },
+        )
+        return this.header("Authorization", "Bearer ${jwtTokenProvider.generateAccessToken(member.id, member.role)}")
     }
 
     companion object {

--- a/domain/db/V20260610000000_회원 role 컬럼 추가.sql
+++ b/domain/db/V20260610000000_회원 role 컬럼 추가.sql
@@ -1,0 +1,5 @@
+-- 회원 권한(role) 컬럼 추가 — 어드민 인가용
+-- ADMIN 부여는 운영자가 수동으로 실행한다 (대상 회원은 가입 완료(ACTIVE) 상태여야 함):
+--   UPDATE member SET role = 'ADMIN' WHERE id = ?;
+ALTER TABLE member
+    ADD COLUMN role VARCHAR(20) NOT NULL DEFAULT 'USER' COMMENT '회원 권한 (USER, ADMIN)' AFTER status;

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
@@ -41,6 +41,11 @@ class Member(
     @Column(nullable = false, length = 20)
     var status: MemberStatus = MemberStatus.PENDING,
 
+    @Comment("회원 권한")
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 20)
+    var role: MemberRole = MemberRole.USER,
+
     @Comment("이름")
     @Column(nullable = true, length = 50)
     var name: String? = null,
@@ -114,6 +119,7 @@ class Member(
 
     fun isPending(): Boolean = status == MemberStatus.PENDING
     fun isActive(): Boolean = status == MemberStatus.ACTIVE
+    fun isAdmin(): Boolean = role == MemberRole.ADMIN
 
     fun register(
         name: String?,

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberRole.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberRole.kt
@@ -1,0 +1,6 @@
+package com.ditto.domain.member.entity
+
+enum class MemberRole(private val description: String) {
+    USER("일반 회원"),
+    ADMIN("관리자"),
+}

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberTest.kt
@@ -97,6 +97,21 @@ class MemberTest(
             }
         }
 
+        "Member 권한" - {
+            "기본 권한은 USER이다" {
+                val member = memberRepository.save(Member(nickname = "테스트유저"))
+
+                member.role shouldBe MemberRole.USER
+                member.isAdmin() shouldBe false
+            }
+
+            "ADMIN 권한이면 isAdmin()이 true다" {
+                val member = Member(nickname = "관리자", role = MemberRole.ADMIN)
+
+                member.isAdmin() shouldBe true
+            }
+        }
+
         "Member 상태 변경" - {
             "activate() 호출 시 ACTIVE 상태로 변경된다" {
                 val member = memberRepository.save(Member(nickname = "테스트유저", email = "test@kakao.com"))

--- a/domain/src/testFixtures/kotlin/com/ditto/domain/member/MemberFixture.kt
+++ b/domain/src/testFixtures/kotlin/com/ditto/domain/member/MemberFixture.kt
@@ -5,6 +5,7 @@ import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
 import com.ditto.domain.member.entity.Location
 import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberRole
 import com.ditto.domain.member.entity.MemberStatus
 import com.ditto.domain.withId
 
@@ -14,6 +15,7 @@ object MemberFixture {
         nickname: String = "테스트유저",
         email: String = "test@example.com",
         status: MemberStatus = MemberStatus.PENDING,
+        role: MemberRole = MemberRole.USER,
         gender: Gender? = null,
         age: Int? = null,
         interests: Set<Interest> = emptySet(),
@@ -25,6 +27,7 @@ object MemberFixture {
         nickname = nickname,
         email = email,
         status = status,
+        role = role,
         gender = gender,
         age = age,
         interests = interests,


### PR DESCRIPTION
## 개요

`/api/v1/admin/**` 경로가 현재 공통 인증(API Key + JWT)만으로 열려 있어, 인증된 회원이면 누구나 어드민 API(매칭 재생성)를 호출할 수 있는 상태입니다. `MatchAdminController` 주석에 명시돼 있던 "admin 전용 인가 후속 작업"을 수행합니다.

## 변경 사항

### 도메인
- `MemberRole` enum(USER/ADMIN) 추가, `Member.role` 필드(기본 USER) + `isAdmin()`
- Flyway 마이그레이션: `member.role VARCHAR(20) NOT NULL DEFAULT 'USER'`

### JWT
- 액세스 토큰에 `role` 클레임 추가 — **FE 표시용**이며 서버 인가는 DB의 `member.role` 기준 (수동 권한 변경이 재로그인 없이 즉시 반영, 강등 시 기존 토큰으로 어드민 접근 불가)
- `AuthService.refresh()`가 회원을 로드해 최신 role로 토큰 재발급

### 인가
- `JwtAuthenticationFilter`에 기존 PENDING 게이트와 동일한 패턴으로 admin 게이트 추가: `/api/v1/admin` 하위 경로 + USER 회원 → 403 + `ApiResponse.error(FORBIDDEN, "0003")`
- 경로 prefix 기반이라 향후 admin 엔드포인트는 추가 작업 없이 자동 보호 (어드민 모듈 분리 시 if 블록 이동만으로 이행 가능)
- `@PreAuthorize` 방식은 어드민 모듈 분리 계획·opt-in 누락 리스크 때문에 미채택

### 운영
- ADMIN 부여는 운영자 수동 실행 (마이그레이션 파일 주석에 레시피): `UPDATE member SET role = 'ADMIN' WHERE id = ?;`
- 어드민도 일반 회원과 동일하게 카카오 OAuth로 로그인 (별도 로그인 체계 없음)

## 테스트

- `JwtAuthenticationFilterTest`: ADMIN 허용 / USER 403 (테스트 경로 + 실제 매칭 재생성 API 2중 검증)
- `JwtTokenProviderTest`: role 클레임 포함 검증
- `MemberTest`: 기본 role=USER, `isAdmin()` 동작
- `./gradlew build check` 통과 (전체 테스트 + Jacoco 50%)

🤖 Generated with [Claude Code](https://claude.com/claude-code)