### PR TITLE
[#116] build. JVM 옵션 정리 — 미검증 하드캡·저효용 옵션 제거

### DIFF
--- a/.aws/task-definition.json
+++ b/.aws/task-definition.json
@@ -31,7 +31,7 @@
                 },
                 {
                     "name": "JAVA_TOOL_OPTIONS",
-                    "value": "-XX:+UseG1GC -XX:MaxRAMPercentage=35.0 -XX:MaxMetaspaceSize=256m -XX:MaxDirectMemorySize=96m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp"
+                    "value": "-XX:+UseG1GC -XX:MaxMetaspaceSize=256m"
                 },
                 {
                     "name": "KAKAO_REDIRECT_URI",


### PR DESCRIPTION
## 개요
`task-definition.json`의 `JAVA_TOOL_OPTIONS`에서 미검증 하드캡·저효용 옵션을 제거한다.

Closes #116

## 변경
- 이전: `-XX:+UseG1GC -XX:MaxRAMPercentage=35.0 -XX:MaxMetaspaceSize=256m -XX:MaxDirectMemorySize=96m -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/tmp`
- 이후: `-XX:+UseG1GC -XX:MaxMetaspaceSize=256m`

**제거**
- `MaxRAMPercentage=35.0` — 튜닝값(필수 아님) → 기본 25%로 회귀(저위험)
- `MaxDirectMemorySize=96m` — 측정 없이 건 하드캡, 낮으면 `Direct buffer memory` OOM 유발 가능 → 기본값(=max heap) 회귀
- `HeapDumpOnOutOfMemoryError` + `HeapDumpPath=/tmp` — Fargate `/tmp` 휘발성이라 덤프 소실, 저효용

**유지**
- `UseG1GC` — 0.5vCPU·1GiB에선 기본이 SerialGC(단일스레드 STW → WebSocket 프리즈)라 G1 강제
- `MaxMetaspaceSize=256m` — 실사용 위 여유값, 저위험 안전망

## 참고 (머지 시)
- 배포 config만 변경(코드/테스트 영향 없음). squash 머지, 소스 브랜치 유지 권장.
- 근본 해결(태스크 2vCPU/2GiB 증설)은 별도.

🤖 Generated with [Claude Code](https://claude.com/claude-code)