### PR TITLE
[#122] feat. 마이프로필 API — 프로필 조회·수정, 내 통계, 받은 평가

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/user/controller/MyProfileController.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/controller/MyProfileController.kt
@@ -1,0 +1,62 @@
+package com.ditto.api.user.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.user.dto.MyRatingsResponse
+import com.ditto.api.user.dto.MyStatsResponse
+import com.ditto.api.user.dto.PublicProfileResponse
+import com.ditto.api.user.dto.UpdateMyProfileRequest
+import com.ditto.api.user.service.MyProfileService
+import com.ditto.common.logging.Loggable
+import com.ditto.common.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+/**
+ * 마이프로필 화면 전용 엔드포인트. 타인 프로필(`/users/{id}/profile`)은 [UserController]에 있다.
+ */
+@RestController
+class MyProfileController(
+    private val myProfileService: MyProfileService,
+) {
+
+    @Loggable
+    @GetMapping("/api/v1/users/me/profile")
+    fun getMyProfile(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<PublicProfileResponse> {
+        val result = myProfileService.getMyProfile(principal.memberId)
+        return ApiResponse.ok(result)
+    }
+
+    @Loggable
+    @PatchMapping("/api/v1/users/me/profile")
+    fun updateMyProfile(
+        @Valid @RequestBody request: UpdateMyProfileRequest,
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<PublicProfileResponse> {
+        val result = myProfileService.updateMyProfile(principal.memberId, request)
+        return ApiResponse.ok(result)
+    }
+
+    @Loggable
+    @GetMapping("/api/v1/users/me/stats")
+    fun getMyStats(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<MyStatsResponse> {
+        val result = myProfileService.getMyStats(principal.memberId)
+        return ApiResponse.ok(result)
+    }
+
+    @Loggable
+    @GetMapping("/api/v1/users/me/ratings")
+    fun getMyRatings(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<MyRatingsResponse> {
+        val result = myProfileService.getMyRatings(principal.memberId)
+        return ApiResponse.ok(result)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/user/dto/MyRatingsResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/MyRatingsResponse.kt
@@ -1,0 +1,24 @@
+package com.ditto.api.user.dto
+
+import java.time.LocalDateTime
+
+/**
+ * 내 프로필의 "받은 평가" 카드.
+ *
+ * 총 평가가 [publicThreshold]건 미만이면 비공개다 — 화면은 "평가가 충분하지 않아요"만 노출하므로
+ * 평균·코멘트·노쇼를 내려보내지 않는다([totalCount]만 실제 값).
+ *
+ * 별점 반올림(.5 이상 올림)·코멘트 3개 노출·`(전체 − 3)` 표기는 FE가 처리한다.
+ */
+data class MyRatingsResponse(
+    val averageScore: Double,
+    val totalCount: Long,
+    val publicThreshold: Int,
+    val noShowCount: Long,
+    val ratings: List<MyRatingItem>,
+)
+
+data class MyRatingItem(
+    val comment: String?,
+    val createdAt: LocalDateTime,
+)

--- a/api/src/main/kotlin/com/ditto/api/user/dto/MyStatsResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/MyStatsResponse.kt
@@ -1,0 +1,14 @@
+package com.ditto.api.user.dto
+
+/**
+ * 내 프로필의 "내 통계" 카드. 각 지표 정의는 피그마 `6.1 프로필` 주석에서 확정됐다.
+ *
+ * - [participationWeeks] 참여 주차 = 퀴즈 참여(완주) 횟수
+ * - [matchCount] 매칭 성사 = 채팅방 개설 횟수
+ * - [meetingCount] 만남 횟수 = 상대방 평가에서 '만났어요'를 받은 개수
+ */
+data class MyStatsResponse(
+    val participationWeeks: Long,
+    val matchCount: Long,
+    val meetingCount: Long,
+)

--- a/api/src/main/kotlin/com/ditto/api/user/dto/UpdateMyProfileRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/UpdateMyProfileRequest.kt
@@ -1,0 +1,29 @@
+package com.ditto.api.user.dto
+
+import jakarta.validation.constraints.Size
+
+/**
+ * 마이프로필 수정 요청. 화면(`6.1.1 프로필 수정`)에서 수정 가능한 항목만 받는다 —
+ * 닉네임·성별·나이·사는곳·직업은 비활성이라 여기에 없다.
+ *
+ * **null = 변경 없음**이다. 값이 온 항목만 검증하고 갱신한다.
+ *
+ * [introduction]은 소개노트 `ONE_WORD` 답변에 write-through 된다(프로필 조회가 그 값을 읽는다).
+ * 상한 50자는 프로필 수정 화면의 제한이다 — 소개노트 화면은 현재 제한이 없어 더 긴 값이
+ * 들어올 수 있고, 그 정합은 후속으로 `IntroQuestion` 단위 상한에서 다룬다(#122 본문).
+ */
+data class UpdateMyProfileRequest(
+    @field:Size(max = INTRODUCTION_MAX_LENGTH, message = "한 줄 소개는 최대 ${INTRODUCTION_MAX_LENGTH}자입니다.")
+    val introduction: String? = null,
+
+    @field:Size(max = 100)
+    val profileImageUrl: String? = null,
+
+    @field:Size(min = 1, max = MAX_INTEREST_COUNT, message = "관심사는 1~${MAX_INTEREST_COUNT}개 선택해야 합니다.")
+    val interests: Set<String>? = null,
+) {
+    companion object {
+        const val INTRODUCTION_MAX_LENGTH = 50
+        const val MAX_INTEREST_COUNT = 5
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/user/service/MyProfileService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/MyProfileService.kt
@@ -1,0 +1,118 @@
+package com.ditto.api.user.service
+
+import com.ditto.api.intronote.service.IntroNoteService
+import com.ditto.api.user.dto.MyRatingItem
+import com.ditto.api.user.dto.MyRatingsResponse
+import com.ditto.api.user.dto.MyStatsResponse
+import com.ditto.api.user.dto.PublicProfileResponse
+import com.ditto.api.user.dto.UpdateMyProfileRequest
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.chat.repository.ChatRoomMemberRepository
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.member.entity.Interest
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.quiz.entity.QuizProgressStatus
+import com.ditto.domain.quiz.repository.QuizProgressRepository
+import com.ditto.domain.review.entity.MeetingStatus
+import com.ditto.domain.review.repository.ReviewAnswerRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 마이프로필 화면(`6.1 프로필`, `6.1.1 프로필 수정`) 전용 서비스.
+ *
+ * 조회는 타인 공개 프로필과 같은 응답을 쓴다 — [UserService.getPublicProfile]이 이미
+ * 본인 조회(`viewerId == targetId`)를 허용하므로 별칭으로 재사용한다.
+ */
+@Service
+class MyProfileService(
+    private val userService: UserService,
+    private val introNoteService: IntroNoteService,
+    private val memberRepository: MemberRepository,
+    private val quizProgressRepository: QuizProgressRepository,
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
+    private val reviewAnswerRepository: ReviewAnswerRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getMyProfile(memberId: Long): PublicProfileResponse =
+        userService.getPublicProfile(memberId, memberId)
+
+    /**
+     * 캐리커쳐·관심사·한 줄 소개만 수정한다. null인 항목은 건드리지 않는다.
+     *
+     * 한 줄 소개는 `member`가 아니라 소개노트 `ONE_WORD`에 저장된다 — 프로필 조회가 그 답변을
+     * 읽어 `introduction`으로 내려주므로, 저장 위치를 한 곳으로 유지해야 두 화면이 어긋나지 않는다.
+     */
+    @Transactional
+    fun updateMyProfile(memberId: Long, request: UpdateMyProfileRequest): PublicProfileResponse {
+        val member = memberRepository.findById(memberId).orElseThrow {
+            WarnException(ErrorCode.NOT_FOUND)
+        }
+
+        member.updateProfile(
+            caricature = request.profileImageUrl,
+            interests = request.interests?.map { Interest.from(it) }?.toSet(),
+        )
+
+        request.introduction?.let { introduction ->
+            if (introduction.isBlank()) {
+                throw WarnException(ErrorCode.BAD_REQUEST, "한 줄 소개를 입력해 주세요.")
+            }
+            introNoteService.saveAnswer(memberId, IntroQuestion.ONE_WORD.code, introduction.trim())
+        }
+
+        return userService.getPublicProfile(memberId, memberId)
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyStats(memberId: Long): MyStatsResponse = MyStatsResponse(
+        participationWeeks = quizProgressRepository.countByMemberIdAndStatus(
+            memberId = memberId,
+            status = QuizProgressStatus.COMPLETED,
+        ),
+        matchCount = chatRoomMemberRepository.countByMemberId(memberId),
+        meetingCount = reviewAnswerRepository.countByReviewedMemberIdAndMeetingStatusAndAnsweredAtIsNotNull(
+            reviewedMemberId = memberId,
+            meetingStatus = MeetingStatus.MET,
+        ),
+    )
+
+    @Transactional(readOnly = true)
+    fun getMyRatings(memberId: Long): MyRatingsResponse {
+        val received = reviewAnswerRepository
+            .findAllByReviewedMemberIdAndAnsweredAtIsNotNullOrderByAnsweredAtDesc(memberId)
+        val totalCount = received.size.toLong()
+
+        // 공개 기준 미달이면 총 건수만 알린다 — 화면이 평균·코멘트·노쇼를 렌더하지 않는다.
+        if (totalCount < PUBLIC_THRESHOLD) {
+            return MyRatingsResponse(
+                averageScore = 0.0,
+                totalCount = totalCount,
+                publicThreshold = PUBLIC_THRESHOLD,
+                noShowCount = 0,
+                ratings = emptyList(),
+            )
+        }
+
+        return MyRatingsResponse(
+            averageScore = received.mapNotNull { it.rating }.average(),
+            totalCount = totalCount,
+            publicThreshold = PUBLIC_THRESHOLD,
+            noShowCount = received.count { it.meetingStatus == MeetingStatus.NO_SHOW }.toLong(),
+            ratings = received.map { answer ->
+                MyRatingItem(
+                    comment = answer.comment,
+                    // 확정 평가만 조회했으므로 answeredAt은 항상 존재한다.
+                    createdAt = answer.answeredAt!!,
+                )
+            },
+        )
+    }
+
+    companion object {
+        /** 받은 평가 공개 기준 — 3건 미만이면 "평가가 충분하지 않아요"를 노출한다. */
+        const val PUBLIC_THRESHOLD = 3
+    }
+}

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -94,7 +94,7 @@ paths:
                     "reason" : "inappropriate-behavior",
                     "source" : "profile",
                     "detail" : "대화 중 폭언을 반복했습니다.",
-                    "imageKeys" : [ "pending/user-reports/1/8ad984e5-7603-49ed-94f3-adacccaa200e" ]
+                    "imageKeys" : [ "pending/user-reports/1/db2933d6-3141-400e-be23-95fa920f1251" ]
                   }
       responses:
         "200":
@@ -126,7 +126,7 @@ paths:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: "#/components/schemas/api-v1-users-2041696623"
+              $ref: "#/components/schemas/api-v1-users1822882528"
             examples:
               user-register:
                 value: |-
@@ -168,10 +168,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-08-04 11:30:18",
+                        "joinedAt" : "2026-08-05 00:11:25",
                         "role" : null,
-                        "createdAt" : "2026-08-04 11:30:18",
-                        "updatedAt" : "2026-08-04 11:30:18"
+                        "createdAt" : "2026-08-05 00:11:25",
+                        "updatedAt" : "2026-08-05 00:11:25"
                       },
                       "error" : null
                     }
@@ -454,8 +454,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-08-03 11:30:18",
-                          "endDate" : "2026-08-05 11:30:18",
+                          "startDate" : "2026-08-04 00:11:25",
+                          "endDate" : "2026-08-06 00:11:25",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -472,8 +472,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-08-04 11:30:18",
-                            "updatedAt" : "2026-08-04 11:30:18"
+                            "createdAt" : "2026-08-05 00:11:25",
+                            "updatedAt" : "2026-08-05 00:11:25"
                           } ]
                         } ]
                       },
@@ -520,8 +520,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-08-04 11:30:18",
-                        "updatedAt" : "2026-08-04 11:30:18"
+                        "createdAt" : "2026-08-05 00:11:25",
+                        "updatedAt" : "2026-08-05 00:11:25"
                       },
                       "error" : null
                     }
