### PR TITLE
fix. 어드민 퀴즈셋 폼 일시 datetime-local 형식 고정 및 빈 일시 400 처리

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/admin/quiz/AdminQuizService.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/quiz/AdminQuizService.kt
@@ -45,8 +45,8 @@ class AdminQuizService(
             category = form.category,
             title = form.title,
             description = form.description,
-            startDate = requireNotNull(form.startDate) { "시작일시는 필수입니다." },
-            endDate = requireNotNull(form.endDate) { "종료일시는 필수입니다." },
+            startDate = form.requiredStartDate(),
+            endDate = form.requiredEndDate(),
             isActive = form.isActive,
             matchingType = form.matchingType,
         )
@@ -59,8 +59,8 @@ class AdminQuizService(
             category = form.category,
             title = form.title,
             description = form.description,
-            startDate = requireNotNull(form.startDate) { "시작일시는 필수입니다." },
-            endDate = requireNotNull(form.endDate) { "종료일시는 필수입니다." },
+            startDate = form.requiredStartDate(),
+            endDate = form.requiredEndDate(),
             matchingType = form.matchingType,
         )
         if (form.isActive) quizSet.activate() else quizSet.deactivate()

--- a/api/src/main/kotlin/com/ditto/api/admin/quiz/dto/QuizSetForm.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/quiz/dto/QuizSetForm.kt
@@ -1,12 +1,16 @@
 package com.ditto.api.admin.quiz.dto
 
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
 import com.ditto.domain.quiz.entity.MatchingType
 import com.ditto.domain.quiz.entity.QuizSet
