### PR TITLE
feat. 어드민 회원 Role 변경 (이메일 검색 → 개별 권한 변경)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberController.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberController.kt
@@ -1,0 +1,52 @@
+package com.ditto.api.admin.member
+
+import com.ditto.api.admin.auth.AdminPrincipal
+import com.ditto.domain.member.entity.MemberRole
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestParam
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+/**
+ * 회원 검색(이메일) 및 권한 변경. 같은 이메일에 여러 회원이 있을 수 있어 목록으로 보여주고 개별 변경한다.
+ */
+@Controller
+class AdminMemberController(
+    private val adminMemberService: AdminMemberService,
+) {
+    @GetMapping("/admin/members")
+    fun page(@RequestParam(required = false) email: String?, model: Model): String {
+        model.addAttribute("email", email ?: "")
+        model.addAttribute("roles", MemberRole.entries)
+        model.addAttribute("searched", !email.isNullOrBlank())
+        if (!email.isNullOrBlank()) {
+            model.addAttribute("members", adminMemberService.searchByEmail(email))
+        }
+        model.addAttribute("active", "member")
+        return "member/list"
+    }
+
+    @PostMapping("/admin/members/{id}/role")
+    fun changeRole(
+        @PathVariable id: Long,
+        @RequestParam role: MemberRole,
+        @RequestParam(required = false) email: String?,
+        @AuthenticationPrincipal admin: AdminPrincipal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        adminMemberService.changeRole(id, role)
+        log.info { "어드민[${admin.displayName}] 이 회원 #$id 의 권한을 $role 로 변경" }
+        redirectAttributes.addFlashAttribute("message", "회원 #$id 의 권한을 ${role.label} 로 변경했습니다.")
+        if (!email.isNullOrBlank()) redirectAttributes.addAttribute("email", email)
+        return "redirect:/admin/members"
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberController.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberController.kt
@@ -23,6 +23,7 @@ class AdminMemberController(
     fun page(@RequestParam(required = false) email: String?, model: Model): String {
         model.addAttribute("email", email ?: "")
         model.addAttribute("roles", MemberRole.entries)
+        model.addAttribute("admins", adminMemberService.listAdmins())
         model.addAttribute("searched", !email.isNullOrBlank())
         if (!email.isNullOrBlank()) {
             model.addAttribute("members", adminMemberService.searchByEmail(email))

--- a/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberService.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberService.kt
@@ -1,0 +1,32 @@
+package com.ditto.api.admin.member
+
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberRole
+import com.ditto.domain.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 어드민 회원 운영 — 이메일 검색 및 권한(Role) 변경.
+ */
+@Service
+@Transactional
+class AdminMemberService(
+    private val memberRepository: MemberRepository,
+) {
+    /** 이메일 정확 일치 검색. 입력의 공백은 모두 제거 후 매칭한다. */
+    @Transactional(readOnly = true)
+    fun searchByEmail(email: String): List<Member> {
+        val normalized = email.filterNot { it.isWhitespace() }
+        if (normalized.isEmpty()) return emptyList()
+        return memberRepository.findByEmailOrderByIdAsc(normalized)
+    }
+
+    /** 회원 권한을 변경한다. */
+    fun changeRole(memberId: Long, role: MemberRole) {
+        val member = memberRepository.findById(memberId).orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+        member.changeRole(role)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberService.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/member/AdminMemberService.kt
@@ -24,6 +24,10 @@ class AdminMemberService(
         return memberRepository.findByEmailOrderByIdAsc(normalized)
     }
 
+    /** 현재 ADMIN 권한 보유 회원 목록. */
+    @Transactional(readOnly = true)
+    fun listAdmins(): List<Member> = memberRepository.findByRoleOrderByIdAsc(MemberRole.ADMIN)
+
     /** 회원 권한을 변경한다. */
     fun changeRole(memberId: Long, role: MemberRole) {
         val member = memberRepository.findById(memberId).orElseThrow { WarnException(ErrorCode.NOT_FOUND) }

--- a/api/src/main/resources/templates/fragments.html
+++ b/api/src/main/resources/templates/fragments.html
@@ -14,6 +14,7 @@
     <nav class="nav">
         <a th:href="@{/admin}" th:classappend="${active == 'dashboard'} ? 'active'"><span class="ico">🏠</span> 대시보드</a>
         <a th:href="@{/admin/quiz-sets}" th:classappend="${active == 'quiz'} ? 'active'"><span class="ico">📝</span> 퀴즈셋 관리</a>
+        <a th:href="@{/admin/members}" th:classappend="${active == 'member'} ? 'active'"><span class="ico">👤</span> 회원 관리</a>
         <a th:href="@{/admin/time-override}" th:classappend="${active == 'time'} ? 'active'"><span class="ico">⏱️</span> 시간 조정</a>
         <a th:href="@{/admin/matching}" th:classappend="${active == 'matching'} ? 'active'"><span class="ico">💞</span> 매칭 실행</a>
     </nav>

--- a/api/src/main/resources/templates/member/list.html
+++ b/api/src/main/resources/templates/member/list.html
@@ -1,0 +1,57 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments :: head('회원 관리')}"></head>
+<body>
+<div class="layout">
+    <aside th:replace="~{fragments :: sidebar('member')}"></aside>
+    <div class="main-wrap">
+        <header th:replace="~{fragments :: topbar}"></header>
+        <main class="content">
+            <h1 class="page-title">회원 관리</h1>
+            <p class="page-desc">이메일로 회원을 검색해 권한(Role)을 변경합니다.</p>
+            <div th:replace="~{fragments :: alerts}"></div>
+
+            <div class="card">
+                <form th:action="@{/admin/members}" method="get" class="field-row" style="align-items:flex-end">
+                    <div class="field" style="flex:1">
+                        <label>이메일</label>
+                        <input type="text" name="email" th:value="${email}" placeholder="member@example.com"/>
+                    </div>
+                    <div class="field"><button class="btn" type="submit">검색</button></div>
+                </form>
+            </div>
+
+            <div class="card" th:if="${searched}">
+                <p class="muted" th:if="${members == null or members.isEmpty()}">검색 결과가 없습니다.</p>
+                <table class="tbl" th:unless="${members == null or members.isEmpty()}">
+                    <thead>
+                    <tr><th>ID</th><th>닉네임</th><th>이메일</th><th>상태</th><th>현재 권한</th><th>권한 변경</th></tr>
+                    </thead>
+                    <tbody>
+                    <tr th:each="m : ${members}">
+                        <td class="num" th:text="${m.id}">-</td>
+                        <td th:text="${m.nickname}">nick</td>
+                        <td th:text="${m.email}">email</td>
+                        <td class="num" th:text="${m.status}">status</td>
+                        <td>
+                            <span class="badge" th:classappend="${m.admin} ? 'on' : 'off'" th:text="${m.role}">role</span>
+                        </td>
+                        <td>
+                            <form class="btn-row" style="margin:0" th:action="@{/admin/members/{id}/role(id=${m.id})}" method="post"
+                                  onsubmit="return confirm('이 회원의 권한을 변경할까요?');">
+                                <input type="hidden" name="email" th:value="${email}"/>
+                                <select name="role" style="width:auto; padding:7px 10px; border:1px solid var(--border); border-radius:8px; font-family:inherit;">
+                                    <option th:each="r : ${roles}" th:value="${r}" th:text="${r.label}" th:selected="${r == m.role}"></option>
+                                </select>
+                                <button class="btn sm" type="submit">변경</button>
+                            </form>
+                        </td>
+                    </tr>
+                    </tbody>
+                </table>
+            </div>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/api/src/main/resources/templates/member/list.html
+++ b/api/src/main/resources/templates/member/list.html
@@ -8,47 +8,32 @@
         <header th:replace="~{fragments :: topbar}"></header>
         <main class="content">
             <h1 class="page-title">회원 관리</h1>
-            <p class="page-desc">이메일로 회원을 검색해 권한(Role)을 변경합니다.</p>
+            <p class="page-desc">이메일로 회원을 검색하거나, 현재 관리자 목록에서 권한(Role)을 변경합니다.</p>
             <div th:replace="~{fragments :: alerts}"></div>
 
+            <!-- 현재 관리자 -->
+            <div class="card">
+                <h2>현재 관리자 <span class="badge cat" th:text="${admins.size()} + '명'">0명</span></h2>
+                <p class="muted" th:if="${admins.isEmpty()}">관리자가 없습니다.</p>
+                <div th:unless="${admins.isEmpty()}" th:replace="~{member/parts :: memberTable(${admins})}"></div>
+            </div>
+
+            <!-- 이메일 검색 -->
             <div class="card">
                 <form th:action="@{/admin/members}" method="get" class="field-row" style="align-items:flex-end">
                     <div class="field" style="flex:1">
-                        <label>이메일</label>
+                        <label>이메일로 검색</label>
                         <input type="text" name="email" th:value="${email}" placeholder="member@example.com"/>
                     </div>
                     <div class="field"><button class="btn" type="submit">검색</button></div>
                 </form>
             </div>
 
+            <!-- 검색 결과 -->
             <div class="card" th:if="${searched}">
+                <h2>검색 결과</h2>
                 <p class="muted" th:if="${members == null or members.isEmpty()}">검색 결과가 없습니다.</p>
-                <table class="tbl" th:unless="${members == null or members.isEmpty()}">
-                    <thead>
-                    <tr><th>ID</th><th>닉네임</th><th>이메일</th><th>상태</th><th>현재 권한</th><th>권한 변경</th></tr>
-                    </thead>
-                    <tbody>
-                    <tr th:each="m : ${members}">
-                        <td class="num" th:text="${m.id}">-</td>
-                        <td th:text="${m.nickname}">nick</td>
-                        <td th:text="${m.email}">email</td>
-                        <td class="num" th:text="${m.status}">status</td>
-                        <td>
-                            <span class="badge" th:classappend="${m.admin} ? 'on' : 'off'" th:text="${m.role}">role</span>
-                        </td>
-                        <td>
-                            <form class="btn-row" style="margin:0" th:action="@{/admin/members/{id}/role(id=${m.id})}" method="post"
-                                  onsubmit="return confirm('이 회원의 권한을 변경할까요?');">
-                                <input type="hidden" name="email" th:value="${email}"/>
-                                <select name="role" style="width:auto; padding:7px 10px; border:1px solid var(--border); border-radius:8px; font-family:inherit;">
-                                    <option th:each="r : ${roles}" th:value="${r}" th:text="${r.label}" th:selected="${r == m.role}"></option>
-                                </select>
-                                <button class="btn sm" type="submit">변경</button>
-                            </form>
-                        </td>
-                    </tr>
-                    </tbody>
-                </table>
+                <div th:unless="${members == null or members.isEmpty()}" th:replace="~{member/parts :: memberTable(${members})}"></div>
             </div>
         </main>
     </div>

--- a/api/src/main/resources/templates/member/parts.html
+++ b/api/src/main/resources/templates/member/parts.html
@@ -1,0 +1,32 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<body>
+<!-- 회원 표(재사용). 호출 컨텍스트의 ${roles}, ${email} 을 사용한다. -->
+<table th:fragment="memberTable(rows)" class="tbl">
+    <thead>
+    <tr><th>ID</th><th>닉네임</th><th>이메일</th><th>상태</th><th>현재 권한</th><th>권한 변경</th></tr>
+    </thead>
+    <tbody>
+    <tr th:each="m : ${rows}">
+        <td class="num" th:text="${m.id}">-</td>
+        <td th:text="${m.nickname}">nick</td>
+        <td th:text="${m.email}">email</td>
+        <td class="num" th:text="${m.status}">status</td>
+        <td>
+            <span class="badge" th:classappend="${m.admin} ? 'on' : 'off'" th:text="${m.role}">role</span>
+        </td>
+        <td>
+            <form class="btn-row" style="margin:0" th:action="@{/admin/members/{id}/role(id=${m.id})}" method="post"
+                  onsubmit="return confirm('이 회원의 권한을 변경할까요?');">
+                <input type="hidden" name="email" th:value="${email}"/>
+                <select name="role" style="width:auto; padding:7px 10px; border:1px solid var(--border); border-radius:8px; font-family:inherit;">
+                    <option th:each="r : ${roles}" th:value="${r}" th:text="${r.label}" th:selected="${r == m.role}"></option>
+                </select>
+                <button class="btn sm" type="submit">변경</button>
+            </form>
+        </td>
+    </tr>
+    </tbody>
+</table>
+</body>
+</html>

--- a/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
@@ -154,6 +154,33 @@ class AdminWebTest {
     }
 
     @Test
+    @DisplayName("회원 관리 페이지 — 검색 전/검색 결과 렌더")
+    fun memberSearchPage() {
+        // 검색 전 빈 상태
+        mockMvc.perform(get("/admin/members").with(authentication(admin()))).andExpect(status().isOk)
+
+        // 같은 이메일을 가진 회원 2명
+        memberRepository.save(MemberFixture.create(nickname = "m1", email = "dup@ditto.pics", role = MemberRole.USER))
+        memberRepository.save(MemberFixture.create(nickname = "m2", email = "dup@ditto.pics", role = MemberRole.ADMIN))
+
+        mockMvc.perform(get("/admin/members").param("email", "dup@ditto.pics").with(authentication(admin())))
+            .andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("회원 권한 변경 후 검색어 유지 리다이렉트")
+    fun memberRoleChange() {
+        val member = memberRepository.save(
+            MemberFixture.create(nickname = "rolechg", email = "role@ditto.pics", role = MemberRole.USER),
+        )
+
+        mockMvc.perform(
+            post("/admin/members/{id}/role", member.id).with(authentication(admin())).with(csrf())
+                .param("role", "ADMIN").param("email", "role@ditto.pics"),
+        ).andExpect(status().is3xxRedirection)
+    }
+
+    @Test
     @DisplayName("카카오 로그인 진입은 인가 URL로 리다이렉트된다")
     fun oauthAuthorizeRedirect() {
         mockMvc.perform(get("/admin/oauth/kakao")).andExpect(status().is3xxRedirection)

--- a/api/src/test/kotlin/com/ditto/api/admin/member/AdminMemberServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/member/AdminMemberServiceTest.kt
@@ -49,4 +49,13 @@ class AdminMemberServiceTest : FreeSpec({
 
         shouldThrow<WarnException> { AdminMemberService(repository).changeRole(99L, MemberRole.ADMIN) }
     }
+
+    "listAdmins 는 ADMIN 권한 회원을 조회한다" {
+        val repository = mockk<MemberRepository>()
+        every { repository.findByRoleOrderByIdAsc(MemberRole.ADMIN) } returns
+            listOf(MemberFixture.create(role = MemberRole.ADMIN, id = 1L))
+
+        AdminMemberService(repository).listAdmins() shouldHaveSize 1
+        verify { repository.findByRoleOrderByIdAsc(MemberRole.ADMIN) }
+    }
 })

--- a/api/src/test/kotlin/com/ditto/api/admin/member/AdminMemberServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/member/AdminMemberServiceTest.kt
@@ -1,0 +1,52 @@
+package com.ditto.api.admin.member
+
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.MemberFixture
+import com.ditto.domain.member.entity.MemberRole
+import com.ditto.domain.member.repository.MemberRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.collections.shouldHaveSize
+import io.kotest.matchers.shouldBe
+import io.mockk.every
+import io.mockk.mockk
+import io.mockk.verify
+import java.util.Optional
+
+class AdminMemberServiceTest : FreeSpec({
+    "searchByEmail 은 공백을 제거하고 이메일 정확 일치로 조회한다" {
+        val repository = mockk<MemberRepository>()
+        every { repository.findByEmailOrderByIdAsc("a@b.com") } returns
+            listOf(MemberFixture.create(email = "a@b.com", id = 1L))
+
+        val result = AdminMemberService(repository).searchByEmail("  a@b.com ")
+
+        result shouldHaveSize 1
+        verify { repository.findByEmailOrderByIdAsc("a@b.com") }
+    }
+
+    "searchByEmail 은 공백뿐이면 조회 없이 빈 목록" {
+        val repository = mockk<MemberRepository>()
+
+        AdminMemberService(repository).searchByEmail("   ") shouldBe emptyList()
+
+        verify(exactly = 0) { repository.findByEmailOrderByIdAsc(any()) }
+    }
+
+    "changeRole 은 회원 권한을 변경한다" {
+        val repository = mockk<MemberRepository>()
+        val member = MemberFixture.create(role = MemberRole.USER, id = 1L)
+        every { repository.findById(1L) } returns Optional.of(member)
+
+        AdminMemberService(repository).changeRole(1L, MemberRole.ADMIN)
+
+        member.role shouldBe MemberRole.ADMIN
+    }
+
+    "changeRole 은 없는 회원이면 예외" {
+        val repository = mockk<MemberRepository>()
+        every { repository.findById(99L) } returns Optional.empty()
+
+        shouldThrow<WarnException> { AdminMemberService(repository).changeRole(99L, MemberRole.ADMIN) }
+    }
+})

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
@@ -121,6 +121,11 @@ class Member(
     fun isActive(): Boolean = status == MemberStatus.ACTIVE
     fun isAdmin(): Boolean = role == MemberRole.ADMIN
 
+    /** 회원 권한을 변경한다(어드민 운영용). */
+    fun changeRole(role: MemberRole) {
+        this.role = role
+    }
+
     fun register(
         name: String?,
         nickname: String?,

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberRole.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberRole.kt
@@ -1,6 +1,10 @@
 package com.ditto.domain.member.entity
 
-enum class MemberRole(private val description: String) {
+enum class MemberRole(val description: String) {
     USER("일반 회원"),
     ADMIN("관리자"),
+    ;
+
+    /** 화면 표기용 라벨. 예: `USER(일반 회원)` */
+    val label: String get() = "$name($description)"
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
@@ -5,4 +5,7 @@ import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
     fun existsByNickname(nickname: String): Boolean
+
+    /** 이메일 정확 일치 회원 목록(같은 이메일에 여러 명 가능). */
+    fun findByEmailOrderByIdAsc(email: String): List<Member>
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
@@ -1,6 +1,7 @@
 package com.ditto.domain.member.repository
 
 import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberRole
 import org.springframework.data.jpa.repository.JpaRepository
 
 interface MemberRepository : JpaRepository<Member, Long> {
@@ -8,4 +9,7 @@ interface MemberRepository : JpaRepository<Member, Long> {
 
     /** 이메일 정확 일치 회원 목록(같은 이메일에 여러 명 가능). */
     fun findByEmailOrderByIdAsc(email: String): List<Member>
+
+    /** 특정 권한을 가진 회원 목록(어드민 보유자 조회 등). */
+    fun findByRoleOrderByIdAsc(role: MemberRole): List<Member>
 }


### PR DESCRIPTION
Closes #86

## 개요
어드민(`/admin/members`)에서 **이메일로 회원을 검색**하고, 같은 이메일을 가진 여러 회원 중 **개별로 권한(Role)을 변경**한다.

## 기능
- 이메일 **정확 일치** 검색 — 입력의 공백은 모두 제거 후 매칭. 동일 이메일 다중 회원 목록 표시.
- 회원별 Role 변경: `MemberRole` 전체(현재 USER/ADMIN), **`USER(일반 회원)` 형식** 표기. 변경 시 confirm + 검색어 유지 리다이렉트.
- **자기 자신 강등 허용**.
- 변경 시 audit 로그(`어드민[이름(이메일)] 이 회원 #id 의 권한을 ROLE 로 변경`).

## 변경
- domain: `MemberRepository.findByEmailOrderByIdAsc`, `Member.changeRole`, `MemberRole` 에 `description`/`label`(예: `USER(일반 회원)`) 노출
- api: `com.ditto.api.admin.member` (AdminMemberService/Controller) + `templates/member/list.html`, 사이드바 "회원 관리" 메뉴
- 보안: 기존 `/admin/**` ROLE_ADMIN 체인에 포함(별도 작업 없음)

## 검증
- `./gradlew build check` 전 모듈 통과 (테스트 + jacoco)
- `AdminMemberServiceTest`(공백 제거 검색/빈 검색/권한 변경/없는 회원), `AdminWebTest`(검색 페이지·권한 변경 플로우)
- SonarCloud New Code 커버리지 게이트 확인 예정

🤖 Generated with [Claude Code](https://claude.com/claude-code)