### PR TITLE
feat. 어드민 더미 참여자 생성 (특정 퀴즈셋 랜덤 풀이 더미 생성·삭제)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyController.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyController.kt
@@ -26,6 +26,7 @@ class AdminDummyController(
     fun page(model: Model): String {
         model.addAttribute("form", DummyGenerateForm())
         model.addAttribute("quizSets", quizSetRepository.findAllByOrderByYearDescMonthDescWeekDescIdDesc())
+        model.addAttribute("dummyCount", adminDummyService.countDummies())
         model.addAttribute("active", "dummy")
         return "dummy"
     }
@@ -46,6 +47,17 @@ class AdminDummyController(
                 if (e !is WarnException) throw e
                 redirectAttributes.addFlashAttribute("error", e.message)
             }
+        return "redirect:/admin/dummy"
+    }
+
+    @PostMapping("/admin/dummy/clear")
+    fun clear(
+        @AuthenticationPrincipal admin: AdminPrincipal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        val deleted = adminDummyService.deleteAllDummies()
+        log.info { "어드민[${admin.displayName}] 이 더미 ${deleted}명 삭제" }
+        redirectAttributes.addFlashAttribute("message", "더미 ${deleted}명을 삭제했습니다.")
         return "redirect:/admin/dummy"
     }
 

