### PR TITLE
feat. 로컬 전용 어드민 자동 로그인 (카카오 OAuth 생략)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/admin/auth/AdminDevLoginController.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/auth/AdminDevLoginController.kt
@@ -1,0 +1,45 @@
+package com.ditto.api.admin.auth
+
+import com.ditto.api.admin.config.AdminSecurityConfig
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.context.annotation.Profile
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
+import org.springframework.security.core.authority.SimpleGrantedAuthority
+import org.springframework.security.core.context.SecurityContextHolder
+import org.springframework.security.web.context.SecurityContextRepository
+import org.springframework.stereotype.Controller
+import org.springframework.web.bind.annotation.GetMapping
+
+/**
+ * 로컬 전용 어드민 자동 로그인. 카카오 OAuth·DB 조회 없이 합성 principal 로 세션 인증을 설정한다.
+ * local 프로파일에서만 빈으로 등록되므로 prod 에는 핸들러가 없다(404).
+ */
+@Profile("local")
+@Controller
+class AdminDevLoginController(
+    private val securityContextRepository: SecurityContextRepository,
+) {
+    @GetMapping("/admin/oauth/dev")
+    fun devLogin(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+    ): String {
+        val principal = AdminPrincipal(memberId = LOCAL_DEV_MEMBER_ID, name = "로컬 관리자", email = null)
+        val authentication = UsernamePasswordAuthenticationToken(
+            principal,
+            null,
+            listOf(SimpleGrantedAuthority(AdminSecurityConfig.ROLE_ADMIN)),
+        )
+        val context = SecurityContextHolder.createEmptyContext().apply { this.authentication = authentication }
+        SecurityContextHolder.setContext(context)
+        securityContextRepository.saveContext(context, request, response)
+
+        return "redirect:/admin"
+    }
+
+    companion object {
+        /** 실존 회원이 아닌 합성 principal 표시용 ID — 어드민 기능은 memberId 로 회원을 조회하지 않는다. */
+        private const val LOCAL_DEV_MEMBER_ID = 0L
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/admin/auth/AdminOAuthController.kt
+++ b/api/src/main/kotlin/com/ditto/api/admin/auth/AdminOAuthController.kt
@@ -4,6 +4,7 @@ import com.ditto.api.admin.config.AdminSecurityConfig
 import io.github.oshai.kotlinlogging.KotlinLogging
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
+import org.springframework.core.env.Environment
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.authority.SimpleGrantedAuthority
 import org.springframework.security.core.context.SecurityContextHolder
@@ -20,6 +21,7 @@ import org.springframework.web.bind.annotation.RequestParam
 class AdminOAuthController(
     private val adminLoginService: AdminLoginService,
     private val securityContextRepository: SecurityContextRepository,
+    private val environment: Environment,
 ) {
     @GetMapping("/admin/login")
     fun loginPage(
@@ -29,6 +31,7 @@ class AdminOAuthController(
     ): String {
         if (error != null) model.addAttribute("error", "로그인할 수 없습니다. 관리자 권한이 있는 계정인지 확인해 주세요.")
         if (logout != null) model.addAttribute("message", "로그아웃되었습니다.")
+        model.addAttribute("devLoginEnabled", environment.matchesProfiles("local"))
         return "login"
     }
 

--- a/api/src/main/resources/static/admin/css/admin.css
+++ b/api/src/main/resources/static/admin/css/admin.css
@@ -218,3 +218,19 @@ hr.sep { border: none; border-top: 1px solid var(--border); margin: 20px 0; }
     cursor: pointer;
 }
 .btn-kakao:hover { filter: brightness(0.97); }
+.btn-dev {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 100%;
+    margin-top: 10px;
+    padding: 13px;
+    border-radius: 10px;
+    background: var(--bg);
+    color: var(--text-sub);
+    font-weight: 700;
+    font-size: 14px;
+    border: 1px dashed var(--border);
+    cursor: pointer;
+}
+.btn-dev:hover { filter: brightness(0.97); }

--- a/api/src/main/resources/templates/login.html
+++ b/api/src/main/resources/templates/login.html
@@ -9,6 +9,7 @@
         <div class="alert error" th:if="${error}" th:text="${error}"></div>
         <div class="alert success" th:if="${message}" th:text="${message}"></div>
         <a th:href="@{/admin/oauth/kakao}" class="btn-kakao">카카오로 로그인</a>
+        <a th:if="${devLoginEnabled}" th:href="@{/admin/oauth/dev}" class="btn-dev">로컬 개발 로그인</a>
     </div>
 </div>
 </body>

--- a/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/AdminWebTest.kt
@@ -13,11 +13,13 @@ import com.ditto.domain.quiz.repository.QuizSetRepository
 import com.ditto.domain.socialaccount.entity.SocialAccount
 import com.ditto.domain.socialaccount.entity.SocialProvider
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import org.hamcrest.Matchers.containsString
 import org.junit.jupiter.api.DisplayName
 import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
 import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.mock.web.MockHttpSession
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken
 import org.springframework.security.core.Authentication
 import org.springframework.security.core.authority.SimpleGrantedAuthority
@@ -27,6 +29,7 @@ import org.springframework.test.context.ActiveProfiles
 import org.springframework.test.web.servlet.MockMvc
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrl
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 import org.springframework.transaction.annotation.Transactional
@@ -227,6 +230,31 @@ class AdminWebTest {
         mockMvc.perform(get("/admin/oauth/kakao/callback").param("code", "test-code"))
             .andExpect(status().is3xxRedirection)
             .andExpect(redirectedUrl("/admin/login?error"))
+    }
+
+    @Test
+    @DisplayName("로컬 개발 로그인은 세션 설정 후 대시보드로 이동한다")
+    fun devLoginRedirect() {
+        mockMvc.perform(get("/admin/oauth/dev"))
+            .andExpect(status().is3xxRedirection)
+            .andExpect(redirectedUrl("/admin"))
+    }
+
+    @Test
+    @DisplayName("로컬 개발 로그인 세션으로 어드민 페이지에 접근할 수 있다")
+    fun devLoginSessionGrantsAccess() {
+        val session = mockMvc.perform(get("/admin/oauth/dev"))
+            .andReturn().request.session as MockHttpSession
+
+        mockMvc.perform(get("/admin").session(session)).andExpect(status().isOk)
+    }
+
+    @Test
+    @DisplayName("local 프로파일에서 로그인 페이지에 로컬 개발 로그인 버튼이 노출된다")
+    fun loginPageShowsDevLoginButton() {
+        mockMvc.perform(get("/admin/login"))
+            .andExpect(status().isOk)
+            .andExpect(content().string(containsString("로컬 개발 로그인")))
     }
 
     @Test

--- a/api/src/test/kotlin/com/ditto/api/admin/auth/AdminDevLoginProfileGateTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/admin/auth/AdminDevLoginProfileGateTest.kt
@@ -1,0 +1,52 @@
+package com.ditto.api.admin.auth
+
+import com.ditto.api.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import org.hamcrest.Matchers.containsString
+import org.hamcrest.Matchers.not
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc
+import org.springframework.context.ApplicationContext
+import org.springframework.mock.web.MockHttpSession
+import org.springframework.test.context.ActiveProfiles
+import org.springframework.test.web.servlet.MockMvc
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.content
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.redirectedUrlPattern
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+import javax.sql.DataSource
+
+/**
+ * dev 로그인이 local 프로파일에만 존재하는지 검증하는 회귀 테스트.
+ * [AdminDevLoginController]의 `@Profile("local")`이 실수로 지워지면 여기서 잡힌다.
+ * 부모의 local 프로파일을 [ActiveProfiles.inheritProfiles] = false 로 걷어내고 test 단독으로 부트한다.
+ */
+@AutoConfigureMockMvc
+@ActiveProfiles("test", inheritProfiles = false)
+class AdminDevLoginProfileGateTest(
+    private val mockMvc: MockMvc,
+    private val applicationContext: ApplicationContext,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+    "local 프로파일이 아니면" - {
+        "dev 로그인 빈이 등록되지 않는다" {
+            applicationContext.getBeanNamesForType(AdminDevLoginController::class.java).size shouldBe 0
+        }
+
+        "로그인 페이지에 로컬 개발 로그인 버튼이 노출되지 않는다" {
+            mockMvc.perform(get("/admin/login"))
+                .andExpect(status().isOk)
+                .andExpect(content().string(not(containsString("로컬 개발 로그인"))))
+        }
+
+        "dev 로그인 경로로 어드민 세션을 얻을 수 없다" {
+            // 핸들러가 없어도 GlobalExceptionHandler 가 200 + ApiResponse 실패 바디로 바꾸므로, 404 대신 "세션 인증이 생기지 않음"을 검증한다.
+            val result = mockMvc.perform(get("/admin/oauth/dev")).andReturn()
+            result.response.redirectedUrl shouldBe null
+
+            val session = result.request.session as MockHttpSession
+            mockMvc.perform(get("/admin").session(session))
+                .andExpect(status().is3xxRedirection)
+                .andExpect(redirectedUrlPattern("**/admin/login"))
+        }
+    }
+})


### PR DESCRIPTION
## 요약

로컬에서 어드민(`/admin/**`)을 확인하려면 카카오 OAuth + `role=ADMIN` 회원 시드가 매번 필요한 마찰을 없앤다. `@Profile("local")` 전용 `GET /admin/oauth/dev`가 카카오·DB 조회 없이 합성 `AdminPrincipal`로 세션 인증을 설정하고 `/admin`으로 리다이렉트한다.

Closes #90

## 변경 내용

- **`AdminDevLoginController`** (신규, `@Profile("local")`): 합성 `AdminPrincipal(memberId=0, "로컬 관리자")`로 카카오 콜백과 동일한 세션 인증 설정. 어드민 기능은 principal 을 표시용(`displayName`/`name`/`email`)으로만 쓰고 `memberId`로 회원을 조회하지 않으므로 DB 시드 불필요.
- **`AdminOAuthController`**: `loginPage()`에 `devLoginEnabled = environment.matchesProfiles("local")` 플래그 1줄 추가.
- **`login.html` / `admin.css`**: local 한정 "로컬 개발 로그인" 버튼(`th:if`) + `.btn-dev` 스타일.
- **테스트**
  - `AdminWebTest` +3: dev 로그인 리다이렉트 / 그 세션으로 `/admin` 접근 200 / 로그인 페이지 버튼 노출.
  - `AdminDevLoginProfileGateTest` (신규, `local` 프로파일 제외 부트): 빈 미등록 / dev 경로로 세션 미발급 / 버튼 미노출 — `@Profile("local")`이 실수로 지워지는 회귀를 CI에서 잡는다.

## 안전성

- prod(`SPRING_PROFILES_ACTIVE=prod`)에서는 dev 로그인 빈이 등록되지 않아 핸들러가 없고, 버튼도 렌더되지 않는다. 기존 카카오 로그인 흐름·`AdminSecurityConfig` 보안 체인은 무변경.

## 리뷰(kotlin-ddd-reviewer)에서 반영하지 않은 항목과 근거

- **경로 `/admin/oauth/dev` 유지** (제안: `/admin/dev-login` + 명시적 permitAll): 이슈 #90 의 설계 근거가 "이미 `permitAll`인 `/admin/oauth/**` 하위라 보안 설정 수정 불필요"였고, 경로를 바꾸면 `AdminSecurityConfig` 수정이 필요해져 "기존 보안 체인 무변경" 원칙이 깨진다. 감사 가독성 지적은 이 PR 본문과 컨트롤러 KDoc 으로 보완.
- **`@ConditionalOnProperty` 이중 게이트 미적용**: prod 에서 `SPRING_PROFILES_ACTIVE`가 누락되는 오설정 시나리오는 앱 전체가 local 설정(H2 인메모리 DB)으로 떠서 서비스가 즉시 눈에 띄게 깨지므로, dev 로그인만 조용히 노출되는 경로가 없다. 프로파일 게이트 자체의 회귀는 `AdminDevLoginProfileGateTest`가 CI 에서 방어한다.
- **세션 인증 로직 공통화(DRY) 보류**: `kakaoCallback()`과 중복은 4줄이며, 이 이슈 범위에서 구조 변경을 얹지 않는다(최소 diff).

🤖 Generated with [Claude Code](https://claude.com/claude-code)