### PR TITLE
[#118] feat. 그룹 채팅방 자동 생성 (GroupMatch 활성화 시 연동)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/chat/service/ChatService.kt
+++ b/api/src/main/kotlin/com/ditto/api/chat/service/ChatService.kt
@@ -50,6 +50,22 @@ class ChatService(
     }
 
     /**
+     * 그룹 매칭이 활성화(참가자 임계값 도달)될 때 참가자 전원의 채팅방을 생성한다.
+     * 이미 있으면 아무 것도 하지 않는다(멱등). 그룹 참여 트랜잭션 안에서 호출된다.
+     */
+    @Transactional
+    fun createGroupRoom(groupMatchId: Long, memberIds: List<Long>) {
+        if (chatRoomRepository.existsByRoomTypeAndSourceId(ChatRoomType.GROUP, groupMatchId)) {
+            return
+        }
+
+        val room = chatRoomRepository.save(ChatRoom.group(groupMatchId))
+        chatRoomMemberRepository.saveAll(
+            memberIds.map { ChatRoomMember.of(roomId = room.id, memberId = it) },
+        )
+    }
+
+    /**
      * 이미지 업로드용 presigned PUT URL 발급. 방 멤버만 발급 가능하며, 크기·타입 검증 후 발급한다.
      * 발급받은 key(`chat/{memberId}/{uuid}`)로 업로드한 뒤 messageType=IMAGE, content=key 로 전송한다.
      */

--- a/api/src/main/kotlin/com/ditto/api/match/service/GroupMatchService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/GroupMatchService.kt
@@ -1,5 +1,6 @@
 package com.ditto.api.match.service
 
+import com.ditto.api.chat.service.ChatService
 import com.ditto.api.match.dto.GroupMatchDeclineRequest
 import com.ditto.api.match.dto.GroupMatchJoinRequest
 import com.ditto.api.match.dto.GroupMatchJoinResponse
@@ -20,6 +21,7 @@ class GroupMatchService(
     private val groupMatchRepository: GroupMatchRepository,
     private val groupMatchMemberRepository: GroupMatchMemberRepository,
     private val groupMatchDeclineRepository: GroupMatchDeclineRepository,
+    private val chatService: ChatService,
 ) {
 
     /** 그룹 매칭 참여 */
@@ -38,6 +40,13 @@ class GroupMatchService(
         val room = findOrCreateRoom(quizSetId)
         room.addParticipant()
         groupMatchMemberRepository.save(GroupMatchMember.of(room.id, memberId))
+
+        // 방이 막 활성화(참가자 임계값 도달)됐다면 참가자 전원의 채팅방을 생성한다.
+        // findOrCreateRoom 은 비활성 방만 반환하므로, isActive == true 는 이번 참여로 활성화됐음을 뜻한다.
+        if (room.isActive) {
+            val memberIds = groupMatchMemberRepository.findByRoomId(room.id).map { it.memberId }
+            chatService.createGroupRoom(room.id, memberIds)
+        }
 
         return GroupMatchJoinResponse.from(room)
     }

--- a/api/src/test/kotlin/com/ditto/api/chat/ChatServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/chat/ChatServiceTest.kt
@@ -45,6 +45,26 @@ class ChatServiceTest(
         chatRoomRepository.findAll().count { it.sourceId == 100L } shouldBe 1
     }
 
+    "그룹 방을 생성하면 참가자 전원의 멤버 레코드가 GROUP 방에 생성된다" {
+        // when
+        chatService.createGroupRoom(groupMatchId = 200L, memberIds = listOf(1L, 2L, 3L))
+
+        // then
+        val room = chatRoomRepository.findByRoomTypeAndSourceId(ChatRoomType.GROUP, 200L)
+        room shouldNotBe null
+        chatRoomMemberRepository.findByRoomIdIn(listOf(room!!.id))
+            .map { it.memberId }.toSet() shouldBe setOf(1L, 2L, 3L)
+    }
+
+    "이미 그룹 방이 있으면 다시 생성해도 방이 하나만 유지된다(멱등)" {
+        // when
+        chatService.createGroupRoom(groupMatchId = 200L, memberIds = listOf(1L, 2L, 3L))
+        chatService.createGroupRoom(groupMatchId = 200L, memberIds = listOf(1L, 2L, 3L))
+
+        // then
+        chatRoomRepository.findAll().count { it.sourceId == 200L } shouldBe 1
+    }
+
     "내 채팅방 목록은 상대 회원·마지막 메시지·안읽음 수를 담아 반환한다" {
         // given: 방 + 나(1)/상대(2), 메시지 3개, 첫 메시지까지 읽음
         chatService.createPersonalRoom(personalMatchId = 100L, memberAId = 1L, memberBId = 2L)

--- a/api/src/test/kotlin/com/ditto/api/match/GroupMatchServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/GroupMatchServiceTest.kt
@@ -6,6 +6,9 @@ import com.ditto.api.match.service.GroupMatchService
 import com.ditto.api.support.IntegrationTest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
+import com.ditto.domain.chat.entity.ChatRoomType
+import com.ditto.domain.chat.repository.ChatRoomMemberRepository
+import com.ditto.domain.chat.repository.ChatRoomRepository
 import com.ditto.domain.match.GroupMatchFixture
 import com.ditto.domain.match.entity.GroupMatchDecline
 import com.ditto.domain.match.repository.GroupMatchDeclineRepository
@@ -21,6 +24,8 @@ class GroupMatchServiceTest(
     private val groupMatchRepository: GroupMatchRepository,
     private val groupMatchMemberRepository: GroupMatchMemberRepository,
     private val groupMatchDeclineRepository: GroupMatchDeclineRepository,
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
     dataSource: DataSource,
 ) : IntegrationTest(dataSource, {
 
@@ -61,6 +66,32 @@ class GroupMatchServiceTest(
         // then
         result.isActive shouldBe true
         result.participantCount shouldBe 3
+    }
+
+    "3번째 참여로 방이 활성화되면 참가자 전원의 채팅방이 생성된다" {
+        // given
+        groupMatchService.joinGroupMatch(1L, GroupMatchJoinRequest(quizSetId))
+        groupMatchService.joinGroupMatch(2L, GroupMatchJoinRequest(quizSetId))
+
+        // when
+        val result = groupMatchService.joinGroupMatch(3L, GroupMatchJoinRequest(quizSetId))
+
+        // then
+        val chatRoom = chatRoomRepository.findByRoomTypeAndSourceId(ChatRoomType.GROUP, result.roomId)
+        chatRoom shouldNotBe null
+        chatRoomMemberRepository.findByRoomIdIn(listOf(chatRoom!!.id))
+            .map { it.memberId }.toSet() shouldBe setOf(1L, 2L, 3L)
+    }
+
+    "3명 미만이면 채팅방이 생성되지 않는다" {
+        // given
+        groupMatchService.joinGroupMatch(1L, GroupMatchJoinRequest(quizSetId))
+
+        // when
+        val result = groupMatchService.joinGroupMatch(2L, GroupMatchJoinRequest(quizSetId))
+
+        // then
+        chatRoomRepository.findByRoomTypeAndSourceId(ChatRoomType.GROUP, result.roomId) shouldBe null
     }
 
     "활성화된 방만 있으면 새 방이 생성된다" {


### PR DESCRIPTION
## 개요
그룹 매칭이 활성화(참가자 3명)되는 순간 그룹 채팅방을 자동 생성한다. 이 훅이 없어 그룹 채팅이 end-to-end로 동작하지 않던 것을 연결한다. (1:1은 이미 매칭 수락 시 자동 생성)

Closes #118

## 변경
- `ChatService.createGroupRoom(groupMatchId, memberIds)` — `ChatRoom.group` + 참가자 전원 `ChatRoomMember` 등록, 멱등(GROUP·sourceId 존재 시 no-op). `createPersonalRoom`과 동일 패턴.
- `GroupMatchService.joinGroupMatch` — `addParticipant()`로 방이 활성화되면 그 방 GroupMatchMember 전원으로 채팅방 생성(같은 트랜잭션). `findOrCreateRoom`이 비활성 방만 반환하므로 `isActive==true`는 "이번 참여로 활성화됨"을 의미.

## 그룹 대응이 이미 되어 있어 그대로 동작
- 스키마(GROUP 타입·N명 멤버), 조회(`counterpartMemberIds` List), 실시간(멤버십 검증+`/sub/chat/rooms/{id}` 팬아웃), 이미지 — 모두 인원수 무관.

## 범위 밖(후속)
- 방 나가기(`left_at`), 입퇴장 SYSTEM 메시지, 방 이름/제목.

## 테스트
- `ChatServiceTest`(+2): createGroupRoom 전원 등록/멱등
- `GroupMatchServiceTest`(+2): 3번째 참여로 채팅방 생성 / 3명 미만이면 미생성
- `./gradlew :api:test` 통과

🤖 Generated with [Claude Code](https://claude.com/claude-code)