+import org.springframework.format.annotation.DateTimeFormat
 import java.time.LocalDateTime
 
 /**
  * 퀴즈셋 생성·수정 폼 바인딩(스프링 MVC 폼 백킹 빈이라 주생성자는 public 으로 둔다 — 바인딩 시 스프링이 인스턴스화).
- * datetime-local 입력은 ISO_LOCAL_DATE_TIME("yyyy-MM-ddTHH:mm") 이라 스프링 기본 변환으로 바인딩된다.
+ * 일시 형식은 datetime-local 인풋과 맞춰야 한다 — 형식 지정이 없으면 수정 폼 렌더링 시
+ * 로캘 형식으로 출력돼 브라우저가 값을 버리고 빈 칸으로 표시된다(#93).
  */
 class QuizSetForm(
     var year: Int = 0,
@@ -15,11 +19,19 @@ class QuizSetForm(
     var category: String = "",
     var title: String = "",
     var description: String? = null,
+    @field:DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     var startDate: LocalDateTime? = null,
+    @field:DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")
     var endDate: LocalDateTime? = null,
     var matchingType: MatchingType = MatchingType.ONE_TO_ONE,
     var isActive: Boolean = false,
 ) {
+    fun requiredStartDate(): LocalDateTime =
+        startDate ?: throw WarnException(ErrorCode.BAD_REQUEST, "시작일시는 필수입니다.")
+
+    fun requiredEndDate(): LocalDateTime =
+        endDate ?: throw WarnException(ErrorCode.BAD_REQUEST, "종료일시는 필수입니다.")
+
     companion object {
         fun from(quizSet: QuizSet) = QuizSetForm(
             year = quizSet.year,

--- a/api/src/main/resources/templates/quiz/form.html
+++ b/api/src/main/resources/templates/quiz/form.html
@@ -32,8 +32,8 @@
                 <div class="field"><label>제목</label><input type="text" th:field="*{title}" placeholder="예: 이번 주 1:1 매칭"/></div>
                 <div class="field"><label>설명</label><textarea rows="2" th:field="*{description}"></textarea></div>
                 <div class="field-row">
-                    <div class="field"><label>시작일시</label><input type="datetime-local" th:field="*{startDate}"/></div>
-                    <div class="field"><label>종료일시</label><input type="datetime-local" th:field="*{endDate}"/></div>
+                    <div class="field"><label>시작일시</label><input type="datetime-local" th:field="*{startDate}" required/></div>
+                    <div class="field"><label>종료일시</label><input type="datetime-local" th:field="*{endDate}" required/></div>
                 </div>
                 <div class="field check">
                     <input type="checkbox" id="isActive" th:field="*{isActive}"/>

--- a/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
@@ -13,6 +13,7 @@ import com.ditto.domain.quiz.repository.QuizSetRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import org.hamcrest.CoreMatchers.containsString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
@@ -27,6 +28,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
@@ -234,6 +236,17 @@ class AdminWebTest {
     fun loginPageMessages() {
         mockMvc.perform(get("/admin/login").param("error", "")).andExpect(status().isOk)
         mockMvc.perform(get("/admin/login").param("logout", "")).andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("퀴즈셋 수정 폼의 시작/종료일시가 datetime-local 형식으로 렌더링된다")
+    fun editFormRendersDateTimeLocalValues() {
+        val quizSet = quizSetRepository.save(QuizSetFixture.create())
+
+        mockMvc.perform(get("/admin/quiz-sets/{id}/edit", quizSet.id).with(authentication(admin())))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("value=\"2026-04-06T00:00\"")))
+            .andExpect(content().string(containsString("value=\"2026-04-12T23:59\"")))
     }
 
     @Test

--- a/docs/modules/api.md
+++ b/docs/modules/api.md
@@ -13,7 +13,7 @@
 - 요청 경로는 **각 핸들러 메서드의 매핑 애너테이션에 전체 경로로 명시**한다. 클래스 레벨 `@RequestMapping`으로 prefix를 묶지 않는다 — 한 곳만 보고 전체 URL을 알 수 있어 `grep`·추적이 쉽다.
   - `@GetMapping("/api/v1/quiz-sets/current-week")` (O) / 클래스 `@RequestMapping` 후 메서드 상대경로 (X)
 - 폼 백킹 빈(서버 렌더링)·요청 바인딩 객체의 주생성자는 **public**으로 둔다 (스프링이 바인딩 시 인스턴스화).
-- `LocalDateTime` 파라미터는 `ISO_LOCAL_DATE_TIME`(`yyyy-MM-ddTHH:mm`)을 스프링 기본 변환으로 바인딩한다 — 별도 `@DateTimeFormat` 불필요.
+- `LocalDateTime` **파싱**(요청 → 객체)은 `ISO_LOCAL_DATE_TIME`(`yyyy-MM-ddTHH:mm`)이 스프링 기본 변환으로 바인딩된다. 그러나 **렌더링**(객체 → Thymeleaf `th:field` 출력)은 애너테이션이 없으면 로캘 형식(`4/6/26, 12:00 AM`)으로 찍혀 `datetime-local` 인풋이 값을 버린다 — 폼 백킹 빈의 일시 필드에는 `@field:DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")`을 붙인다(#93).
 
 ## 응답 형태 (상세)
 


### PR DESCRIPTION
## 요약

어드민 퀴즈셋 생성/수정에서 저장 시 500(9999) 에러가 발생하던 버그 수정. Refs #93

## 원인

- `QuizSetForm.startDate/endDate`가 형식 지정 없는 `LocalDateTime`이라, 수정 폼 렌더링 시 Thymeleaf가 값을 로캘 형식(`4/6/26, 12:00 AM`)으로 출력 → `datetime-local` 인풋이 값을 버려 **일시가 항상 빈 칸으로 표시**됨
- 그 상태로 저장하면 빈 값이 서버에 도착 → `requireNotNull` → `IllegalArgumentException`이 핸들러 미매핑이라 500/9999("알 수 없는 에러")로 응답

## 변경

- `QuizSetForm` 일시 필드에 `@field:DateTimeFormat(pattern = "yyyy-MM-dd'T'HH:mm")` — 렌더링·바인딩 양방향을 datetime-local 형식으로 고정 (근본 수정)
- 폼 일시 인풋에 `required` — 빈 제출을 브라우저 단에서 차단
- 빈 일시 검증을 `QuizSetForm.requiredStartDate()/requiredEndDate()`로 이동하고 `WarnException(BAD_REQUEST)`로 응답 — 500/9999 대신 400 + "시작일시는 필수입니다"
- `docs/modules/api.md`의 `LocalDateTime` 바인딩 설명 정정 (파싱은 ISO 기본 변환으로 되지만 렌더링은 로캘 형식을 탐)

## 검증

- 재현 회귀 테스트 추가: 수정 폼 렌더링 값이 `2026-04-06T00:00` 형식인지 검증 — 수정 전 실패(`value="4/6/26, 12:00 AM"` 렌더링 확인) → 수정 후 통과
- `AdminWebTest` 16/16, `./gradlew build check` 통과

## 참고

- 제보의 "현재 주차 오류"는 로그상 예외 없음 — 증상 확인 후 별도 이슈로 진행 예정
- 기존 `23:59:59`처럼 초가 있는 일시는 수정 폼 저장 시 분 단위로 잘림(datetime-local 특성) — 리뷰에서 검토 후 수용

🤖 Generated with [Claude Code](https://claude.com/claude-code)