@@ -598,11 +598,11 @@ paths:
                       "success" : true,
                       "data" : {
                         "uploads" : [ {
-                          "objectKey" : "pending/user-reports/1/6652e3e9-a628-4996-a9e1-9d099ee7ff80",
-                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/6652e3e9-a628-4996-a9e1-9d099ee7ff80"
+                          "objectKey" : "pending/user-reports/1/827a6cad-cee9-4857-8a3c-65e01550cee3",
+                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/827a6cad-cee9-4857-8a3c-65e01550cee3"
                         }, {
-                          "objectKey" : "pending/user-reports/1/c1b96e5f-8f77-40bd-92be-808b8faca8df",
-                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/c1b96e5f-8f77-40bd-92be-808b8faca8df"
+                          "objectKey" : "pending/user-reports/1/2569fddf-d61b-4075-9a33-49197cff1878",
+                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/2569fddf-d61b-4075-9a33-49197cff1878"
                         } ]
                       },
                       "error" : null
@@ -885,7 +885,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODU4MTA2MTUsImV4cCI6MTc4NTgxNDIxNX0.sC5_X9wl-nGre52u5Y0uEmG0XUnFPHmCjtfP4SPgVJ6A4dNC8vcxZt-WHaytVXBhSNtaIPV8Y7gIeiRmSdjTJw"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODU4NTYyODEsImV4cCI6MTc4NTg1OTg4MX0.rposjPujZbs13aaJsLSzvMw96EnbNnnfXcX4-IXPZ2aqYUEscv0BWB0ov4xuk86MwPdKiiWrf0qYV5lAGtW3WQ"
                       },
                       "error" : null
                     }