--- a/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyController.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyController.kt
@@ -1,0 +1,55 @@
+package com.ditto.api.admin.dummy
+
+import com.ditto.api.admin.auth.AdminPrincipal
+import com.ditto.api.admin.dummy.dto.DummyGenerateForm
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.stereotype.Controller
+import org.springframework.ui.Model
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.ModelAttribute
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.servlet.mvc.support.RedirectAttributes
+
+/**
+ * 더미 참여자 생성(서버 렌더링). 선택한 퀴즈셋을 랜덤하게 푼 더미 회원을 남/여 인원수만큼 만든다.
+ * 데이터(회원·진행·답변)만 생성하며, 매칭 후보는 '매칭 실행'에서 별도로 재생성한다.
+ */
+@Controller
+class AdminDummyController(
+    private val adminDummyService: AdminDummyService,
+    private val quizSetRepository: QuizSetRepository,
+) {
+    @GetMapping("/admin/dummy")
+    fun page(model: Model): String {
+        model.addAttribute("form", DummyGenerateForm())
+        model.addAttribute("quizSets", quizSetRepository.findAllByOrderByYearDescMonthDescWeekDescIdDesc())
+        model.addAttribute("active", "dummy")
+        return "dummy"
+    }
+
+    @PostMapping("/admin/dummy")
+    fun generate(
+        @ModelAttribute("form") form: DummyGenerateForm,
+        @AuthenticationPrincipal admin: AdminPrincipal,
+        redirectAttributes: RedirectAttributes,
+    ): String {
+        runCatching { adminDummyService.generate(form) }
+            .onSuccess { created ->
+                log.info { "어드민[${admin.displayName}] 이 퀴즈셋 #${form.quizSetId} 에 더미 ${created}명 생성" }
+                redirectAttributes.addFlashAttribute("message", "퀴즈셋 #${form.quizSetId} 에 더미 ${created}명을 생성했습니다.")
+            }
+            .onFailure { e ->
+                // 입력값 오류(WarnException)는 화면에 안내하고, 예기치 못한 예외는 전역 핸들러로 전파한다.
+                if (e !is WarnException) throw e
+                redirectAttributes.addFlashAttribute("error", e.message)
+            }
+        return "redirect:/admin/dummy"
+    }
+
+    companion object {
+        private val log = KotlinLogging.logger {}
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyService.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyService.kt
@@ -9,6 +9,7 @@ import com.ditto.domain.member.entity.Job
 import com.ditto.domain.member.entity.Location
 import com.ditto.domain.member.entity.Member
 import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.match.repository.MatchCandidateRepository
 import com.ditto.domain.quiz.entity.Quiz
 import com.ditto.domain.quiz.entity.QuizAnswer
 import com.ditto.domain.quiz.entity.QuizChoice
@@ -37,6 +38,7 @@ class AdminDummyService(
     private val memberRepository: MemberRepository,
     private val quizProgressRepository: QuizProgressRepository,
     private val quizAnswerRepository: QuizAnswerRepository,
+    private val matchCandidateRepository: MatchCandidateRepository,
 ) {
     /** 더미를 생성하고 생성된 인원수를 반환한다. */
     fun generate(form: DummyGenerateForm): Int {
@@ -60,6 +62,21 @@ class AdminDummyService(
             count
         }
     }
+
+    /** 마커로 식별된 모든 더미 회원과 그들의 진행·답변·매칭 후보를 삭제하고 삭제 인원수를 반환한다. */
+    fun deleteAllDummies(): Int {
+        val dummyIds = memberRepository.findByNicknameStartingWith(NICKNAME_PREFIX).map { it.id }
+        if (dummyIds.isEmpty()) return 0
+        quizAnswerRepository.deleteByMemberIdIn(dummyIds)
+        quizProgressRepository.deleteByMemberIdIn(dummyIds)
+        matchCandidateRepository.deleteByOwnerOrOtherMemberIdIn(dummyIds)
+        memberRepository.deleteAllByIdInBatch(dummyIds)
+        return dummyIds.size
+    }
+
+    /** 현재 더미 회원 수(현황 표시용). */
+    @Transactional(readOnly = true)
+    fun countDummies(): Long = memberRepository.countByNicknameStartingWith(NICKNAME_PREFIX)
 
     private fun validate(form: DummyGenerateForm) {
         if (form.maleCount < 0 || form.femaleCount < 0) {

--- a/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyService.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyService.kt
@@ -67,6 +67,7 @@ class AdminDummyService(
     fun deleteAllDummies(): Int {
         val dummyIds = memberRepository.findByNicknameStartingWith(NICKNAME_PREFIX).map { it.id }
         if (dummyIds.isEmpty()) return 0
+        // 회원에 딸린 데이터(답변·진행·매칭후보)를 먼저 지우고 회원을 마지막에 삭제한다.
         quizAnswerRepository.deleteByMemberIdIn(dummyIds)
         quizProgressRepository.deleteByMemberIdIn(dummyIds)
         matchCandidateRepository.deleteByOwnerOrOtherMemberIdIn(dummyIds)
@@ -145,7 +146,7 @@ class AdminDummyService(
 
     companion object {
         const val NICKNAME_PREFIX = "dummy-"
-        const val EMAIL_DOMAIN = "dummy.local"
+        private const val EMAIL_DOMAIN = "dummy.local"
         private const val DUMMY_CARICATURE = "dummy"
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyService.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/dummy/AdminDummyService.kt
@@ -1,0 +1,134 @@
+package com.ditto.api.admin.dummy
+
+import com.ditto.api.admin.dummy.dto.DummyGenerateForm
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.GenderPreference
+import com.ditto.domain.member.entity.Job
+import com.ditto.domain.member.entity.Location
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.entity.Quiz
+import com.ditto.domain.quiz.entity.QuizAnswer
+import com.ditto.domain.quiz.entity.QuizChoice
+import com.ditto.domain.quiz.entity.QuizProgress
+import com.ditto.domain.quiz.repository.QuizAnswerRepository
+import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizProgressRepository
+import com.ditto.domain.quiz.repository.QuizRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+import java.util.UUID
+import kotlin.random.Random
+
+/**
+ * 어드민 편의 기능 — 특정 퀴즈셋을 랜덤하게 푼(COMPLETED) 더미 회원을 남/여 인원수만큼 생성한다.
+ * 회원(member)·진행(quiz_progress)·답변(quiz_answer)만 만들고 매칭 후보(match_candidate)는
+ * 만들지 않는다(어드민 '매칭 재생성'으로 분리). 더미는 닉네임/이메일 마커로 식별·정리한다.
+ */
+@Service
+@Transactional
+class AdminDummyService(
+    private val quizSetRepository: QuizSetRepository,
+    private val quizRepository: QuizRepository,
+    private val quizChoiceRepository: QuizChoiceRepository,
+    private val memberRepository: MemberRepository,
+    private val quizProgressRepository: QuizProgressRepository,
+    private val quizAnswerRepository: QuizAnswerRepository,
+) {
+    /** 더미를 생성하고 생성된 인원수를 반환한다. */
+    fun generate(form: DummyGenerateForm): Int {
+        validate(form)
+
+        val quizSet = quizSetRepository.findById(form.quizSetId)
+            .orElseThrow { WarnException(ErrorCode.NOT_FOUND) }
+
+        val quizzes = quizRepository.findByQuizSetIdOrderByDisplayOrderAsc(quizSet.id)
+            .ifEmpty { throw WarnException(ErrorCode.BAD_REQUEST, "문항이 없는 퀴즈셋에는 더미를 생성할 수 없습니다.") }
+
+        val choicesByQuizId = quizChoiceRepository
+            .findByQuizIdInOrderByDisplayOrderAsc(quizzes.map { it.id })
+            .groupBy { it.quizId }
+
+        val context = SolveContext(quizSet.id, quizzes, choicesByQuizId)
+        val genderCounts = listOf(Gender.MALE to form.maleCount, Gender.FEMALE to form.femaleCount)
+
+        return genderCounts.sumOf { (gender, count) ->
+            repeat(count) { createDummy(gender, form, context) }
+            count
+        }
+    }
+
+    private fun validate(form: DummyGenerateForm) {
+        if (form.maleCount < 0 || form.femaleCount < 0) {
+            throw WarnException(ErrorCode.BAD_REQUEST, "생성 인원수는 음수일 수 없습니다.")
+        }
+        if (form.maleCount + form.femaleCount == 0) {
+            throw WarnException(ErrorCode.BAD_REQUEST, "생성할 인원수를 입력해주세요.")
+        }
+        if (form.minAge <= 0) {
+            throw WarnException(ErrorCode.BAD_REQUEST, "나이는 1 이상이어야 합니다.")
+        }
+        if (form.minAge > form.maxAge) {
+            throw WarnException(ErrorCode.BAD_REQUEST, "최소 나이가 최대 나이보다 클 수 없습니다.")
+        }
+    }
+
+    private fun createDummy(gender: Gender, form: DummyGenerateForm, context: SolveContext) {
+        val member = memberRepository.save(newDummyMember(gender, form))
+        saveCompletedProgress(member.id, context, form.preferredGender)
+        saveRandomAnswers(member.id, context)
+    }
+
+    private fun newDummyMember(gender: Gender, form: DummyGenerateForm): Member {
+        val nickname = "$NICKNAME_PREFIX${gender.name.lowercase()}-${UUID.randomUUID().toString().take(8)}"
+        // 실제 가입과 동일하게 register() 로 활성화한다(ACTIVE 전이·joinedAt·필수 프로필을 도메인이 소유).
+        // gender·age 가 null 이면 매칭 후보 풀에서 제외되므로 더미는 반드시 채운다.
+        return Member(nickname = nickname, email = "$nickname@$EMAIL_DOMAIN").apply {
+            register(
+                name = null,
+                nickname = null,
+                phoneNumber = null,
+                gender = gender,
+                age = Random.nextInt(form.minAge, form.maxAge + 1),
+                birthDate = null,
+                email = null,
+                interests = emptySet(),
+                location = Location.entries.random(),
+                job = Job.entries.random(),
+                caricature = DUMMY_CARICATURE,
+            )
+        }
+    }
+
+    private fun saveCompletedProgress(memberId: Long, context: SolveContext, preferredGender: GenderPreference) {
+        val progress = QuizProgress.create(memberId, context.quizSetId, context.quizzes.size)
+        progress.selectPreferredGender(preferredGender)
+        // status·answeredCount 는 protected set 이라 recordAnswer 를 문항 수만큼 호출해야 COMPLETED 가 된다.
+        repeat(context.quizzes.size) { progress.recordAnswer() }
+        quizProgressRepository.save(progress)
+    }
+
+    private fun saveRandomAnswers(memberId: Long, context: SolveContext) {
+        val answers = context.quizzes.map { quiz ->
+            val choices = context.choicesByQuizId[quiz.id]
+                ?: throw WarnException(ErrorCode.BAD_REQUEST, "선택지가 없는 문항이 있어 더미를 생성할 수 없습니다: quizId=${quiz.id}")
+            QuizAnswer.create(memberId, quiz.id, choices.random().id)
+        }
+        quizAnswerRepository.saveAll(answers)
+    }
+
+    private class SolveContext(
+        val quizSetId: Long,
+        val quizzes: List<Quiz>,
+        val choicesByQuizId: Map<Long, List<QuizChoice>>,
+    )
+
+    companion object {
+        const val NICKNAME_PREFIX = "dummy-"
+        const val EMAIL_DOMAIN = "dummy.local"
+        private const val DUMMY_CARICATURE = "dummy"
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/admin/dummy/dto/DummyGenerateForm.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/dummy/dto/DummyGenerateForm.kt
@@ -1,0 +1,13 @@
+package com.ditto.api.admin.dummy.dto
+
+import com.ditto.domain.member.entity.GenderPreference
+
+/** 더미 참여자 생성 폼(스프링 폼 바인딩). */
+class DummyGenerateForm(
+    var quizSetId: Long = 0L,
+    var maleCount: Int = 0,
+    var femaleCount: Int = 0,
+    var minAge: Int = 20,
+    var maxAge: Int = 35,
+    var preferredGender: GenderPreference = GenderPreference.OPPOSITE,
+)

--- a/api/src/main/resources/templates/dummy.html
+++ b/api/src/main/resources/templates/dummy.html
@@ -48,6 +48,15 @@
             </form>
 
             <p class="muted">매칭은 ONE_TO_ONE 퀴즈셋에서만 동작합니다(GROUP은 후보가 생성되지 않습니다).</p>
+
+            <div class="card">
+                <h2>더미 정리</h2>
+                <p class="muted">현재 더미 회원 <strong th:text="${dummyCount}">0</strong> 명. 마커(<code>dummy-</code> 닉네임)로 식별된 더미와 그들의 진행·답변·매칭 후보를 모두 삭제합니다.</p>
+                <form th:action="@{/admin/dummy/clear}" method="post" class="inline-form"
+                      onsubmit="return confirm('마커로 식별된 모든 더미 회원과 관련 데이터를 삭제합니다. 계속할까요?');">
+                    <button class="btn secondary" type="submit">더미 전체 삭제</button>
+                </form>
+            </div>
         </main>
     </div>
 </div>

--- a/api/src/main/resources/templates/dummy.html
+++ b/api/src/main/resources/templates/dummy.html
@@ -1,0 +1,55 @@
+<!DOCTYPE html>
+<html lang="ko" xmlns:th="http://www.thymeleaf.org">
+<head th:replace="~{fragments :: head('더미 생성')}"></head>
+<body>
+<div class="layout">
+    <aside th:replace="~{fragments :: sidebar('dummy')}"></aside>
+    <div class="main-wrap">
+        <header th:replace="~{fragments :: topbar}"></header>
+        <main class="content">
+            <h1 class="page-title">더미 참여자 생성</h1>
+            <p class="page-desc">선택한 퀴즈셋을 랜덤하게 푼(완료) 더미 회원을 남/여 인원수만큼 생성합니다.
+                매칭 후보는 만들지 않으니, 생성 후 '매칭 실행'에서 재생성하세요.</p>
+            <div th:replace="~{fragments :: alerts}"></div>
+
+            <form class="card"
+                  th:object="${form}"
+                  th:action="@{/admin/dummy}"
+                  method="post"
+                  onsubmit="return confirm('운영 환경을 포함한 모든 환경에서 실행됩니다.\n선택한 퀴즈셋에 더미 회원을 생성할까요?');">
+                <div class="field">
+                    <label>대상 퀴즈셋</label>
+                    <select th:field="*{quizSetId}">
+                        <option th:each="qs : ${quizSets}" th:value="${qs.id}"
+                                th:text="|${@weekLabel.of(qs.year, qs.month, qs.week)} · ${qs.title} (${qs.matchingType})|">-</option>
+                    </select>
+                </div>
+                <div class="field-row">
+                    <div class="field"><label>남자 수</label><input type="number" th:field="*{maleCount}" min="0"/></div>
+                    <div class="field"><label>여자 수</label><input type="number" th:field="*{femaleCount}" min="0"/></div>
+                </div>
+                <div class="field-row">
+                    <div class="field"><label>최소 나이</label><input type="number" th:field="*{minAge}" min="1"/></div>
+                    <div class="field"><label>최대 나이</label><input type="number" th:field="*{maxAge}" min="1"/></div>
+                </div>
+                <div class="field">
+                    <label>매칭 성별 선호</label>
+                    <select th:field="*{preferredGender}">
+                        <option th:value="OPPOSITE">이성끼리 (OPPOSITE)</option>
+                        <option th:value="SAME">동성끼리 (SAME)</option>
+                        <option th:value="ANY">제한 없음 (ANY)</option>
+                    </select>
+                    <p class="muted">기본 OPPOSITE에선 남↔여만 매칭되므로 남·여를 함께 생성해야 페어가 만들어집니다.</p>
+                </div>
+                <hr class="sep"/>
+                <div class="btn-row">
+                    <button type="submit" class="btn">더미 생성</button>
+                </div>
+            </form>
+
+            <p class="muted">매칭은 ONE_TO_ONE 퀴즈셋에서만 동작합니다(GROUP은 후보가 생성되지 않습니다).</p>
+        </main>
+    </div>
+</div>
+</body>
+</html>

--- a/api/src/main/resources/templates/fragments.html
+++ b/api/src/main/resources/templates/fragments.html
@@ -17,6 +17,7 @@
         <a th:href="@{/admin/members}" th:classappend="${active == 'member'} ? 'active'"><span class="ico">👤</span> 회원 관리</a>
         <a th:href="@{/admin/time-override}" th:classappend="${active == 'time'} ? 'active'"><span class="ico">⏱️</span> 시간 조정</a>
         <a th:href="@{/admin/matching}" th:classappend="${active == 'matching'} ? 'active'"><span class="ico">💞</span> 매칭 실행</a>
+        <a th:href="@{/admin/dummy}" th:classappend="${active == 'dummy'} ? 'active'"><span class="ico">🧪</span> 더미 생성</a>
     </nav>
 </aside>
 

--- a/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
@@ -154,6 +154,28 @@ class AdminWebTest {
     }
 
     @Test
+    @DisplayName("더미 생성 페이지 렌더 + 생성/삭제")
+    fun dummyPage() {
+        mockMvc.perform(get("/admin/dummy").with(authentication(admin()))).andExpect(status().isOk)
+
+        val quizSet = quizSetRepository.save(QuizSetFixture.create())
+        val quiz = quizRepository.save(QuizFixture.create(quizSetId = quizSet.id, displayOrder = 1))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "A", displayOrder = 1))
+        quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "B", displayOrder = 2))
+
+        mockMvc.perform(
+            post("/admin/dummy").with(authentication(admin())).with(csrf())
+                .param("quizSetId", quizSet.id.toString())
+                .param("maleCount", "2").param("femaleCount", "2")
+                .param("minAge", "20").param("maxAge", "30")
+                .param("preferredGender", "OPPOSITE"),
+        ).andExpect(status().is3xxRedirection)
+
+        mockMvc.perform(post("/admin/dummy/clear").with(authentication(admin())).with(csrf()))
+            .andExpect(status().is3xxRedirection)
+    }
+
+    @Test
     @DisplayName("회원 관리 페이지 — 검색 전/검색 결과 렌더")
     fun memberSearchPage() {
         // 검색 전 빈 상태

--- a/api/src/test/kotlin/com/ditto/api/admin/dummy/AdminDummyServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/dummy/AdminDummyServiceTest.kt
@@ -21,6 +21,7 @@ import com.ditto.domain.quiz.repository.QuizProgressRepository
 import com.ditto.domain.quiz.repository.QuizRepository
 import com.ditto.domain.quiz.repository.QuizSetRepository
 import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
 import io.kotest.matchers.shouldBe
 import io.kotest.matchers.shouldNotBe
 import javax.sql.DataSource
@@ -59,7 +60,7 @@ class AdminDummyServiceTest(
             )
 
             created shouldBe 5
-            val dummies = memberRepository.findByNicknameStartingWith("dummy-")
+            val dummies = memberRepository.findByNicknameStartingWith(AdminDummyService.NICKNAME_PREFIX)
             dummies.size shouldBe 5
             dummies.count { it.gender == Gender.MALE } shouldBe 2
             dummies.count { it.gender == Gender.FEMALE } shouldBe 3
@@ -79,10 +80,9 @@ class AdminDummyServiceTest(
             )
 
             val quizIds = quizRepository.findByQuizSetIdOrderByDisplayOrderAsc(quizSetId).map { it.id }
-            memberRepository.findByNicknameStartingWith("dummy-").forEach { dummy ->
-                val progress = quizProgressRepository.findByMemberIdAndQuizSetId(dummy.id, quizSetId)
-                progress shouldNotBe null
-                progress!!.status shouldBe QuizProgressStatus.COMPLETED
+            memberRepository.findByNicknameStartingWith(AdminDummyService.NICKNAME_PREFIX).forEach { dummy ->
+                val progress = quizProgressRepository.findByMemberIdAndQuizSetId(dummy.id, quizSetId).shouldNotBeNull()
+                progress.status shouldBe QuizProgressStatus.COMPLETED
                 progress.preferredGender shouldBe GenderPreference.SAME
                 quizAnswerRepository.findByMemberIdAndQuizIdIn(dummy.id, quizIds).size shouldBe 3
             }
@@ -96,7 +96,7 @@ class AdminDummyServiceTest(
             val choiceIdsByQuizId = quizzes.associate { quiz ->
                 quiz.id to quizChoiceRepository.findByQuizIdOrderByDisplayOrderAsc(quiz.id).map { it.id }.toSet()
             }
-            val dummy = memberRepository.findByNicknameStartingWith("dummy-").first()
+            val dummy = memberRepository.findByNicknameStartingWith(AdminDummyService.NICKNAME_PREFIX).first()
             quizAnswerRepository.findByMemberIdAndQuizIdIn(dummy.id, quizzes.map { it.id }).forEach { answer ->
                 (answer.choiceId in choiceIdsByQuizId.getValue(answer.quizId)) shouldBe true
             }
@@ -108,8 +108,9 @@ class AdminDummyServiceTest(
                 DummyGenerateForm(quizSetId = quizSetId, maleCount = 5, femaleCount = 0, minAge = 25, maxAge = 27),
             )
 
-            memberRepository.findByNicknameStartingWith("dummy-").forEach {
-                (it.age!! in 25..27) shouldBe true
+            memberRepository.findByNicknameStartingWith(AdminDummyService.NICKNAME_PREFIX).forEach {
+                val age = it.age.shouldNotBeNull()
+                (age in 25..27) shouldBe true
             }
         }
     }
@@ -160,7 +161,7 @@ class AdminDummyServiceTest(
             val deleted = adminDummyService.deleteAllDummies()
 
             deleted shouldBe 3
-            memberRepository.findByNicknameStartingWith("dummy-").size shouldBe 0
+            memberRepository.findByNicknameStartingWith(AdminDummyService.NICKNAME_PREFIX).size shouldBe 0
             quizProgressRepository.findAll().size shouldBe 0
             quizAnswerRepository.findAll().size shouldBe 0
         }
@@ -168,7 +169,7 @@ class AdminDummyServiceTest(
         "더미가 포함된 매칭 후보도 함께 삭제된다" {
             val quizSetId = setupQuizSet()
             adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 1, femaleCount = 1))
-            val dummies = memberRepository.findByNicknameStartingWith("dummy-")
+            val dummies = memberRepository.findByNicknameStartingWith(AdminDummyService.NICKNAME_PREFIX)
             matchCandidateRepository.save(
                 MatchCandidate.create(dummies[0].id, dummies[1].id, quizSetId, 50.0, 1, 2),
             )

--- a/api/src/test/kotlin/com/ditto/api/admin/dummy/AdminDummyServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/dummy/AdminDummyServiceTest.kt
@@ -1,0 +1,207 @@
+package com.ditto.api.admin.dummy
+
+import com.ditto.api.admin.dummy.dto.DummyGenerateForm
+import com.ditto.api.support.IntegrationTest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.match.entity.MatchCandidate
+import com.ditto.domain.match.repository.MatchCandidateRepository
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.GenderPreference
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.QuizChoiceFixture
+import com.ditto.domain.quiz.QuizFixture
+import com.ditto.domain.quiz.QuizSetFixture
+import com.ditto.domain.quiz.entity.QuizProgressStatus
+import com.ditto.domain.quiz.repository.QuizAnswerRepository
+import com.ditto.domain.quiz.repository.QuizChoiceRepository
+import com.ditto.domain.quiz.repository.QuizProgressRepository
+import com.ditto.domain.quiz.repository.QuizRepository
+import com.ditto.domain.quiz.repository.QuizSetRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.matchers.shouldNotBe
+import javax.sql.DataSource
+
+class AdminDummyServiceTest(
+    private val adminDummyService: AdminDummyService,
+    private val quizSetRepository: QuizSetRepository,
+    private val quizRepository: QuizRepository,
+    private val quizChoiceRepository: QuizChoiceRepository,
+    private val quizProgressRepository: QuizProgressRepository,
+    private val quizAnswerRepository: QuizAnswerRepository,
+    private val memberRepository: MemberRepository,
+    private val matchCandidateRepository: MatchCandidateRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    // 문항마다 선택지 2개를 가진 퀴즈셋을 만들고 id 를 반환한다.
+    fun setupQuizSet(quizCount: Int = 3): Long {
+        val quizSet = quizSetRepository.save(QuizSetFixture.create())
+        repeat(quizCount) { index ->
+            val quiz = quizRepository.save(
+                QuizFixture.create(quizSetId = quizSet.id, question = "질문$index", displayOrder = index + 1),
+            )
+            quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "A", displayOrder = 1))
+            quizChoiceRepository.save(QuizChoiceFixture.create(quizId = quiz.id, content = "B", displayOrder = 2))
+        }
+        return quizSet.id
+    }
+
+    "더미 생성" - {
+        "남/여 인원수만큼 ACTIVE 더미 회원이 생성된다" {
+            val quizSetId = setupQuizSet()
+
+            val created = adminDummyService.generate(
+                DummyGenerateForm(quizSetId = quizSetId, maleCount = 2, femaleCount = 3),
+            )
+
+            created shouldBe 5
+            val dummies = memberRepository.findByNicknameStartingWith("dummy-")
+            dummies.size shouldBe 5
+            dummies.count { it.gender == Gender.MALE } shouldBe 2
+            dummies.count { it.gender == Gender.FEMALE } shouldBe 3
+            dummies.forEach {
+                it.status shouldBe MemberStatus.ACTIVE
+                it.age shouldNotBe null
+                it.location shouldNotBe null
+                it.caricature shouldNotBe null
+            }
+        }
+
+        "각 더미는 해당 퀴즈셋을 COMPLETED 로 풀고 문항 수만큼 답변을 남긴다" {
+            val quizSetId = setupQuizSet(quizCount = 3)
+
+            adminDummyService.generate(
+                DummyGenerateForm(quizSetId = quizSetId, maleCount = 1, femaleCount = 1, preferredGender = GenderPreference.SAME),
+            )
+
+            val quizIds = quizRepository.findByQuizSetIdOrderByDisplayOrderAsc(quizSetId).map { it.id }
+            memberRepository.findByNicknameStartingWith("dummy-").forEach { dummy ->
+                val progress = quizProgressRepository.findByMemberIdAndQuizSetId(dummy.id, quizSetId)
+                progress shouldNotBe null
+                progress!!.status shouldBe QuizProgressStatus.COMPLETED
+                progress.preferredGender shouldBe GenderPreference.SAME
+                quizAnswerRepository.findByMemberIdAndQuizIdIn(dummy.id, quizIds).size shouldBe 3
+            }
+        }
+
+        "각 답변의 choiceId 는 해당 문항의 선택지 중 하나다" {
+            val quizSetId = setupQuizSet(quizCount = 3)
+            adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 1, femaleCount = 0))
+
+            val quizzes = quizRepository.findByQuizSetIdOrderByDisplayOrderAsc(quizSetId)
+            val choiceIdsByQuizId = quizzes.associate { quiz ->
+                quiz.id to quizChoiceRepository.findByQuizIdOrderByDisplayOrderAsc(quiz.id).map { it.id }.toSet()
+            }
+            val dummy = memberRepository.findByNicknameStartingWith("dummy-").first()
+            quizAnswerRepository.findByMemberIdAndQuizIdIn(dummy.id, quizzes.map { it.id }).forEach { answer ->
+                (answer.choiceId in choiceIdsByQuizId.getValue(answer.quizId)) shouldBe true
+            }
+        }
+
+        "나이는 지정한 범위 안에서 채워진다" {
+            val quizSetId = setupQuizSet(quizCount = 1)
+            adminDummyService.generate(
+                DummyGenerateForm(quizSetId = quizSetId, maleCount = 5, femaleCount = 0, minAge = 25, maxAge = 27),
+            )
+
+            memberRepository.findByNicknameStartingWith("dummy-").forEach {
+                (it.age!! in 25..27) shouldBe true
+            }
+        }
+    }
+
+    "더미 생성 입력 검증" - {
+        "인원수가 모두 0이면 예외가 발생한다" {
+            val quizSetId = setupQuizSet()
+
+            val exception = shouldThrow<WarnException> {
+                adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 0, femaleCount = 0))
+            }
+            exception.errorCode shouldBe ErrorCode.BAD_REQUEST
+        }
+
+        "최소 나이가 최대 나이보다 크면 예외가 발생한다" {
+            val quizSetId = setupQuizSet()
+
+            val exception = shouldThrow<WarnException> {
+                adminDummyService.generate(
+                    DummyGenerateForm(quizSetId = quizSetId, maleCount = 1, femaleCount = 0, minAge = 30, maxAge = 20),
+                )
+            }
+            exception.errorCode shouldBe ErrorCode.BAD_REQUEST
+        }
+
+        "존재하지 않는 퀴즈셋이면 NOT_FOUND 예외가 발생한다" {
+            val exception = shouldThrow<WarnException> {
+                adminDummyService.generate(DummyGenerateForm(quizSetId = 99999L, maleCount = 1, femaleCount = 1))
+            }
+            exception.errorCode shouldBe ErrorCode.NOT_FOUND
+        }
+
+        "문항이 없는 퀴즈셋이면 BAD_REQUEST 예외가 발생한다" {
+            val quizSet = quizSetRepository.save(QuizSetFixture.create())
+
+            val exception = shouldThrow<WarnException> {
+                adminDummyService.generate(DummyGenerateForm(quizSetId = quizSet.id, maleCount = 1, femaleCount = 1))
+            }
+            exception.errorCode shouldBe ErrorCode.BAD_REQUEST
+        }
+    }
+
+    "더미 일괄 삭제" - {
+        "더미 회원과 그 진행·답변을 모두 삭제하고 삭제 수를 반환한다" {
+            val quizSetId = setupQuizSet()
+            adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 2, femaleCount = 1))
+
+            val deleted = adminDummyService.deleteAllDummies()
+
+            deleted shouldBe 3
+            memberRepository.findByNicknameStartingWith("dummy-").size shouldBe 0
+            quizProgressRepository.findAll().size shouldBe 0
+            quizAnswerRepository.findAll().size shouldBe 0
+        }
+
+        "더미가 포함된 매칭 후보도 함께 삭제된다" {
+            val quizSetId = setupQuizSet()
+            adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 1, femaleCount = 1))
+            val dummies = memberRepository.findByNicknameStartingWith("dummy-")
+            matchCandidateRepository.save(
+                MatchCandidate.create(dummies[0].id, dummies[1].id, quizSetId, 50.0, 1, 2),
+            )
+            matchCandidateRepository.save(
+                MatchCandidate.create(dummies[1].id, dummies[0].id, quizSetId, 50.0, 1, 2),
+            )
+
+            adminDummyService.deleteAllDummies()
+
+            matchCandidateRepository.findAll().size shouldBe 0
+        }
+
+        "더미가 아닌 회원은 삭제되지 않는다" {
+            val real = memberRepository.save(Member(nickname = "진짜유저"))
+            val quizSetId = setupQuizSet()
+            adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 1, femaleCount = 1))
+
+            adminDummyService.deleteAllDummies()
+
+            memberRepository.findById(real.id).isPresent shouldBe true
+        }
+
+        "더미가 없으면 0을 반환한다" {
+            adminDummyService.deleteAllDummies() shouldBe 0
+        }
+    }
+
+    "더미 수 조회" - {
+        "countDummies 가 마커로 식별된 더미 수를 반환한다" {
+            val quizSetId = setupQuizSet()
+            adminDummyService.generate(DummyGenerateForm(quizSetId = quizSetId, maleCount = 2, femaleCount = 2))
+
+            adminDummyService.countDummies() shouldBe 4L
+        }
+    }
+})

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/MatchCandidateRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/MatchCandidateRepository.kt
@@ -18,7 +18,7 @@ interface MatchCandidateRepository : JpaRepository<MatchCandidate, Long> {
     @Query("delete from MatchCandidate mc where mc.quizSetId = :quizSetId")
     fun deleteByQuizSetId(@Param("quizSetId") quizSetId: Long): Int
 
-    /** owner/other 어느 쪽이든 해당 회원이 포함된 후보를 단일 벌크 DELETE 로 삭제 (더미 정리용) */
+    /** owner/other 어느 쪽이든 해당 회원이 포함된 후보를 단일 벌크 DELETE 로 삭제 */
     @Modifying
     @Transactional
     @Query("delete from MatchCandidate mc where mc.ownerMemberId in :memberIds or mc.otherMemberId in :memberIds")

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/MatchCandidateRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/MatchCandidateRepository.kt
@@ -17,4 +17,10 @@ interface MatchCandidateRepository : JpaRepository<MatchCandidate, Long> {
     @Transactional
     @Query("delete from MatchCandidate mc where mc.quizSetId = :quizSetId")
     fun deleteByQuizSetId(@Param("quizSetId") quizSetId: Long): Int
+
+    /** owner/other 어느 쪽이든 해당 회원이 포함된 후보를 단일 벌크 DELETE 로 삭제 (더미 정리용) */
+    @Modifying
+    @Transactional
+    @Query("delete from MatchCandidate mc where mc.ownerMemberId in :memberIds or mc.otherMemberId in :memberIds")
+    fun deleteByOwnerOrOtherMemberIdIn(@Param("memberIds") memberIds: List<Long>): Int
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
@@ -12,4 +12,10 @@ interface MemberRepository : JpaRepository<Member, Long> {
 
     /** 특정 권한을 가진 회원 목록(어드민 보유자 조회 등). */
     fun findByRoleOrderByIdAsc(role: MemberRole): List<Member>
+
+    /** 닉네임 접두사로 시작하는 회원 목록(더미 식별·일괄 정리용). */
+    fun findByNicknameStartingWith(prefix: String): List<Member>
+
+    /** 닉네임 접두사로 시작하는 회원 수(더미 현황 표시용). */
+    fun countByNicknameStartingWith(prefix: String): Long
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
@@ -13,9 +13,9 @@ interface MemberRepository : JpaRepository<Member, Long> {
     /** 특정 권한을 가진 회원 목록(어드민 보유자 조회 등). */
     fun findByRoleOrderByIdAsc(role: MemberRole): List<Member>
 
-    /** 닉네임 접두사로 시작하는 회원 목록(더미 식별·일괄 정리용). */
+    /** 닉네임 접두사로 시작하는 회원 목록. */
     fun findByNicknameStartingWith(prefix: String): List<Member>
 
-    /** 닉네임 접두사로 시작하는 회원 수(더미 현황 표시용). */
+    /** 닉네임 접두사로 시작하는 회원 수. */
     fun countByNicknameStartingWith(prefix: String): Long
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
@@ -3,6 +3,10 @@ package com.ditto.domain.quiz.repository
 import com.ditto.domain.quiz.entity.QuizAnswer
 import com.ditto.domain.quiz.repository.querydsl.QuizAnswerRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.transaction.annotation.Transactional
 
 interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long>, QuizAnswerRepositoryCustom {
     fun findByMemberIdAndQuizId(memberId: Long, quizId: Long): QuizAnswer?
@@ -10,4 +14,10 @@ interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long>, QuizAnswerRepo
 
     /** 여러 회원의 여러 문항 답변을 한 번에 조회 (매칭 점수 계산용 벌크 로드) */
     fun findByMemberIdInAndQuizIdIn(memberIds: List<Long>, quizIds: List<Long>): List<QuizAnswer>
+
+    /** 여러 회원의 답변을 단일 벌크 DELETE 로 삭제 (더미 정리용) */
+    @Modifying
+    @Transactional
+    @Query("delete from QuizAnswer qa where qa.memberId in :memberIds")
+    fun deleteByMemberIdIn(@Param("memberIds") memberIds: List<Long>): Int
 }

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizAnswerRepository.kt
@@ -15,7 +15,7 @@ interface QuizAnswerRepository : JpaRepository<QuizAnswer, Long>, QuizAnswerRepo
     /** 여러 회원의 여러 문항 답변을 한 번에 조회 (매칭 점수 계산용 벌크 로드) */
     fun findByMemberIdInAndQuizIdIn(memberIds: List<Long>, quizIds: List<Long>): List<QuizAnswer>
 
-    /** 여러 회원의 답변을 단일 벌크 DELETE 로 삭제 (더미 정리용) */
+    /** 여러 회원의 답변을 단일 벌크 DELETE 로 삭제 */
     @Modifying
     @Transactional
     @Query("delete from QuizAnswer qa where qa.memberId in :memberIds")

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
@@ -31,7 +31,7 @@ interface QuizProgressRepository : JpaRepository<QuizProgress, Long>, QuizProgre
         status: QuizProgressStatus,
     ): List<QuizProgress>
 
-    /** 여러 회원의 진행을 단일 벌크 DELETE 로 삭제 (더미 정리용) */
+    /** 여러 회원의 진행을 단일 벌크 DELETE 로 삭제 */
     @Modifying
     @Transactional
     @Query("delete from QuizProgress qp where qp.memberId in :memberIds")

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
@@ -4,6 +4,10 @@ import com.ditto.domain.quiz.entity.QuizProgress
 import com.ditto.domain.quiz.entity.QuizProgressStatus
 import com.ditto.domain.quiz.repository.querydsl.QuizProgressRepositoryCustom
 import org.springframework.data.jpa.repository.JpaRepository
+import org.springframework.data.jpa.repository.Modifying
+import org.springframework.data.jpa.repository.Query
+import org.springframework.data.repository.query.Param
+import org.springframework.transaction.annotation.Transactional
 
 interface QuizProgressRepository : JpaRepository<QuizProgress, Long>, QuizProgressRepositoryCustom {
     fun findByMemberIdAndQuizSetId(
@@ -26,4 +30,10 @@ interface QuizProgressRepository : JpaRepository<QuizProgress, Long>, QuizProgre
         quizSetId: Long,
         status: QuizProgressStatus,
     ): List<QuizProgress>
+
+    /** 여러 회원의 진행을 단일 벌크 DELETE 로 삭제 (더미 정리용) */
+    @Modifying
+    @Transactional
+    @Query("delete from QuizProgress qp where qp.memberId in :memberIds")
+    fun deleteByMemberIdIn(@Param("memberIds") memberIds: List<Long>): Int
 }


### PR DESCRIPTION
## 개요

어드민 편의 기능 — 특정 퀴즈셋에 **남 N명 / 여 M명** 더미 회원을 생성하고, 그 더미들이 해당 퀴즈셋을 **랜덤하게 푼(COMPLETED) 상태**로 만든다. 기존 `/admin/matching`의 "매칭 재생성"과 조합하면 매칭 결과를 손쉽게 시연·검증할 수 있다.

화면: `/admin/dummy` (사이드바 `🧪 더미 생성`)

## 동작

- 더미 1명 = `member`(ACTIVE) + `quiz_progress`(COMPLETED) + `quiz_answer`(문항별 랜덤 선택지)
- 입력: 대상 퀴즈셋, 남/여 인원, 나이 범위, 매칭 성별 선호(OPPOSITE/SAME/ANY)
- 더미 일괄 삭제 버튼 제공 (마커로 식별된 더미 + 진행·답변·매칭후보 정리)
- 생성·삭제 모두 confirm 모달 (운영 포함 전 환경 실행)

## 설계 결정

- **도메인 재사용**: 더미도 실제 가입과 동일하게 `Member.register()`로 활성화 → ACTIVE 전이·`joinedAt`·필수 프로필을 도메인이 소유. "dummy" 개념을 순수 `domain` 모듈에 넣지 않음.
- **식별/정리**: 닉네임 마커 `dummy-{gender}-{uuid8}` + email `@dummy.local`. 실유저 닉네임은 `^[a-zA-Z0-9가-힣]+$`(하이픈 불가)로 검증되므로 마커 충돌 없음.
- **매칭 분리**: 더미는 데이터(member·progress·answer)만 생성. `match_candidate`는 기존 "매칭 재생성"으로 생성.
- **필수 필드**: 매칭 풀 진입에 `gender`·`age` 필수, 후보 조회 직렬화에 `location`·`caricature` 필수 → 모두 채움.

## 변경 단위 (커밋)

1. `feat.` 핵심 생성 로직 (`AdminDummyService`, 폼 DTO)
2. `feat.` 생성 화면 (컨트롤러·`dummy.html`·사이드바 메뉴)
3. `feat.` 일괄삭제 (repo 메서드 + 서비스 + 버튼)
4. `test.` 통합테스트
5. `refactor.` 코드리뷰(kotlin-ddd-reviewer) 반영

## 테스트

- `AdminDummyServiceTest` (Kotest 13케이스): 인원/성별 분포, COMPLETED·문항수 답변, choiceId 정합, 나이범위, 입력검증 4종, 일괄삭제(진행·답변·매칭후보·비더미 보존), countDummies
- `AdminWebTest` (+1): GET `/admin/dummy` 렌더 + POST 생성/삭제
- 로컬 `./gradlew check` 통과 (전 모듈 테스트 + Jacoco 50% 게이트)

Closes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)