@@ -1211,13 +1211,13 @@ paths:
                         "noShowCount" : 1,
                         "ratings" : [ {
                           "comment" : null,
-                          "createdAt" : "2026-08-04 11:07:27"
+                          "createdAt" : "2026-08-05 00:11:25"
                         }, {
                           "comment" : "약속 시간 잘 지켜요",
-                          "createdAt" : "2026-08-04 11:07:27"
+                          "createdAt" : "2026-08-05 00:11:25"
                         }, {
                           "comment" : "대화가 편하고 좋았어요",
-                          "createdAt" : "2026-08-04 11:07:27"
+                          "createdAt" : "2026-08-05 00:11:25"
                         } ]
                       },
                       "error" : null
@@ -1250,8 +1250,8 @@ paths:
                           "levelDescription" : "기간 이용 정지",
                           "reason" : null,
                           "reasonDescription" : null,
-                          "startsAt" : "2026-07-28 11:30:18",
-                          "endsAt" : "2026-08-11 11:30:18"
+                          "startsAt" : "2026-07-29 00:11:25",
+                          "endsAt" : "2026-08-12 00:11:25"
                         }
                       },
                       "error" : null
@@ -1427,8 +1427,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-08-04 11:30:18",
-                        "updatedAt" : "2026-08-04 11:30:18"
+                        "createdAt" : "2026-08-05 00:11:25",
+                        "updatedAt" : "2026-08-05 00:11:25"
                       },
                       "error" : null
                     }
@@ -1455,7 +1455,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-users-id-profile-829103765"
+                $ref: "#/components/schemas/api-v1-users-id-profile58842976"
               examples:
                 user-public-profile:
                   value: |-
@@ -3023,6 +3023,58 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users1822882528:
+      required:
+      - caricature
+      - interests
+      - job
+      - location
+      type: object
+      properties:
+        caricature:
+          type: string
+          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
+        phoneNumber:
+          type: string
+          description: 전화번호 (010-0000-0000)
+          nullable: true
+        gender:
+          type: string
+          description: "성별 (MALE, FEMALE)"
+          nullable: true
+        nickname:
+          type: string
+          description: "닉네임 (2~10자, 한글·영문·숫자)"
+          nullable: true
+        name:
+          type: string
+          description: 이름
+          nullable: true
+        location:
+          type: string
+          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
+            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
+            \ jeonnam, gyeongbuk, gyeongnam, jeju"
+        job:
+          type: string
+          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
+            \ education, medical, finance, legal, manufacturing, distribution, service,\
+            \ construction, arts-media, research, public-admin, student, etc"
+        interests:
+          type: array
+          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, exhibition,\
+            \ performance, photography, reading, music, cooking, travel, gaming, finance,\
+            \ self-improvement, pets, etc"
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        age:
+          type: number
+          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
+          nullable: true
     api-v1-matching-status-quizSetId414593137:
       required:
       - error
@@ -3421,58 +3473,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-2041696623:
-      required:
-      - caricature
-      - interests
-      - job
-      - location
-      type: object
-      properties:
-        caricature:
-          type: string
-          description: "프로필 캐리커쳐 (필수, FE 문자열 그대로 저장)"
-        phoneNumber:
-          type: string
-          description: 전화번호 (010-0000-0000)
-          nullable: true
-        gender:
-          type: string
-          description: "성별 (MALE, FEMALE)"
-          nullable: true
-        nickname:
-          type: string
-          description: "닉네임 (2~10자, 한글·영문·숫자)"
-          nullable: true
-        name:
-          type: string
-          description: 이름
-          nullable: true
-        location:
-          type: string
-          description: "사는곳 code (필수). 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
-            \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
-            \ jeonnam, gyeongbuk, gyeongnam, jeju"
-        job:
-          type: string
-          description: "직업 code (필수). 가능한 값: it-tech, management, marketing, design,\
-            \ education, medical, finance, legal, manufacturing, distribution, service,\
-            \ construction, arts-media, research, public-admin, student, etc"
-        interests:
-          type: array
-          description: "관심사 code 목록 (필수, 최소 1개). 가능한 값: workout, movie-drama, performance,\
-            \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
-            \ pets, etc"
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        age:
-          type: number
-          description: "나이대 (20, 25, 30, 35, 40, 45, 50, 60)"
-          nullable: true
     api-v1-matches-group-join-1969670024:
       required:
       - quizSetId
@@ -3481,6 +3481,68 @@ components:
         quizSetId:
           type: number
           description: 퀴즈 세트 ID
+    api-v1-users-id-profile58842976:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - nickname
+          - userId
+          type: object
+          properties:
+            occupation:
+              type: string
+              description: "직업 code. 가능한 값: it-tech, management, marketing, design,\
+                \ education, medical, finance, legal, manufacturing, distribution,\
+                \ service, construction, arts-media, research, public-admin, student,\
+                \ etc"
+              nullable: true
+            gender:
+              type: string
+              description: "성별 (MALE, FEMALE)"
+              nullable: true
+            nickname:
+              type: string
+              description: 닉네임
+            location:
+              type: string
+              description: "지역 code. 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
+                \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
+                \ jeonnam, gyeongbuk, gyeongnam, jeju"
+              nullable: true
+            interests:
+              type: array
+              description: "관심사 code 목록. 가능한 값: workout, movie-drama, exhibition,\
+                \ performance, photography, reading, music, cooking, travel, gaming,\
+                \ finance, self-improvement, pets, etc"
+              nullable: true
+              items:
+                oneOf:
+                - type: object
+                - type: boolean
+                - type: string
+                - type: number
+            profileImageUrl:
+              type: string
+              description: 프로필 이미지 경로
+              nullable: true
+            userId:
+              type: number
+              description: 대상 사용자 ID
+            introduction:
+              type: string
+              description: "자기소개 (소개노트 one-word 답변, 없으면 null)"
+              nullable: true
+            age:
+              type: number
+              description: 나이
+              nullable: true
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-users-me-intro-notes-questionCode974133747:
       required:
       - answer
@@ -3813,68 +3875,6 @@ components:
             introduction:
               type: string
               description: "한 줄 소개 (소개노트 one-word 답변, 미작성이면 null)"
-              nullable: true
-            age:
-              type: number
-              description: 나이
-              nullable: true
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-id-profile-829103765:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - nickname
-          - userId
-          type: object
-          properties:
-            occupation:
-              type: string
-              description: "직업 code. 가능한 값: it-tech, management, marketing, design,\
-                \ education, medical, finance, legal, manufacturing, distribution,\
-                \ service, construction, arts-media, research, public-admin, student,\
-                \ etc"
-              nullable: true
-            gender:
-              type: string
-              description: "성별 (MALE, FEMALE)"
-              nullable: true
-            nickname:
-              type: string
-              description: 닉네임
-            location:
-              type: string
-              description: "지역 code. 가능한 값: seoul, gyeonggi, incheon, busan, daegu,\
-                \ daejeon, gwangju, ulsan, sejong, gangwon, chungbuk, chungnam, jeonbuk,\
-                \ jeonnam, gyeongbuk, gyeongnam, jeju"
-              nullable: true
-            interests:
-              type: array
-              description: "관심사 code 목록. 가능한 값: workout, movie-drama, performance,\
-                \ photography, reading, music, cooking, travel, gaming, finance, self-improvement,\
-                \ pets, etc"
-              nullable: true
-              items:
-                oneOf:
-                - type: object
-                - type: boolean
-                - type: string
-                - type: number
-            profileImageUrl:
-              type: string
-              description: 프로필 이미지 경로
-              nullable: true
-            userId:
-              type: number
-              description: 대상 사용자 ID
-            introduction:
-              type: string
-              description: "자기소개 (소개노트 one-word 답변, 없으면 null)"
               nullable: true
             age:
               type: number

--- a/api/src/test/kotlin/com/ditto/api/user/MyProfileControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/MyProfileControllerTest.kt
@@ -1,0 +1,380 @@
+package com.ditto.api.user
+
+import com.ditto.api.support.RestDocsTest
+import com.ditto.api.user.dto.UpdateMyProfileRequest
+import com.ditto.domain.chat.ChatRoomMemberFixture
+import com.ditto.domain.chat.repository.ChatRoomMemberRepository
+import com.ditto.domain.intronote.entity.IntroNote
+import com.ditto.domain.intronote.entity.IntroQuestion
+import com.ditto.domain.intronote.repository.IntroNoteRepository
+import com.ditto.domain.member.MemberFixture
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.Interest
+import com.ditto.domain.member.entity.Job
+import com.ditto.domain.member.entity.Location
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.quiz.QuizProgressFixture
+import com.ditto.domain.quiz.repository.QuizProgressRepository
+import com.ditto.domain.review.MemberReviewFixture
+import com.ditto.domain.review.ReviewAnswerFixture
+import com.ditto.domain.review.entity.MeetingStatus
+import com.ditto.domain.review.entity.ReviewAnswerContent
+import com.ditto.domain.review.repository.MemberReviewRepository
+import com.ditto.domain.review.repository.ReviewAnswerRepository
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import java.time.LocalDateTime
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+private val INTEREST_CODES = Interest.entries.joinToString(", ") { it.code }
+
+class MyProfileControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var introNoteRepository: IntroNoteRepository
+
+    @Autowired
+    private lateinit var quizProgressRepository: QuizProgressRepository
+
+    @Autowired
+    private lateinit var chatRoomMemberRepository: ChatRoomMemberRepository
+
+    @Autowired
+    private lateinit var memberReviewRepository: MemberReviewRepository
+
+    @Autowired
+    private lateinit var reviewAnswerRepository: ReviewAnswerRepository
+
+    @Test
+    @DisplayName("내 프로필을 조회한다")
+    fun getMyProfile() {
+        val member = saveActiveMember()
+        introNoteRepository.save(
+            IntroNote.create(member.id, IntroQuestion.ONE_WORD, "주말마다 한강 산책하는 걸 좋아해요!"),
+        )
+
+        mockMvc.perform(
+            get("/api/v1/users/me/profile")
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.nickname").value("개굴개굴렌"))
+            .andExpect(jsonPath("$.data.introduction").value("주말마다 한강 산책하는 걸 좋아해요!"))
+            .andDo(
+                document(
+                    "my-profile-get",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Users")
+                            .summary("내 프로필 조회")
+                            .description(
+                                "내 프로필을 조회합니다. 응답 형태는 타인 공개 프로필(GET /api/v1/users/{id}/profile)과 같습니다. " +
+                                    "introduction은 소개노트 'one-word' 답변이며, 미작성이면 null입니다.",
+                            )
+                            .responseFields(*profileResponseFields())
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("캐리커쳐·관심사·한 줄 소개를 수정한다")
+    fun updateMyProfile() {
+        val member = saveActiveMember()
+        val request = UpdateMyProfileRequest(
+            introduction = "주말마다 한강 산책하는 걸 좋아해요!",
+            profileImageUrl = "/assets/avatar/m3.png",
+            interests = setOf("workout", "movie-drama", "exhibition"),
+        )
+
+        mockMvc.perform(
+            patch("/api/v1/users/me/profile")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andExpect(jsonPath("$.data.profileImageUrl").value("/assets/avatar/m3.png"))
+            .andExpect(jsonPath("$.data.introduction").value("주말마다 한강 산책하는 걸 좋아해요!"))
+            .andDo(
+                document(
+                    "my-profile-update",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Users")
+                            .summary("내 프로필 수정")
+                            .description(
+                                "프로필 수정 화면에서 편집 가능한 항목만 수정합니다 — 캐리커쳐·관심사·한 줄 소개. " +
+                                    "닉네임·성별·나이·사는곳·직업은 수정할 수 없습니다. " +
+                                    "생략(null)한 항목은 변경하지 않습니다. " +
+                                    "한 줄 소개는 소개노트 'one-word' 답변으로 저장됩니다.",
+                            )
+                            .requestFields(
+                                fieldWithPath("introduction")
+                                    .description("한 줄 소개 (최대 50자, 공백만 입력 불가). 생략 시 변경 없음")
+                                    .optional(),
+                                fieldWithPath("profileImageUrl")
+                                    .description("캐리커쳐 경로. 생략 시 변경 없음")
+                                    .optional(),
+                                fieldWithPath("interests")
+                                    .description("관심사 code 1~5개. 생략 시 변경 없음. 가능한 값: $INTEREST_CODES")
+                                    .optional(),
+                            )
+                            .responseFields(*profileResponseFields())
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("한 줄 소개가 50자를 넘으면 거부한다")
+    fun updateMyProfileRejectsTooLongIntroduction() {
+        val member = saveActiveMember()
+        val request = UpdateMyProfileRequest(introduction = "가".repeat(51))
+
+        mockMvc.perform(
+            patch("/api/v1/users/me/profile")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    @DisplayName("한 줄 소개가 공백만이면 거부한다")
+    fun updateMyProfileRejectsBlankIntroduction() {
+        val member = saveActiveMember()
+        val request = UpdateMyProfileRequest(introduction = "   ")
+
+        mockMvc.perform(
+            patch("/api/v1/users/me/profile")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    @DisplayName("관심사를 6개 이상 보내면 거부한다")
+    fun updateMyProfileRejectsTooManyInterests() {
+        val member = saveActiveMember()
+        val request = UpdateMyProfileRequest(
+            interests = setOf("workout", "movie-drama", "exhibition", "performance", "photo", "reading"),
+        )
+
+        mockMvc.perform(
+            patch("/api/v1/users/me/profile")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    @DisplayName("내 통계를 조회한다")
+    fun getMyStats() {
+        val member = saveActiveMember()
+        saveCompletedQuizProgress(member.id, quizSetId = 1L)
+        saveCompletedQuizProgress(member.id, quizSetId = 2L)
+        chatRoomMemberRepository.save(ChatRoomMemberFixture.create(roomId = 1L, memberId = member.id))
+        saveReceivedAnswer(member.id, MeetingStatus.MET, rating = 5, comment = "대화가 편하고 좋았어요")
+
+        mockMvc.perform(
+            get("/api/v1/users/me/stats")
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.participationWeeks").value(2))
+            .andExpect(jsonPath("$.data.matchCount").value(1))
+            .andExpect(jsonPath("$.data.meetingCount").value(1))
+            .andDo(
+                document(
+                    "my-profile-stats",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Users")
+                            .summary("내 통계 조회")
+                            .description(
+                                "내 프로필의 '내 통계' 카드용 지표입니다. " +
+                                    "참여 주차는 완주한 퀴즈 수, 매칭 성사는 개설된 채팅방 수, " +
+                                    "만남 횟수는 상대방 평가에서 '만났어요'를 받은 개수입니다.",
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.participationWeeks").description("참여 주차 (완주한 퀴즈 수)"),
+                                fieldWithPath("data.matchCount").description("매칭 성사 (개설된 채팅방 수)"),
+                                fieldWithPath("data.meetingCount").description("만남 횟수 ('만났어요' 평가를 받은 개수)"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("받은 평가가 3건 이상이면 평균·코멘트를 공개한다")
+    fun getMyRatings() {
+        val member = saveActiveMember()
+        saveReceivedAnswer(member.id, MeetingStatus.MET, rating = 5, comment = "대화가 편하고 좋았어요")
+        saveReceivedAnswer(member.id, MeetingStatus.MET, rating = 4, comment = "약속 시간 잘 지켜요")
+        saveReceivedAnswer(member.id, MeetingStatus.NO_SHOW, rating = 3, comment = null)
+
+        mockMvc.perform(
+            get("/api/v1/users/me/ratings")
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.totalCount").value(3))
+            .andExpect(jsonPath("$.data.averageScore").value(4.0))
+            .andExpect(jsonPath("$.data.publicThreshold").value(3))
+            .andExpect(jsonPath("$.data.noShowCount").value(1))
+            .andDo(
+                document(
+                    "my-profile-ratings",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Users")
+                            .summary("받은 평가 조회")
+                            .description(
+                                "내가 받은 평가 요약입니다. 총 평가가 publicThreshold(3)건 미만이면 비공개로, " +
+                                    "totalCount만 실제 값이고 평균·노쇼는 0, 코멘트는 빈 배열입니다. " +
+                                    "별점 반올림과 코멘트 3개 노출은 클라이언트가 처리합니다.",
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data.averageScore").description("평균 별점 (비공개 시 0)"),
+                                fieldWithPath("data.totalCount").description("받은 평가 총 건수"),
+                                fieldWithPath("data.publicThreshold").description("공개 기준 건수 (3)"),
+                                fieldWithPath("data.noShowCount").description("노쇼 평가를 받은 횟수 (비공개 시 0)"),
+                                fieldWithPath("data.ratings").description("평가 목록 최신순 (비공개 시 빈 배열)"),
+                                fieldWithPath("data.ratings[].comment").description("한줄 코멘트 (미입력이면 null)").optional(),
+                                fieldWithPath("data.ratings[].createdAt").description("평가 확정 일시"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("받은 평가가 3건 미만이면 총 건수만 내려준다")
+    fun getMyRatingsBelowThreshold() {
+        val member = saveActiveMember()
+        saveReceivedAnswer(member.id, MeetingStatus.MET, rating = 5, comment = "좋았어요")
+
+        mockMvc.perform(
+            get("/api/v1/users/me/ratings")
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.totalCount").value(1))
+            .andExpect(jsonPath("$.data.averageScore").value(0.0))
+            .andExpect(jsonPath("$.data.noShowCount").value(0))
+            .andExpect(jsonPath("$.data.ratings").isEmpty)
+    }
+
+    private var authorSequence = 1
+
+    private fun saveActiveMember(): Member = memberRepository.save(
+        MemberFixture.create(
+            nickname = "개굴개굴렌",
+            status = MemberStatus.ACTIVE,
+            gender = Gender.MALE,
+            age = 27,
+            interests = setOf(Interest.WORKOUT),
+            location = Location.SEOUL,
+            job = Job.IT_TECH,
+            caricature = "/assets/avatar/m1.png",
+        ),
+    )
+
+    /** 완주(COMPLETED) 상태의 퀴즈 진행 하나를 만든다 — 총 1문항을 답한 것으로 둔다. */
+    private fun saveCompletedQuizProgress(memberId: Long, quizSetId: Long) {
+        val progress = QuizProgressFixture.create(memberId = memberId, quizSetId = quizSetId, totalCount = 1)
+        progress.recordAnswer()
+        quizProgressRepository.save(progress)
+    }
+
+    /** 다른 회원이 [reviewedMemberId]에게 남긴 확정 평가 하나를 만든다. */
+    private fun saveReceivedAnswer(
+        reviewedMemberId: Long,
+        meetingStatus: MeetingStatus,
+        rating: Int,
+        comment: String?,
+    ) {
+        val author = memberRepository.save(
+            MemberFixture.create(
+                nickname = "평가자${authorSequence++}",
+                email = "reviewer${authorSequence}@example.com",
+                status = MemberStatus.ACTIVE,
+            ),
+        )
+        val review = memberReviewRepository.save(MemberReviewFixture.create(authorMemberId = author.id))
+        val answer = reviewAnswerRepository.save(
+            ReviewAnswerFixture.pending(memberReviewId = review.id, reviewedMemberId = reviewedMemberId),
+        )
+        answer.answer(
+            ReviewAnswerContent.of(meetingStatus, rating, comment),
+            LocalDateTime.now(),
+        )
+        reviewAnswerRepository.save(answer)
+    }
+
+    private fun profileResponseFields() = arrayOf(
+        fieldWithPath("success").description("성공 여부"),
+        fieldWithPath("data.userId").description("회원 ID"),
+        fieldWithPath("data.nickname").description("닉네임"),
+        fieldWithPath("data.gender").description("성별 (MALE/FEMALE)").optional(),
+        fieldWithPath("data.age").description("나이").optional(),
+        fieldWithPath("data.introduction").description("한 줄 소개 (소개노트 one-word 답변, 미작성이면 null)").optional(),
+        fieldWithPath("data.profileImageUrl").description("캐리커쳐 경로").optional(),
+        fieldWithPath("data.location").description("사는 곳 code").optional(),
+        fieldWithPath("data.occupation").description("직업 code").optional(),
+        fieldWithPath("data.interests").description("관심사 code 목록"),
+        fieldWithPath("data.rating").description("평점 (평가 도메인 연동 전이라 null)").optional(),
+        fieldWithPath("data.preferredMinAge").description("선호 최소 나이 (미사용, null)").optional(),
+        fieldWithPath("data.preferredMaxAge").description("선호 최대 나이 (미사용, null)").optional(),
+        fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+    )
+}

--- a/domain/src/main/kotlin/com/ditto/domain/chat/repository/ChatRoomMemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/chat/repository/ChatRoomMemberRepository.kt
@@ -8,7 +8,7 @@ interface ChatRoomMemberRepository : JpaRepository<ChatRoomMember, Long> {
     /** 내가 참여한 채팅방 멤버 레코드 목록 */
     fun findByMemberId(memberId: Long): List<ChatRoomMember>
 
-    /** 내가 참여한 채팅방 수 — 탈퇴 가드(진행 중 채팅 판정)에 쓴다. */
+    /** 내가 참여한 채팅방 수 — 프로필 통계의 "매칭 성사"(= 채팅방 개설 횟수)용 */
     fun countByMemberId(memberId: Long): Long
 
     fun findByRoomIdIn(roomIds: Collection<Long>): List<ChatRoomMember>

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Interest.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Interest.kt
@@ -18,6 +18,8 @@ enum class Interest(
 ) {
     WORKOUT("workout", "운동"),
     MOVIE_DRAMA("movie-drama", "영화/드라마"),
+    // 프로필 수정 화면(피그마 6.1.1)에만 있던 칩. 온보딩 목록에는 없어 뒤늦게 추가됐다.
+    EXHIBITION("exhibition", "전시"),
     PERFORMANCE("performance", "공연"),
     PHOTOGRAPHY("photography", "사진"),
     READING("reading", "독서"),

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
@@ -173,6 +173,25 @@ class Member(
         return leftAt.plusDays(retentionDays) <= now
     }
 
+    /**
+     * 마이프로필에서 수정 가능한 항목만 갱신한다 — 캐리커쳐·관심사.
+     * 닉네임·성별·나이·사는곳·직업은 화면에서 비활성이라 여기서 받지 않는다.
+     *
+     * null이 온 항목은 변경 없음으로 둔다. 관심사는 온보딩 필수 정보이므로
+     * 빈 집합으로 지울 수 없다 — 이 불변식은 `register`가 세운 것을 그대로 유지한다.
+     */
+    fun updateProfile(caricature: String?, interests: Set<Interest>?) {
+        if (interests != null) {
+            if (interests.isEmpty()) {
+                throw WarnException(ErrorCode.BAD_REQUEST, "관심사는 최소 1개 이상이어야 합니다.")
+            }
+            this.interests = interests
+        }
+        if (caricature != null) {
+            this.caricature = caricature
+        }
+    }
+
     fun isPending(): Boolean = status == MemberStatus.PENDING
     fun isActive(): Boolean = status == MemberStatus.ACTIVE
     fun isAdmin(): Boolean = role == MemberRole.ADMIN

--- a/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/quiz/repository/QuizProgressRepository.kt
@@ -31,6 +31,15 @@ interface QuizProgressRepository : JpaRepository<QuizProgress, Long>, QuizProgre
         status: QuizProgressStatus,
     ): List<QuizProgress>
 
+    /**
+     * 회원이 특정 상태로 남긴 진행 수 — 프로필 통계의 "참여 주차"용.
+     * 진행은 (회원, 퀴즈셋) 단위로 하나뿐이라 COMPLETED 개수가 곧 완주한 주차 수다.
+     */
+    fun countByMemberIdAndStatus(
+        memberId: Long,
+        status: QuizProgressStatus,
+    ): Long
+
     /** 여러 회원의 진행을 단일 벌크 DELETE 로 삭제 */
     @Modifying
     @Transactional

--- a/domain/src/main/kotlin/com/ditto/domain/review/repository/ReviewAnswerRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/review/repository/ReviewAnswerRepository.kt
@@ -1,5 +1,6 @@
 package com.ditto.domain.review.repository
 
+import com.ditto.domain.review.entity.MeetingStatus
 import com.ditto.domain.review.entity.ReviewAnswer
 import org.springframework.data.jpa.repository.JpaRepository
 
@@ -12,4 +13,18 @@ interface ReviewAnswerRepository : JpaRepository<ReviewAnswer, Long> {
 
     /** 여러 평가의 대상을 한 번에 읽는다. 반환 순서는 단건 조회와 동일(생성 순). */
     fun findAllByMemberReviewIdInOrderByIdAsc(memberReviewIds: Collection<Long>): List<ReviewAnswer>
+
+    /**
+     * 내가 **받은** 확정 평가를 최신순으로 읽는다 — 프로필의 "받은 평가" 집계용.
+     * 미응답(`answeredAt == null`)은 아직 평가가 아니므로 제외한다.
+     */
+    fun findAllByReviewedMemberIdAndAnsweredAtIsNotNullOrderByAnsweredAtDesc(
+        reviewedMemberId: Long,
+    ): List<ReviewAnswer>
+
+    /** 내가 받은 확정 평가 중 특정 만남 상태의 개수 — 만남 횟수(MET)·노쇼 횟수(NO_SHOW)용. */
+    fun countByReviewedMemberIdAndMeetingStatusAndAnsweredAtIsNotNull(
+        reviewedMemberId: Long,
+        meetingStatus: MeetingStatus,
+    ): Long
 }

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberProfileUpdateTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberProfileUpdateTest.kt
@@ -1,0 +1,71 @@
+package com.ditto.domain.member.entity
+
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.MemberFixture
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import io.kotest.core.spec.style.FreeSpec
+
+class MemberProfileUpdateTest : FreeSpec(
+    {
+        "updateProfile" - {
+            "캐리커쳐와 관심사를 함께 바꾼다" {
+                val member = MemberFixture.create(
+                    status = MemberStatus.ACTIVE,
+                    interests = setOf(Interest.WORKOUT),
+                    caricature = "/assets/avatar/m1.png",
+                )
+
+                member.updateProfile(
+                    caricature = "/assets/avatar/m3.png",
+                    interests = setOf(Interest.MOVIE_DRAMA, Interest.EXHIBITION),
+                )
+
+                member.caricature shouldBe "/assets/avatar/m3.png"
+                member.interests shouldBe setOf(Interest.MOVIE_DRAMA, Interest.EXHIBITION)
+            }
+
+            "null인 항목은 기존 값을 유지한다" {
+                val member = MemberFixture.create(
+                    status = MemberStatus.ACTIVE,
+                    interests = setOf(Interest.WORKOUT),
+                    caricature = "/assets/avatar/m1.png",
+                )
+
+                member.updateProfile(caricature = null, interests = null)
+
+                member.caricature shouldBe "/assets/avatar/m1.png"
+                member.interests shouldBe setOf(Interest.WORKOUT)
+            }
+
+            "관심사만 바꿀 수 있다" {
+                val member = MemberFixture.create(
+                    status = MemberStatus.ACTIVE,
+                    interests = setOf(Interest.WORKOUT),
+                    caricature = "/assets/avatar/m1.png",
+                )
+
+                member.updateProfile(caricature = null, interests = setOf(Interest.MUSIC))
+
+                member.interests shouldBe setOf(Interest.MUSIC)
+                member.caricature shouldBe "/assets/avatar/m1.png"
+            }
+
+            "관심사를 빈 집합으로 지울 수 없다 — 온보딩 필수 정보다" {
+                val member = MemberFixture.create(
+                    status = MemberStatus.ACTIVE,
+                    interests = setOf(Interest.WORKOUT),
+                )
+
+                val exception = shouldThrow<WarnException> {
+                    member.updateProfile(caricature = null, interests = emptySet())
+                }
+
+                exception.errorCode shouldBe ErrorCode.BAD_REQUEST
+                // 실패해도 기존 값은 그대로다.
+                member.interests shouldBe setOf(Interest.WORKOUT)
+            }
+        }
+    },
+)


### PR DESCRIPTION
Closes #122

## 요약

마이프로필 화면(`6.1 프로필`·`6.1.1 프로필 수정`)이 부르는 4개 엔드포인트를 추가했다. FE는 이미 완성돼 있었고 구 백엔드 경로(`/api/users/me/*`)를 호출해 전부 404였다.

| 엔드포인트 | 설명 |
|---|---|
| `GET /api/v1/users/me/profile` | 기존 `getPublicProfile`의 self 별칭 (이미 `viewerId == targetId`를 허용) |
| `PATCH /api/v1/users/me/profile` | 캐리커쳐·관심사(1~5)·한 줄 소개(≤50자). null인 항목은 변경 없음 |
| `GET /api/v1/users/me/stats` | 참여 주차·매칭 성사·만남 횟수 |
| `GET /api/v1/users/me/ratings` | 평균·건수·노쇼·코멘트(최신순), 3건 미만이면 비공개 |

## 설계 근거

지표 정의는 피그마 `6.1 프로필` 주석에서 확정된 것을 그대로 옮겼다.

- 참여 주차 = 퀴즈 참여 횟수 → `QuizProgress`의 COMPLETED 개수
- 매칭 성사 = 채팅방 개설 횟수 → `ChatRoomMember` 개수
- 만남 횟수 = 상대방 평가에서 '만났어요' 받은 개수 → `ReviewAnswer(reviewedMemberId=me, MET)`
- 받은 평가 공개 기준 3건 — 미달 시 `totalCount`만 실제 값으로 내려보내고 평균·노쇼·코멘트는 비운다

한 줄 소개는 `member`가 아니라 **소개노트 `ONE_WORD`에 저장**한다. 조회(`getPublicProfile`)가 이미 그 답변을 읽어 `introduction`으로 내려주므로, 저장 위치를 한 곳으로 유지해야 프로필 화면과 소개노트 화면이 어긋나지 않는다.

## 함께 고친 것

**`Interest.EXHIBITION`(전시) 추가** — 프로필 수정 화면(피그마 6.1.1)에는 "🖼️ 전시" 칩이 있고 FE도 `exhibition`을 보내는데 서버 enum에 값이 없어 `Interest.from`이 400을 던지고 있었다. 온보딩 목록에는 없는 값이라 여태 드러나지 않았다. enum 값 추가만 했으므로 기존 데이터에 영향은 없다.

## 알려진 제약 (이 PR의 문제가 아님)

`GET /users/me/ratings`와 `stats.meetingCount`는 **평가 생성 어댑터(I1P·I1G)가 붙을 때까지 항상 0/빈 값**이다.

#120이 머지되어 `chat_room`에 종료 생명주기는 생겼지만, `MemberReviewService.createReviews`를 호출하는 곳이 아직 없다 — #120은 "끝났다"는 사실까지만 책임지고 평가 생성은 후속 어댑터로 분리했다. 계약과 화면은 이 PR로 완성되고, 실데이터는 어댑터 연결 이후 채워진다.

## 후속 논의 — 한 줄 소개 길이 불일치

`ONE_WORD` 하나를 두 화면이 다른 제한으로 편집한다: 프로필 수정 화면 50자 / 소개노트 편집 화면 제한 없음 / 서버 컬럼 500자. 이 PR은 `PATCH`에서 50자를 검증하지만, 소개노트 경로로는 여전히 더 긴 값이 들어올 수 있다. `IntroQuestion` 단위 상한으로 정리하는 편이 맞다고 보는데 별도 이슈로 뺐다 (#122 본문에 기록).

## 검증

- [x] `./gradlew build check` (전체 테스트 + Jacoco 게이트) 통과
- [x] REST Docs 문서화 테스트 7건 — 조회·수정·통계·평가(공개/비공개) + 유효성 거부 2건
- [ ] Sonar New Code 게이트는 PR 체크 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

