### PR TITLE
[#123] feat. 설정 API — 알림 설정 토글, 사용자 차단(목록·해제·효과 집행)

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/match/matching/MatchingModels.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/matching/MatchingModels.kt
@@ -18,6 +18,7 @@ data class MatchParticipant(
     val gender: Gender,
     val age: Int,
     val preferredGender: GenderPreference = GenderPreference.ANY,
+    val blockedMemberIds: Set<Long> = emptySet(),
 ) {
     /** 이 참여자가 [other]의 성별을 매칭 대상으로 받아들이는가. */
     fun accepts(other: MatchParticipant): Boolean =
@@ -26,6 +27,14 @@ data class MatchParticipant(
     /** 두 참여자가 서로의 성별 선호를 모두 충족하는가(상호 호환). 1:1 매칭 페어 성립 조건. */
     fun isMutuallyCompatibleWith(other: MatchParticipant): Boolean =
         accepts(other) && other.accepts(this)
+
+    /**
+     * 둘 사이에 차단이 있는가. 차단은 방향과 무관하게 페어를 깨야 해서 양쪽을 모두 본다
+     * ([blockedMemberIds]가 이미 양방향으로 채워지지만, 대칭 판정을 이 함수 안에 두어
+     * 채우는 쪽 실수에 의존하지 않게 한다).
+     */
+    fun isBlockedWith(other: MatchParticipant): Boolean =
+        other.memberId in blockedMemberIds || memberId in other.blockedMemberIds
 }
 
 /**

--- a/api/src/main/kotlin/com/ditto/api/match/matching/OneToOneMatchingProcessor.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/matching/OneToOneMatchingProcessor.kt
@@ -44,9 +44,14 @@ class OneToOneMatchingProcessor : MatchingProcessor {
             }
         }
 
-    /** 매칭 자격: 성별 상호호환 + 나이차 [MAX_AGE_GAP] 이내. 둘 다 대칭이라 양방향 원칙을 깨지 않는다. */
+    /**
+     * 매칭 자격: 성별 상호호환 + 나이차 [MAX_AGE_GAP] 이내 + 차단 없음.
+     * 세 조건 모두 대칭이라 양방향 원칙을 깨지 않는다.
+     */
     private fun isValidPair(a: MatchParticipant, b: MatchParticipant): Boolean =
-        a.isMutuallyCompatibleWith(b) && abs(a.age - b.age) <= MAX_AGE_GAP
+        a.isMutuallyCompatibleWith(b) &&
+            abs(a.age - b.age) <= MAX_AGE_GAP &&
+            !a.isBlockedWith(b)
 
     companion object {
         private const val TOP_RATIO = 0.2 // 상위 20% 선발

--- a/api/src/main/kotlin/com/ditto/api/match/service/MatchmakingService.kt
+++ b/api/src/main/kotlin/com/ditto/api/match/service/MatchmakingService.kt
@@ -9,6 +9,7 @@ import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
 import com.ditto.domain.match.entity.MatchCandidate
 import com.ditto.domain.match.repository.MatchCandidateRepository
+import com.ditto.domain.member.repository.MemberBlockRepository
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.quiz.entity.MatchingType
 import com.ditto.domain.quiz.entity.QuizProgress
@@ -37,6 +38,7 @@ class MatchmakingService(
     private val quizAnswerRepository: QuizAnswerRepository,
     private val matchCandidateRepository: MatchCandidateRepository,
     private val memberRepository: MemberRepository,
+    private val memberBlockRepository: MemberBlockRepository,
     private val exclusionPolicies: List<MatchExclusionPolicy>,
     private val matchingProcessors: List<MatchingProcessor>,
     private val sanctionExpiryService: SanctionExpiryService,
@@ -109,6 +111,7 @@ class MatchmakingService(
             .mapValues { (_, answers) -> answers.associate { it.quizId to it.choiceId } }
         val membersById = memberRepository.findAllById(memberIds).associateBy { it.id }
         val preferenceByMember = completedProgresses.associate { it.memberId to it.preferredGender }
+        val blockedIdsByMember = loadBlockedIdsByMember(memberIds)
         return memberIds.mapNotNull { memberId ->
             // 성별·나이 미상 회원은 성별·나이 기반 매칭이 불가하므로 후보 풀에서 제외한다.
             val member = membersById[memberId] ?: return@mapNotNull null
@@ -121,8 +124,26 @@ class MatchmakingService(
                 age = age,
                 // memberIds 는 completedProgresses 에서 유래하므로 선호값은 항상 존재한다(기본값은 QuizProgress 가 보유).
                 preferredGender = preferenceByMember.getValue(memberId),
+                blockedMemberIds = blockedIdsByMember[memberId].orEmpty(),
             )
         }
+    }
+
+    /**
+     * 후보 풀 안에서 차단 관계인 상대를 회원별로 모은다(방향 무관).
+     * 차단은 회원 전체를 풀에서 빼는 게 아니라 **그 페어만** 깨야 하므로 제외 정책이 아니라 여기서 다룬다.
+     */
+    private fun loadBlockedIdsByMember(memberIds: Set<Long>): Map<Long, Set<Long>> {
+        if (memberIds.isEmpty()) return emptyMap()
+        val blocks = memberBlockRepository.findAllInvolving(memberIds)
+        if (blocks.isEmpty()) return emptyMap()
+
+        val blockedIdsByMember = mutableMapOf<Long, MutableSet<Long>>()
+        blocks.forEach { block ->
+            blockedIdsByMember.getOrPut(block.blockerId) { mutableSetOf() }.add(block.blockedMemberId)
+            blockedIdsByMember.getOrPut(block.blockedMemberId) { mutableSetOf() }.add(block.blockerId)
+        }
+        return blockedIdsByMember
     }
 
     /** 페어(A,B) 하나를 (A→B), (B→A) 두 방향 행으로 변환한다. */

--- a/api/src/main/kotlin/com/ditto/api/setting/controller/SettingController.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/controller/SettingController.kt
@@ -1,0 +1,74 @@
+package com.ditto.api.setting.controller
+
+import com.ditto.api.config.auth.MemberPrincipal
+import com.ditto.api.setting.dto.BlockedMemberResponse
+import com.ditto.api.setting.dto.CreateBlockRequest
+import com.ditto.api.setting.dto.NotificationSettingsResponse
+import com.ditto.api.setting.dto.UpdateNotificationSettingsRequest
+import com.ditto.api.setting.service.MemberBlockService
+import com.ditto.api.setting.service.NotificationSettingService
+import com.ditto.common.logging.Loggable
+import com.ditto.common.response.ApiResponse
+import jakarta.validation.Valid
+import org.springframework.security.core.annotation.AuthenticationPrincipal
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PatchMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RestController
+
+/** 설정 화면(피그마 6.2)의 알림 설정·차단 목록 엔드포인트. */
+@RestController
+class SettingController(
+    private val notificationSettingService: NotificationSettingService,
+    private val memberBlockService: MemberBlockService,
+) {
+
+    @Loggable
+    @GetMapping("/api/v1/users/me/notification-settings")
+    fun getNotificationSettings(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<NotificationSettingsResponse> =
+        ApiResponse.ok(notificationSettingService.getSettings(principal.memberId))
+
+    @Loggable
+    @PatchMapping("/api/v1/users/me/notification-settings")
+    fun updateNotificationSettings(
+        @RequestBody request: UpdateNotificationSettingsRequest,
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<NotificationSettingsResponse> =
+        ApiResponse.ok(notificationSettingService.updateSettings(principal.memberId, request))
+
+    @Loggable
+    @GetMapping("/api/v1/users/me/blocks")
+    fun getMyBlocks(
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<List<BlockedMemberResponse>> =
+        ApiResponse.ok(memberBlockService.getMyBlocks(principal.memberId))
+
+    /**
+     * 신고 없이 차단만 하는 경로. 신고와 함께 차단하는 경우는
+     * `POST /api/v1/user-reports`의 `block` 필드를 쓴다.
+     */
+    @Loggable
+    @PostMapping("/api/v1/users/me/blocks")
+    fun block(
+        @Valid @RequestBody request: CreateBlockRequest,
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<Unit> {
+        memberBlockService.block(principal.memberId, request.memberId)
+        return ApiResponse.ok(Unit)
+    }
+
+    @Loggable
+    @DeleteMapping("/api/v1/users/me/blocks/{memberId}")
+    fun unblock(
+        @PathVariable memberId: Long,
+        @AuthenticationPrincipal principal: MemberPrincipal,
+    ): ApiResponse<Unit> {
+        memberBlockService.unblock(principal.memberId, memberId)
+        return ApiResponse.ok(Unit)
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/setting/dto/BlockedMemberResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/dto/BlockedMemberResponse.kt
@@ -1,0 +1,16 @@
+package com.ditto.api.setting.dto
+
+import java.time.LocalDateTime
+
+/**
+ * 차단 목록 항목. 차단 사유는 담지 않는다 — 화면이 사유를 노출하지 않는다(피그마 6.2.2 주석).
+ *
+ * [id]는 차단된 **회원 ID**다(차단 레코드 ID가 아니다) — 해제 API가 상대 회원을 식별해 지우고,
+ * 클라이언트도 회원 단위로 목록을 다룬다.
+ */
+data class BlockedMemberResponse(
+    val id: Long,
+    val nickname: String,
+    val profileImageUrl: String?,
+    val blockedAt: LocalDateTime,
+)

--- a/api/src/main/kotlin/com/ditto/api/setting/dto/CreateBlockRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/dto/CreateBlockRequest.kt
@@ -1,0 +1,8 @@
+package com.ditto.api.setting.dto
+
+import jakarta.validation.constraints.Positive
+
+data class CreateBlockRequest(
+    @field:Positive(message = "차단할 회원 ID가 올바르지 않습니다.")
+    val memberId: Long,
+)

--- a/api/src/main/kotlin/com/ditto/api/setting/dto/NotificationSettingsResponse.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/dto/NotificationSettingsResponse.kt
@@ -1,0 +1,19 @@
+package com.ditto.api.setting.dto
+
+import com.ditto.domain.member.entity.MemberNotificationSetting
+
+/**
+ * 설정 화면(피그마 6.2)의 알림 토글 3종. 항목 이름은 화면 라벨을 그대로 따른다 —
+ * 매칭 알림 / 채팅 알림 / 마케팅 정보 수신.
+ */
+data class NotificationSettingsResponse(
+    val matching: Boolean,
+    val chat: Boolean,
+    val marketing: Boolean,
+)
+
+fun MemberNotificationSetting.toResponse() = NotificationSettingsResponse(
+    matching = matching,
+    chat = chat,
+    marketing = marketing,
+)

--- a/api/src/main/kotlin/com/ditto/api/setting/dto/UpdateNotificationSettingsRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/dto/UpdateNotificationSettingsRequest.kt
@@ -1,0 +1,11 @@
+package com.ditto.api.setting.dto
+
+/**
+ * 알림 설정 부분 패치. **null = 변경 없음**이다 —
+ * 화면은 토글 하나를 누를 때마다 그 항목만 보낸다.
+ */
+data class UpdateNotificationSettingsRequest(
+    val matching: Boolean? = null,
+    val chat: Boolean? = null,
+    val marketing: Boolean? = null,
+)

--- a/api/src/main/kotlin/com/ditto/api/setting/service/MemberBlockService.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/service/MemberBlockService.kt
@@ -1,0 +1,75 @@
+package com.ditto.api.setting.service
+
+import com.ditto.api.setting.dto.BlockedMemberResponse
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.entity.MemberBlock
+import com.ditto.domain.member.repository.MemberBlockRepository
+import com.ditto.domain.member.repository.MemberRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 사용자 간 차단. 화면(피그마 6.2.2)이 약속한 효력은 두 가지다 —
+ * 상대가 내 프로필을 볼 수 없고, 매칭에서 서로 제외된다.
+ * 집행 지점은 각각 `UserService.getPublicProfile`과 매칭 후보 생성이며, 판정은 [isBlockedBetween]을 쓴다.
+ */
+@Service
+class MemberBlockService(
+    private val memberBlockRepository: MemberBlockRepository,
+    private val memberRepository: MemberRepository,
+) {
+
+    /**
+     * 차단을 만든다. 이미 차단한 상대면 아무 것도 하지 않는다(멱등) —
+     * 신고와 함께 오는 경로가 있어 재시도·중복 요청이 실패로 보이면 안 된다.
+     */
+    @Transactional
+    fun block(blockerId: Long, blockedMemberId: Long) {
+        if (blockerId == blockedMemberId) {
+            throw WarnException(ErrorCode.BAD_REQUEST, "자기 자신을 차단할 수 없습니다.")
+        }
+        if (!memberRepository.existsById(blockedMemberId)) {
+            throw WarnException(ErrorCode.NOT_FOUND)
+        }
+        if (memberBlockRepository.existsByBlockerIdAndBlockedMemberId(blockerId, blockedMemberId)) {
+            return
+        }
+        memberBlockRepository.save(MemberBlock.create(blockerId, blockedMemberId))
+    }
+
+    @Transactional(readOnly = true)
+    fun getMyBlocks(blockerId: Long): List<BlockedMemberResponse> {
+        val blocks = memberBlockRepository.findAllByBlockerIdOrderByCreatedAtDesc(blockerId)
+        if (blocks.isEmpty()) {
+            return emptyList()
+        }
+
+        // 닉네임·캐리커쳐를 한 번에 읽어 N+1을 피한다.
+        val membersById = memberRepository.findAllById(blocks.map { it.blockedMemberId })
+            .associateBy { it.id }
+
+        return blocks.mapNotNull { block ->
+            val member = membersById[block.blockedMemberId] ?: return@mapNotNull null
+            BlockedMemberResponse(
+                id = member.id,
+                nickname = member.nickname,
+                profileImageUrl = member.caricature,
+                blockedAt = block.createdAt,
+            )
+        }
+    }
+
+    /** 차단 해제. 차단하지 않은 상대를 해제해도 성공으로 둔다 — 목록에서 지우는 동작이 멱등해야 한다. */
+    @Transactional
+    fun unblock(blockerId: Long, blockedMemberId: Long) {
+        val block = memberBlockRepository.findByBlockerIdAndBlockedMemberId(blockerId, blockedMemberId)
+            ?: return
+        memberBlockRepository.delete(block)
+    }
+
+    /** 두 회원 사이에 방향 무관하게 차단이 있는지 — 프로필 조회·매칭 제외의 공통 판정. */
+    @Transactional(readOnly = true)
+    fun isBlockedBetween(oneId: Long, otherId: Long): Boolean =
+        memberBlockRepository.existsBetween(oneId, otherId)
+}

--- a/api/src/main/kotlin/com/ditto/api/setting/service/NotificationSettingService.kt
+++ b/api/src/main/kotlin/com/ditto/api/setting/service/NotificationSettingService.kt
@@ -1,0 +1,40 @@
+package com.ditto.api.setting.service
+
+import com.ditto.api.setting.dto.NotificationSettingsResponse
+import com.ditto.api.setting.dto.UpdateNotificationSettingsRequest
+import com.ditto.api.setting.dto.toResponse
+import com.ditto.domain.member.entity.MemberNotificationSetting
+import com.ditto.domain.member.repository.MemberNotificationSettingRepository
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+/**
+ * 설정 화면의 알림 토글. 행이 없는 회원은 기본값으로 응답하며, 조회만으로 행을 만들지 않는다
+ * — 읽기 트랜잭션에서 쓰기를 하지 않아야 읽기 전용 복제로 옮겨도 안전하다.
+ */
+@Service
+class NotificationSettingService(
+    private val repository: MemberNotificationSettingRepository,
+) {
+
+    @Transactional(readOnly = true)
+    fun getSettings(memberId: Long): NotificationSettingsResponse =
+        (repository.findByMemberId(memberId) ?: MemberNotificationSetting.defaultOf(memberId)).toResponse()
+
+    /** 부분 패치. 아직 행이 없으면 기본값에서 시작해 만든다. */
+    @Transactional
+    fun updateSettings(
+        memberId: Long,
+        request: UpdateNotificationSettingsRequest,
+    ): NotificationSettingsResponse {
+        val setting = repository.findByMemberId(memberId)
+            ?: repository.save(MemberNotificationSetting.defaultOf(memberId))
+
+        setting.update(
+            matching = request.matching,
+            chat = request.chat,
+            marketing = request.marketing,
+        )
+        return setting.toResponse()
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
@@ -20,6 +20,7 @@ import com.ditto.domain.intronote.repository.IntroNoteRepository
 import com.ditto.domain.member.entity.Interest
 import com.ditto.domain.member.entity.Job
 import com.ditto.domain.member.entity.Location
+import com.ditto.domain.member.repository.MemberBlockRepository
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
 import com.ditto.domain.socialaccount.repository.SocialAccountRepository
@@ -29,6 +30,7 @@ import org.springframework.transaction.annotation.Transactional
 @Service
 class UserService(
     private val memberRepository: MemberRepository,
+    private val memberBlockRepository: MemberBlockRepository,
     private val introNoteRepository: IntroNoteRepository,
     private val matchAccessChecker: MatchAccessChecker,
     private val socialAccountRepository: SocialAccountRepository,
@@ -81,10 +83,16 @@ class UserService(
     /**
      * 타인 공개 프로필 조회. 매칭이 성사된 상대(또는 같은 그룹채팅 참여자)만 조회 가능.
      * 민감정보(email·전화번호·실명)는 반환하지 않는다.
+     *
+     * 차단한/차단당한 상대는 매칭 이력이 있어도 볼 수 없다 —
+     * "차단한 사용자는 나의 프로필을 볼 수 없고"(피그마 6.2.2)를 집행하는 지점이다.
      */
     @Transactional(readOnly = true)
     fun getPublicProfile(viewerId: Long, targetId: Long): PublicProfileResponse {
         if (viewerId != targetId && !matchAccessChecker.isMatched(viewerId, targetId)) {
+            throw WarnException(ErrorCode.FORBIDDEN)
+        }
+        if (viewerId != targetId && memberBlockRepository.existsBetween(viewerId, targetId)) {
             throw WarnException(ErrorCode.FORBIDDEN)
         }
 

--- a/api/src/main/kotlin/com/ditto/api/userreport/dto/CreateUserReportRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/userreport/dto/CreateUserReportRequest.kt
@@ -8,6 +8,9 @@ import jakarta.validation.constraints.Size
 
 /**
  * 신고 접수 요청. [imageKeys]는 업로드 URL 발급 API에서 받은 objectKey 목록(최대 3개).
+ *
+ * [block]은 신고 화면 하단의 선택 체크박스("이 사용자 차단하기")에 대응한다 —
+ * 신고와 차단은 별개 기능이고, 체크했을 때만 차단이 생성된다(자동 차단이 아니다).
  */
 data class CreateUserReportRequest(
     @field:Positive(message = "피신고자 ID가 올바르지 않습니다.")
@@ -24,4 +27,6 @@ data class CreateUserReportRequest(
 
     @field:Size(max = MemberReportImage.MAX_COUNT, message = "이미지 첨부는 최대 3장까지 가능합니다.")
     val imageKeys: List<String> = emptyList(),
+
+    val block: Boolean = false,
 )

--- a/api/src/main/kotlin/com/ditto/api/userreport/service/UserReportService.kt
+++ b/api/src/main/kotlin/com/ditto/api/userreport/service/UserReportService.kt
@@ -4,6 +4,7 @@ import com.ditto.api.userreport.dto.CreateUserReportRequest
 import com.ditto.api.userreport.dto.CreateUserReportResponse
 import com.ditto.api.userreport.dto.ImageUploadUrlResponse
 import com.ditto.api.userreport.dto.ImageUploadUrlsResponse
+import com.ditto.api.setting.service.MemberBlockService
 import com.ditto.api.userreport.dto.IssueImageUploadUrlsRequest
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.WarnException
@@ -26,6 +27,7 @@ class UserReportService(
     private val memberReportRepository: MemberReportRepository,
     private val memberReportImageRepository: MemberReportImageRepository,
     private val memberRepository: MemberRepository,
+    private val memberBlockService: MemberBlockService,
     private val objectStorage: ObjectStorage,
 ) {
 
@@ -53,6 +55,12 @@ class UserReportService(
 
         validateReportedMemberExists(request.reportedMemberId)
         validateNotDuplicated(reporterId, request.reportedMemberId)
+
+        // 신고 화면의 "이 사용자 차단하기"를 체크한 경우에만 차단을 만든다 — 자동 차단이 아니다.
+        // 신고와 차단은 별개 기록이라, 이후 신고가 기각돼도 차단은 남는다(내 차단은 내 의사).
+        if (request.block) {
+            memberBlockService.block(reporterId, request.reportedMemberId)
+        }
 
         val saved = memberReportRepository.save(report)
         val images = MemberReportImage.attachAll(

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -79,13 +79,13 @@ paths:
       - UserReports
       summary: 신고 접수
       description: 상대 회원을 신고합니다. 자기 신고·검토 대기 중인 동일 대상 재신고는 거부됩니다. 이미지는 업로드 URL 발급
-        API로 업로드를 마친 objectKey를 전달합니다.
+        API로 업로드를 마친 objectKey를 전달합니다. block을 true로 보내면 신고와 함께 해당 회원을 차단합니다.
       operationId: user-report-create
       requestBody:
         content:
           application/json;charset=UTF-8:
             schema:
-              $ref: "#/components/schemas/api-v1-user-reports1863970767"
+              $ref: "#/components/schemas/api-v1-user-reports387435662"
             examples:
               user-report-create:
                 value: |-
@@ -94,7 +94,8 @@ paths:
                     "reason" : "inappropriate-behavior",
                     "source" : "profile",
                     "detail" : "대화 중 폭언을 반복했습니다.",
-                    "imageKeys" : [ "pending/user-reports/1/db2933d6-3141-400e-be23-95fa920f1251" ]
+                    "imageKeys" : [ "pending/user-reports/1/7afedaa8-20ed-4435-b7f3-a277e33d4539" ],
+                    "block" : false
                   }
       responses:
         "200":
@@ -168,10 +169,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-08-05 00:11:25",
+                        "joinedAt" : "2026-08-05 00:33:42",
                         "role" : null,
-                        "createdAt" : "2026-08-05 00:11:25",
-                        "updatedAt" : "2026-08-05 00:11:25"
+                        "createdAt" : "2026-08-05 00:33:42",
+                        "updatedAt" : "2026-08-05 00:33:42"
                       },
                       "error" : null
                     }
@@ -454,8 +455,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-08-04 00:11:25",
-                          "endDate" : "2026-08-06 00:11:25",
+                          "startDate" : "2026-08-04 00:33:42",
+                          "endDate" : "2026-08-06 00:33:42",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -472,8 +473,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-08-05 00:11:25",
-                            "updatedAt" : "2026-08-05 00:11:25"
+                            "createdAt" : "2026-08-05 00:33:42",
+                            "updatedAt" : "2026-08-05 00:33:42"
                           } ]
                         } ]
                       },
@@ -520,8 +521,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-08-05 00:11:25",
-                        "updatedAt" : "2026-08-05 00:11:25"
+                        "createdAt" : "2026-08-05 00:33:42",
+                        "updatedAt" : "2026-08-05 00:33:42"
                       },
                       "error" : null
                     }
@@ -598,11 +599,11 @@ paths:
                       "success" : true,
                       "data" : {
                         "uploads" : [ {
-                          "objectKey" : "pending/user-reports/1/827a6cad-cee9-4857-8a3c-65e01550cee3",
-                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/827a6cad-cee9-4857-8a3c-65e01550cee3"
+                          "objectKey" : "pending/user-reports/1/81dafd76-2216-4c31-8083-f4961c6b8eb7",
+                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/81dafd76-2216-4c31-8083-f4961c6b8eb7"
                         }, {
-                          "objectKey" : "pending/user-reports/1/2569fddf-d61b-4075-9a33-49197cff1878",
-                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/2569fddf-d61b-4075-9a33-49197cff1878"
+                          "objectKey" : "pending/user-reports/1/c3997f6b-8c9f-4b45-89fe-be8653153a97",
+                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/c3997f6b-8c9f-4b45-89fe-be8653153a97"
                         } ]
                       },
                       "error" : null
@@ -885,7 +886,7 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODU4NTYyODEsImV4cCI6MTc4NTg1OTg4MX0.rposjPujZbs13aaJsLSzvMw96EnbNnnfXcX4-IXPZ2aqYUEscv0BWB0ov4xuk86MwPdKiiWrf0qYV5lAGtW3WQ"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODU4NTc2MTksImV4cCI6MTc4NTg2MTIxOX0.2Kfdn92MfjEEvmCp5b9eYklYAKxC4ef4LyWnIrFQI1dsC4SrL-iz5QtJBa8kvYDmXmE5uJoCYlTm3RVFOm93xw"
                       },
                       "error" : null
                     }
@@ -913,12 +914,12 @@ paths:
                         "id" : 3,
                         "nickname" : "나중차단된회원",
                         "profileImageUrl" : "/assets/avatar/m1.png",
-                        "blockedAt" : "2026-08-04 11:26:49"
+                        "blockedAt" : "2026-08-05 00:33:42"
                       }, {
                         "id" : 2,
                         "nickname" : "먼저차단된회원",
                         "profileImageUrl" : "/assets/avatar/m1.png",
-                        "blockedAt" : "2026-08-04 11:26:49"
+                        "blockedAt" : "2026-08-05 00:33:42"
                       } ],
                       "error" : null
                     }
@@ -1211,13 +1212,13 @@ paths:
                         "noShowCount" : 1,
                         "ratings" : [ {
                           "comment" : null,
-                          "createdAt" : "2026-08-05 00:11:25"
+                          "createdAt" : "2026-08-05 00:33:42"
                         }, {
                           "comment" : "약속 시간 잘 지켜요",
-                          "createdAt" : "2026-08-05 00:11:25"
+                          "createdAt" : "2026-08-05 00:33:42"
                         }, {
                           "comment" : "대화가 편하고 좋았어요",
-                          "createdAt" : "2026-08-05 00:11:25"
+                          "createdAt" : "2026-08-05 00:33:42"
                         } ]
                       },
                       "error" : null
@@ -1250,8 +1251,8 @@ paths:
                           "levelDescription" : "기간 이용 정지",
                           "reason" : null,
                           "reasonDescription" : null,
-                          "startsAt" : "2026-07-29 00:11:25",
-                          "endsAt" : "2026-08-12 00:11:25"
+                          "startsAt" : "2026-07-29 00:33:42",
+                          "endsAt" : "2026-08-12 00:33:42"
                         }
                       },
                       "error" : null
@@ -1427,8 +1428,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-08-05 00:11:25",
-                        "updatedAt" : "2026-08-05 00:11:25"
+                        "createdAt" : "2026-08-05 00:33:42",
+                        "updatedAt" : "2026-08-05 00:33:42"
                       },
                       "error" : null
                     }
@@ -2387,6 +2388,43 @@ components:
           type: boolean
           description: 채팅 알림 수신 여부. 생략 시 변경 없음
           nullable: true
+    api-v1-user-reports387435662:
+      required:
+      - reason
+      - reportedMemberId
+      - source
+      type: object
+      properties:
+        reason:
+          type: string
+          description: "신고 사유 code. 가능한 값: inappropriate-behavior(부적절한 행동 (성희롱·폭언·\
+            협박 등)), money-demand(금전 요구 (돈을 요구하거나 상업적 홍보)), false-information(허위 정보\
+            \ (프로필 정보가 거짓이거나 사진 도용)), underage(미성년자 (19세 미만으로 의심)), etc(기타)"
+        block:
+          type: boolean
+          description: 함께 차단할지 여부 (기본 false). 신고 화면의 '이 사용자 차단하기' 체크박스
+          nullable: true
+        imageKeys:
+          type: array
+          description: "첨부 이미지 objectKey 목록 (선택, 최대 3개)"
+          nullable: true
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        detail:
+          type: string
+          description: "상세 설명 (선택, 최대 500자 — etc 사유는 필수)"
+          nullable: true
+        source:
+          type: string
+          description: "신고 접수 위치 code. 가능한 값: profile(프로필 화면), match-result(매칭 결과\
+            \ 화면), chat-room(채팅방)"
+        reportedMemberId:
+          type: number
+          description: 피신고자 회원 ID
     api-v1-chat-rooms1291226728:
       required:
       - error
@@ -2871,6 +2909,18 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-quiz-progress-answers-1062387050:
+      required:
+      - choiceId
+      - quizId
+      type: object
+      properties:
+        choiceId:
+          type: number
+          description: 선택한 선택지 ID
+        quizId:
+          type: number
+          description: 퀴즈 ID
     api-v1-user-reports900126493:
       required:
       - error
@@ -2888,18 +2938,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-quiz-progress-answers-1062387050:
-      required:
-      - choiceId
-      - quizId
-      type: object
-      properties:
-        choiceId:
-          type: number
-          description: 선택한 선택지 ID
-        quizId:
-          type: number
-          description: 퀴즈 ID
     api-v1-chat-rooms-roomId-image-upload-urls1777271249:
       type: object
       properties:
@@ -3252,39 +3290,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-user-reports1863970767:
-      required:
-      - reason
-      - reportedMemberId
-      - source
-      type: object
-      properties:
-        reason:
-          type: string
-          description: "신고 사유 code. 가능한 값: inappropriate-behavior(부적절한 행동 (성희롱·폭언·\
-            협박 등)), money-demand(금전 요구 (돈을 요구하거나 상업적 홍보)), false-information(허위 정보\
-            \ (프로필 정보가 거짓이거나 사진 도용)), underage(미성년자 (19세 미만으로 의심)), etc(기타)"
-        imageKeys:
-          type: array
-          description: "첨부 이미지 objectKey 목록 (선택, 최대 3개)"
-          nullable: true
-          items:
-            oneOf:
-            - type: object
-            - type: boolean
-            - type: string
-            - type: number
-        detail:
-          type: string
-          description: "상세 설명 (선택, 최대 500자 — etc 사유는 필수)"
-          nullable: true
-        source:
-          type: string
-          description: "신고 접수 위치 code. 가능한 값: profile(프로필 화면), match-result(매칭 결과\
-            \ 화면)"
-        reportedMemberId:
-          type: number
-          description: 피신고자 회원 ID
     api-v1-users-auth-logout-1831456372:
       required:
       - data

--- a/api/src/test/kotlin/com/ditto/api/match/MatchmakingServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/match/MatchmakingServiceTest.kt
@@ -10,6 +10,8 @@ import com.ditto.domain.member.MemberFixture
 import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.GenderPreference
 import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.member.entity.MemberBlock
+import com.ditto.domain.member.repository.MemberBlockRepository
 import com.ditto.domain.member.repository.MemberRepository
 import com.ditto.domain.quiz.QuizAnswerFixture
 import com.ditto.domain.quiz.QuizFixture
@@ -33,6 +35,7 @@ class MatchmakingServiceTest(
     private val quizProgressRepository: QuizProgressRepository,
     private val personalMatchRepository: PersonalMatchRepository,
     private val matchCandidateRepository: MatchCandidateRepository,
+    private val memberBlockRepository: MemberBlockRepository,
     dataSource: DataSource,
 ) : IntegrationTest(
     dataSource,
@@ -106,6 +109,36 @@ class MatchmakingServiceTest(
                 val abCandidate = matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(a, quizSetId).first()
                 abCandidate.matchedQuestionCount shouldBe 2
                 abCandidate.totalQuestionCount shouldBe 2
+            }
+
+            "차단 관계인 두 사람은 후보 페어가 되지 않는다" {
+                val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
+                val a = saveMember("차단회원A")
+                val b = saveMember("차단회원B")
+                // 두 문항 모두 일치해 원래라면 반드시 페어가 되는 조합이다.
+                saveAnswers(a, quizId1 to 1L, quizId2 to 1L)
+                saveAnswers(b, quizId1 to 1L, quizId2 to 1L)
+                listOf(a, b).forEach { saveCompletedProgress(it, quizSetId, total = 2) }
+                memberBlockRepository.save(MemberBlock.create(blockerId = a, blockedMemberId = b))
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(a, quizSetId) shouldHaveSize 0
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(b, quizSetId) shouldHaveSize 0
+            }
+
+            "차단이 없으면 같은 조합이 후보가 된다 (위 케이스의 대조군)" {
+                val (quizSetId, quizId1, quizId2) = saveOneToOneQuizSetWithTwoQuizzes()
+                val a = saveMember("정상회원A")
+                val b = saveMember("정상회원B")
+                saveAnswers(a, quizId1 to 1L, quizId2 to 1L)
+                saveAnswers(b, quizId1 to 1L, quizId2 to 1L)
+                listOf(a, b).forEach { saveCompletedProgress(it, quizSetId, total = 2) }
+
+                matchmakingService.generateMatchingCandidates(quizSetId)
+
+                matchCandidateRepository.findByOwnerMemberIdAndQuizSetId(a, quizSetId)
+                    .map { it.otherMemberId } shouldBe listOf(b)
             }
 
             "완료한 참여자가 없으면 후보를 만들지 않는다" {

--- a/api/src/test/kotlin/com/ditto/api/setting/MemberBlockEffectTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/setting/MemberBlockEffectTest.kt
@@ -1,0 +1,192 @@
+package com.ditto.api.setting
+
+import com.ditto.api.match.matching.MatchParticipant
+import com.ditto.api.match.matching.OneToOneMatchingProcessor
+import com.ditto.api.setting.service.MemberBlockService
+import com.ditto.api.support.IntegrationTest
+import com.ditto.api.user.service.UserService
+import com.ditto.api.userreport.dto.CreateUserReportRequest
+import com.ditto.api.userreport.service.UserReportService
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import com.ditto.domain.member.entity.Gender
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberBlock
+import com.ditto.domain.member.repository.MemberBlockRepository
+import com.ditto.domain.member.repository.MemberRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+/**
+ * 차단의 두 효력을 검증한다 — 화면(피그마 6.2.2)이 약속한 문구가 곧 명세다.
+ * "차단한 사용자는 나의 프로필을 볼 수 없고, 매칭에서 제외돼요."
+ */
+class MemberBlockEffectTest(
+    private val userService: UserService,
+    private val memberRepository: MemberRepository,
+    private val memberBlockRepository: MemberBlockRepository,
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val userReportService: UserReportService,
+    private val memberBlockService: MemberBlockService,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    fun saveMember(nickname: String, gender: Gender = Gender.FEMALE, age: Int = 27) =
+        memberRepository.save(
+            Member(nickname = nickname, gender = gender, age = age).apply { activate() },
+        )
+
+    "차단은 프로필 조회를 막는다" - {
+        "매칭이 성사된 상대라도 차단한 뒤에는 프로필을 조회할 수 없다" {
+            val viewer = saveMember("차단한조회자")
+            val target = saveMember("차단된대상")
+            personalMatchRepository.save(
+                PersonalMatchFixture.create(
+                    requesterId = viewer.id,
+                    receiverId = target.id,
+                    status = PersonalMatchStatus.ACCEPTED,
+                ),
+            )
+            memberBlockRepository.save(MemberBlock.create(viewer.id, target.id))
+
+            val exception = shouldThrow<WarnException> {
+                userService.getPublicProfile(viewer.id, target.id)
+            }
+            exception.errorCode shouldBe ErrorCode.FORBIDDEN
+        }
+
+        "상대가 나를 차단한 경우에도 조회할 수 없다 (방향 무관)" {
+            val viewer = saveMember("차단당한조회자")
+            val target = saveMember("차단한대상")
+            personalMatchRepository.save(
+                PersonalMatchFixture.create(
+                    requesterId = viewer.id,
+                    receiverId = target.id,
+                    status = PersonalMatchStatus.ACCEPTED,
+                ),
+            )
+            // 차단 방향이 반대다 — target이 viewer를 차단했다.
+            memberBlockRepository.save(MemberBlock.create(target.id, viewer.id))
+
+            shouldThrow<WarnException> {
+                userService.getPublicProfile(viewer.id, target.id)
+            }
+        }
+
+        "차단이 없으면 매칭 성사 상대의 프로필을 조회할 수 있다" {
+            val viewer = saveMember("정상조회자")
+            val target = saveMember("정상대상")
+            personalMatchRepository.save(
+                PersonalMatchFixture.create(
+                    requesterId = viewer.id,
+                    receiverId = target.id,
+                    status = PersonalMatchStatus.ACCEPTED,
+                ),
+            )
+
+            val result = userService.getPublicProfile(viewer.id, target.id)
+            result.userId shouldBe target.id
+        }
+    }
+
+    "신고와 함께 차단할 수 있다" - {
+        "block=true면 신고 접수와 같은 트랜잭션에서 차단이 생성된다" {
+            val reporter = saveMember("신고차단자")
+            val reported = saveMember("신고차단대상")
+
+            userReportService.submitReport(
+                reporterId = reporter.id,
+                request = CreateUserReportRequest(
+                    reportedMemberId = reported.id,
+                    reason = "inappropriate-behavior",
+                    source = "chat-room",
+                    detail = "폭언을 반복했습니다.",
+                    block = true,
+                ),
+            )
+
+            memberBlockRepository.existsByBlockerIdAndBlockedMemberId(reporter.id, reported.id) shouldBe true
+        }
+
+        "block을 생략하면 차단하지 않는다 — 자동 차단이 아니다" {
+            val reporter = saveMember("신고만한자")
+            val reported = saveMember("신고만당한대상")
+
+            userReportService.submitReport(
+                reporterId = reporter.id,
+                request = CreateUserReportRequest(
+                    reportedMemberId = reported.id,
+                    reason = "inappropriate-behavior",
+                    source = "profile",
+                    detail = "폭언을 반복했습니다.",
+                ),
+            )
+
+            memberBlockRepository.existsByBlockerIdAndBlockedMemberId(reporter.id, reported.id) shouldBe false
+        }
+    }
+
+    "차단 대상 검증" - {
+        "존재하지 않는 회원은 차단할 수 없다" {
+            val member = saveMember("없는사람차단시도")
+
+            val exception = shouldThrow<WarnException> {
+                memberBlockService.block(member.id, 999999L)
+            }
+            exception.errorCode shouldBe ErrorCode.NOT_FOUND
+        }
+
+        "차단하지 않은 상대를 해제해도 예외가 나지 않는다" {
+            val member = saveMember("해제멱등회원")
+            val other = saveMember("차단안된상대")
+
+            memberBlockService.unblock(member.id, other.id)
+
+            memberBlockRepository.findAllByBlockerIdOrderByCreatedAtDesc(member.id).size shouldBe 0
+        }
+    }
+
+    "차단은 1:1 매칭 후보에서 페어를 제외한다" - {
+        val processor = OneToOneMatchingProcessor()
+
+        fun participant(memberId: Long, blocked: Set<Long> = emptySet()) = MatchParticipant(
+            memberId = memberId,
+            answers = mapOf(1L to 1L, 2L to 1L),
+            gender = if (memberId % 2 == 0L) Gender.FEMALE else Gender.MALE,
+            age = 27,
+            blockedMemberIds = blocked,
+        )
+
+        "차단 관계인 두 명은 후보 페어가 되지 않는다" {
+            val duos = processor.match(
+                listOf(
+                    participant(1L, blocked = setOf(2L)),
+                    participant(2L, blocked = setOf(1L)),
+                ),
+            )
+
+            duos.size shouldBe 0
+        }
+
+        "한쪽만 차단 정보를 들고 있어도 페어가 깨진다" {
+            val duos = processor.match(
+                listOf(
+                    participant(1L, blocked = setOf(2L)),
+                    participant(2L),
+                ),
+            )
+
+            duos.size shouldBe 0
+        }
+
+        "차단이 없으면 페어가 만들어진다" {
+            val duos = processor.match(listOf(participant(1L), participant(2L)))
+
+            duos.size shouldBe 1
+        }
+    }
+})

--- a/api/src/test/kotlin/com/ditto/api/setting/SettingControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/setting/SettingControllerTest.kt
@@ -1,0 +1,286 @@
+package com.ditto.api.setting
+
+import com.ditto.api.setting.dto.CreateBlockRequest
+import com.ditto.api.setting.dto.UpdateNotificationSettingsRequest
+import com.ditto.api.support.RestDocsTest
+import com.ditto.domain.member.MemberFixture
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberBlock
+import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.member.repository.MemberBlockRepository
+import com.epages.restdocs.apispec.MockMvcRestDocumentationWrapper.document
+import com.epages.restdocs.apispec.ResourceDocumentation.parameterWithName
+import com.epages.restdocs.apispec.ResourceDocumentation.resource
+import com.epages.restdocs.apispec.ResourceSnippetParameters
+import org.junit.jupiter.api.DisplayName
+import org.junit.jupiter.api.Test
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.http.MediaType
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.delete
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.get
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.patch
+import org.springframework.restdocs.mockmvc.RestDocumentationRequestBuilders.post
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessRequest
+import org.springframework.restdocs.operation.preprocess.Preprocessors.preprocessResponse
+import org.springframework.restdocs.operation.preprocess.Preprocessors.prettyPrint
+import org.springframework.restdocs.payload.PayloadDocumentation.fieldWithPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
+import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
+
+class SettingControllerTest : RestDocsTest() {
+
+    @Autowired
+    private lateinit var memberBlockRepository: MemberBlockRepository
+
+    @Test
+    @DisplayName("알림 설정을 조회한다 — 저장한 적이 없으면 기본값을 준다")
+    fun getNotificationSettings() {
+        val member = saveMember("알림설정회원")
+
+        mockMvc.perform(
+            get("/api/v1/users/me/notification-settings")
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.matching").value(true))
+            .andExpect(jsonPath("$.data.chat").value(true))
+            .andExpect(jsonPath("$.data.marketing").value(false))
+            .andDo(
+                document(
+                    "notification-settings-get",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Settings")
+                            .summary("알림 설정 조회")
+                            .description(
+                                "설정 화면의 알림 토글 3종을 조회합니다. " +
+                                    "한 번도 저장하지 않은 회원은 기본값(매칭·채팅 수신, 마케팅 미수신)을 받습니다.",
+                            )
+                            .responseFields(*settingsResponseFields())
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("토글 하나만 보내면 그 항목만 바뀐다")
+    fun updateNotificationSettings() {
+        val member = saveMember("알림수정회원")
+        val request = UpdateNotificationSettingsRequest(chat = false)
+
+        mockMvc.perform(
+            patch("/api/v1/users/me/notification-settings")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.chat").value(false))
+            // 보내지 않은 항목은 기존 값(기본값) 그대로다.
+            .andExpect(jsonPath("$.data.matching").value(true))
+            .andExpect(jsonPath("$.data.marketing").value(false))
+            .andDo(
+                document(
+                    "notification-settings-update",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Settings")
+                            .summary("알림 설정 수정")
+                            .description("부분 패치입니다. 생략(null)한 항목은 변경하지 않습니다.")
+                            .requestFields(
+                                fieldWithPath("matching").description("매칭 알림 수신 여부. 생략 시 변경 없음").optional(),
+                                fieldWithPath("chat").description("채팅 알림 수신 여부. 생략 시 변경 없음").optional(),
+                                fieldWithPath("marketing").description("마케팅 정보 수신 여부. 생략 시 변경 없음").optional(),
+                            )
+                            .responseFields(*settingsResponseFields())
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("차단 목록을 최신순으로 조회한다")
+    fun getMyBlocks() {
+        val member = saveMember("차단한회원")
+        val older = saveMember("먼저차단된회원")
+        val newer = saveMember("나중차단된회원")
+        memberBlockRepository.save(MemberBlock.create(member.id, older.id))
+        memberBlockRepository.save(MemberBlock.create(member.id, newer.id))
+
+        mockMvc.perform(
+            get("/api/v1/users/me/blocks")
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.data.length()").value(2))
+            .andDo(
+                document(
+                    "blocks-get",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Settings")
+                            .summary("차단 목록 조회")
+                            .description(
+                                "내가 차단한 회원 목록을 최신순으로 조회합니다. 차단 사유는 노출하지 않습니다. " +
+                                    "id는 차단된 회원 ID이며, 해제 API의 경로 변수로 그대로 사용합니다.",
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data[].id").description("차단된 회원 ID"),
+                                fieldWithPath("data[].nickname").description("차단된 회원 닉네임"),
+                                fieldWithPath("data[].profileImageUrl").description("차단된 회원 캐리커쳐").optional(),
+                                fieldWithPath("data[].blockedAt").description("차단 일시"),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("회원을 차단한다 — 같은 상대를 다시 차단해도 성공한다")
+    fun block() {
+        val member = saveMember("차단요청회원")
+        val target = saveMember("차단대상회원")
+        val request = CreateBlockRequest(memberId = target.id)
+
+        repeat(2) {
+            mockMvc.perform(
+                post("/api/v1/users/me/blocks")
+                    .withApiKey()
+                    .withBearerToken(member.id)
+                    .contentType(MediaType.APPLICATION_JSON)
+                    .content(objectMapper.writeValueAsString(request)),
+            )
+                .andExpect(status().isOk)
+                .andExpect(jsonPath("$.success").value(true))
+        }
+
+        // 멱등 — 두 번 요청해도 행은 하나다.
+        memberBlockRepository.findAllByBlockerIdOrderByCreatedAtDesc(member.id).size.let { count ->
+            check(count == 1) { "차단 행이 $count 개 생성됐다" }
+        }
+
+        mockMvc.perform(
+            post("/api/v1/users/me/blocks")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(request)),
+        )
+            .andExpect(status().isOk)
+            .andDo(
+                document(
+                    "blocks-create",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Settings")
+                            .summary("회원 차단")
+                            .description(
+                                "신고 없이 차단만 합니다. 이미 차단한 상대면 아무 일도 일어나지 않습니다(멱등). " +
+                                    "신고와 함께 차단하려면 POST /api/v1/user-reports 의 block 필드를 사용하세요. " +
+                                    "차단하면 상대는 내 프로필을 볼 수 없고, 서로 매칭 후보에서 제외됩니다.",
+                            )
+                            .requestFields(
+                                fieldWithPath("memberId").description("차단할 회원 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data").description("응답 본문 없음").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+    }
+
+    @Test
+    @DisplayName("자기 자신은 차단할 수 없다")
+    fun blockSelfRejected() {
+        val member = saveMember("자기차단회원")
+
+        mockMvc.perform(
+            post("/api/v1/users/me/blocks")
+                .withApiKey()
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(CreateBlockRequest(memberId = member.id))),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(false))
+    }
+
+    @Test
+    @DisplayName("차단을 해제한다")
+    fun unblock() {
+        val member = saveMember("해제요청회원")
+        val target = saveMember("해제대상회원")
+        memberBlockRepository.save(MemberBlock.create(member.id, target.id))
+
+        mockMvc.perform(
+            delete("/api/v1/users/me/blocks/{memberId}", target.id)
+                .withApiKey()
+                .withBearerToken(member.id),
+        )
+            .andExpect(status().isOk)
+            .andExpect(jsonPath("$.success").value(true))
+            .andDo(
+                document(
+                    "blocks-delete",
+                    preprocessRequest(prettyPrint()),
+                    preprocessResponse(prettyPrint()),
+                    resource(
+                        ResourceSnippetParameters.builder()
+                            .tag("Settings")
+                            .summary("차단 해제")
+                            .description("차단을 해제합니다. 차단하지 않은 상대를 해제해도 성공으로 응답합니다(멱등).")
+                            .pathParameters(
+                                parameterWithName("memberId").description("차단 해제할 회원 ID"),
+                            )
+                            .responseFields(
+                                fieldWithPath("success").description("성공 여부"),
+                                fieldWithPath("data").description("응답 본문 없음").optional(),
+                                fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+                            )
+                            .build(),
+                    ),
+                ),
+            )
+
+        check(memberBlockRepository.findAllByBlockerIdOrderByCreatedAtDesc(member.id).isEmpty()) {
+            "차단이 해제되지 않았다"
+        }
+    }
+
+    private fun saveMember(nickname: String): Member = memberRepository.save(
+        MemberFixture.create(
+            nickname = nickname,
+            email = "$nickname@example.com",
+            status = MemberStatus.ACTIVE,
+            caricature = "/assets/avatar/m1.png",
+        ),
+    )
+
+    private fun settingsResponseFields() = arrayOf(
+        fieldWithPath("success").description("성공 여부"),
+        fieldWithPath("data.matching").description("매칭 알림 수신 여부"),
+        fieldWithPath("data.chat").description("채팅 알림 수신 여부"),
+        fieldWithPath("data.marketing").description("마케팅 정보 수신 여부"),
+        fieldWithPath("error").description("에러 정보 (성공 시 null)"),
+    )
+}

--- a/api/src/test/kotlin/com/ditto/api/userreport/UserReportControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/userreport/UserReportControllerTest.kt
@@ -139,7 +139,8 @@ class UserReportControllerTest : RestDocsTest() {
                             .summary("신고 접수")
                             .description(
                                 "상대 회원을 신고합니다. 자기 신고·검토 대기 중인 동일 대상 재신고는 거부됩니다. " +
-                                    "이미지는 업로드 URL 발급 API로 업로드를 마친 objectKey를 전달합니다.",
+                                    "이미지는 업로드 URL 발급 API로 업로드를 마친 objectKey를 전달합니다. " +
+                                    "block을 true로 보내면 신고와 함께 해당 회원을 차단합니다.",
                             )
                             .requestFields(
                                 fieldWithPath("reportedMemberId").description("피신고자 회원 ID"),
@@ -147,6 +148,9 @@ class UserReportControllerTest : RestDocsTest() {
                                 fieldWithPath("source").description("신고 접수 위치 code. 가능한 값: $REPORT_SOURCE_CODES"),
                                 fieldWithPath("detail").description("상세 설명 (선택, 최대 500자 — etc 사유는 필수)").optional(),
                                 fieldWithPath("imageKeys").description("첨부 이미지 objectKey 목록 (선택, 최대 3개)").optional(),
+                                fieldWithPath("block")
+                                    .description("함께 차단할지 여부 (기본 false). 신고 화면의 '이 사용자 차단하기' 체크박스")
+                                    .optional(),
                             )
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),

--- a/domain/db/V20260803233050_설정 테이블 추가 (알림 설정·차단).sql
+++ b/domain/db/V20260803233050_설정 테이블 추가 (알림 설정·차단).sql
@@ -1,0 +1,35 @@
+-- 설정 화면(피그마 6.2)용 테이블 2종.
+-- member_notification_setting: 알림 토글 3종. member에 컬럼을 늘리지 않고 1:1 테이블로 뺀다
+--                              — 항목이 늘어날 여지가 크고, 회원 조회 경로마다 따라다닐 값이 아니다.
+--                              행이 없으면 기본값으로 간주하므로 가입 시 미리 만들지 않는다.
+-- member_block: 사용자 간 차단. 제재(sanction)와 무관하다 — 제재는 계정 전체에 대한 운영 조치이고
+--               차단은 (차단한 사람, 차단된 사람) 쌍에만 효력이 있으며 당사자가 언제든 해제한다.
+CREATE TABLE member_notification_setting
+(
+    id         BIGINT      NOT NULL AUTO_INCREMENT,
+    member_id  BIGINT      NOT NULL COMMENT '회원 ID',
+    matching   BOOLEAN     NOT NULL DEFAULT TRUE COMMENT '매칭 알림 수신 여부',
+    chat       BOOLEAN     NOT NULL DEFAULT TRUE COMMENT '채팅 알림 수신 여부',
+    marketing  BOOLEAN     NOT NULL DEFAULT FALSE COMMENT '마케팅 정보 수신 여부',
+    created_at DATETIME(6) NOT NULL,
+    updated_at DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    CONSTRAINT member_notification_setting_uk_1 UNIQUE (member_id)
+);
+
+CREATE TABLE member_block
+(
+    id                BIGINT      NOT NULL AUTO_INCREMENT,
+    blocker_id        BIGINT      NOT NULL COMMENT '차단한 회원 ID',
+    blocked_member_id BIGINT      NOT NULL COMMENT '차단된 회원 ID',
+    created_at        DATETIME(6) NOT NULL,
+    updated_at        DATETIME(6) NOT NULL,
+    PRIMARY KEY (id),
+    -- 같은 상대를 두 번 차단할 수 없다. 신고 시 차단이 재요청돼도 멱등하게 처리된다.
+    CONSTRAINT member_block_uk_1 UNIQUE (blocker_id, blocked_member_id)
+);
+
+-- 차단 목록 조회는 최신순이고, 매칭 후보 제외도 blocker 기준으로 읽는다.
+CREATE INDEX member_block_index_1 ON member_block (blocker_id, created_at);
+-- 상대가 나를 차단했는지(프로필 조회 차단) 판정하는 역방향 조회.
+CREATE INDEX member_block_index_2 ON member_block (blocked_member_id, blocker_id);

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberBlock.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberBlock.kt
@@ -1,0 +1,58 @@
+package com.ditto.domain.member.entity
+
+import com.ditto.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Index
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.Comment
+
+/**
+ * 사용자 간 차단. 차단 화면(피그마 6.2.2)의 문구가 곧 이 관계의 효력이다 —
+ * "차단한 사용자는 나의 프로필을 볼 수 없고, 매칭에서 제외돼요. 언제든지 해제할 수 있어요."
+ *
+ * **제재(`sanction`)와 다른 물건이다.** 제재는 운영자가 계정 전체에 내리는 조치이고 해제도 운영자만 한다.
+ * 차단은 [blockerId]와 [blockedMemberId] 쌍에만 효력이 있으며 당사자가 즉시 만들고 즉시 해제한다.
+ *
+ * 생성 경로는 신고 화면의 선택 체크박스("이 사용자 차단하기")와 직접 차단 API 두 가지다.
+ * 신고 여부와 무관하게 독립적으로 존재하며, 신고가 기각돼도 차단은 남는다(내 차단은 내 의사).
+ *
+ * 차단 사유는 받지 않는다 — 화면이 사유를 묻지도, 노출하지도 않는다.
+ */
+@Entity
+@Table(
+    name = "member_block",
+    uniqueConstraints = [
+        UniqueConstraint(name = "member_block_uk_1", columnNames = ["blocker_id", "blocked_member_id"]),
+    ],
+    indexes = [
+        Index(name = "member_block_index_1", columnList = "blocker_id, created_at"),
+        Index(name = "member_block_index_2", columnList = "blocked_member_id, blocker_id"),
+    ],
+)
+class MemberBlock private constructor(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Comment("차단한 회원 ID")
+    @Column(name = "blocker_id", nullable = false)
+    val blockerId: Long,
+
+    @Comment("차단된 회원 ID")
+    @Column(name = "blocked_member_id", nullable = false)
+    val blockedMemberId: Long,
+) : BaseEntity() {
+
+    companion object {
+        fun create(blockerId: Long, blockedMemberId: Long): MemberBlock = MemberBlock(
+            blockerId = blockerId,
+            blockedMemberId = blockedMemberId,
+        )
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberNotificationSetting.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberNotificationSetting.kt
@@ -1,0 +1,70 @@
+package com.ditto.domain.member.entity
+
+import com.ditto.domain.BaseEntity
+import jakarta.persistence.Column
+import jakarta.persistence.Entity
+import jakarta.persistence.GeneratedValue
+import jakarta.persistence.GenerationType
+import jakarta.persistence.Id
+import jakarta.persistence.Table
+import jakarta.persistence.UniqueConstraint
+import org.hibernate.annotations.Comment
+
+/**
+ * 설정 화면(피그마 6.2)의 알림 토글 3종.
+ *
+ * 행이 없으면 [defaultOf]가 주는 기본값으로 간주한다 — 가입 시 미리 만들지 않고,
+ * 회원이 토글을 처음 건드릴 때 생성된다. 그래서 조회는 항상 성공하며 404가 없다.
+ *
+ * 발송 인프라는 아직 없다. 이 값은 저장·조회만 되며, 발송이 붙을 때 게이트로 쓰인다.
+ */
+@Entity
+@Table(
+    name = "member_notification_setting",
+    uniqueConstraints = [
+        UniqueConstraint(name = "member_notification_setting_uk_1", columnNames = ["member_id"]),
+    ],
+)
+class MemberNotificationSetting(
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    val id: Long = 0L,
+
+    @Comment("회원 ID")
+    @Column(name = "member_id", nullable = false)
+    val memberId: Long,
+
+    @Comment("매칭 알림 수신 여부")
+    @Column(nullable = false)
+    var matching: Boolean = true,
+
+    @Comment("채팅 알림 수신 여부")
+    @Column(nullable = false)
+    var chat: Boolean = true,
+
+    @Comment("마케팅 정보 수신 여부")
+    @Column(nullable = false)
+    var marketing: Boolean = false,
+) : BaseEntity() {
+
+    /** 부분 패치 — null인 항목은 변경하지 않는다. */
+    fun update(matching: Boolean?, chat: Boolean?, marketing: Boolean?) {
+        if (matching != null) this.matching = matching
+        if (chat != null) this.chat = chat
+        if (marketing != null) this.marketing = marketing
+    }
+
+    companion object {
+        /**
+         * 미설정 회원의 기본값. 매칭·채팅은 서비스 이용에 필요한 알림이라 수신,
+         * 마케팅은 별도 동의 대상이라 미수신으로 둔다.
+         */
+        fun defaultOf(memberId: Long): MemberNotificationSetting = MemberNotificationSetting(
+            memberId = memberId,
+            matching = true,
+            chat = true,
+            marketing = false,
+        )
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberBlockRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberBlockRepository.kt
@@ -1,0 +1,15 @@
+package com.ditto.domain.member.repository
+
+import com.ditto.domain.member.entity.MemberBlock
+import com.ditto.domain.member.repository.querydsl.MemberBlockRepositoryCustom
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberBlockRepository : JpaRepository<MemberBlock, Long>, MemberBlockRepositoryCustom {
+
+    /** 내 차단 목록 — 화면이 최신순으로 노출한다. */
+    fun findAllByBlockerIdOrderByCreatedAtDesc(blockerId: Long): List<MemberBlock>
+
+    fun findByBlockerIdAndBlockedMemberId(blockerId: Long, blockedMemberId: Long): MemberBlock?
+
+    fun existsByBlockerIdAndBlockedMemberId(blockerId: Long, blockedMemberId: Long): Boolean
+}

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberNotificationSettingRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberNotificationSettingRepository.kt
@@ -1,0 +1,9 @@
+package com.ditto.domain.member.repository
+
+import com.ditto.domain.member.entity.MemberNotificationSetting
+import org.springframework.data.jpa.repository.JpaRepository
+
+interface MemberNotificationSettingRepository : JpaRepository<MemberNotificationSetting, Long> {
+
+    fun findByMemberId(memberId: Long): MemberNotificationSetting?
+}

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/querydsl/MemberBlockRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/querydsl/MemberBlockRepositoryCustom.kt
@@ -1,0 +1,19 @@
+package com.ditto.domain.member.repository.querydsl
+
+import com.ditto.domain.member.entity.MemberBlock
+
+/**
+ * 차단은 (차단한 사람 → 차단된 사람) 한 방향으로 저장되지만, 효력 판정은 **방향과 무관**하다.
+ * 그 "양방향" 조건이 메서드명 파생 쿼리로는 표현이 비대해져 여기로 뺐다.
+ */
+interface MemberBlockRepositoryCustom {
+
+    /** 두 회원 사이에 방향 무관하게 차단이 있는지 — 프로필 조회 차단·매칭 제외의 공통 판정. */
+    fun existsBetween(oneId: Long, otherId: Long): Boolean
+
+    /**
+     * 주어진 회원들이 관여한 차단 전체 — 매칭 후보 풀에 한 번에 싣기 위한 벌크 조회.
+     * 회원 수만큼 쿼리를 날리지 않도록 매칭 배치는 이 메서드를 쓴다.
+     */
+    fun findAllInvolving(memberIds: Collection<Long>): List<MemberBlock>
+}

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/querydsl/MemberBlockRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/querydsl/MemberBlockRepositoryImpl.kt
@@ -1,0 +1,33 @@
+package com.ditto.domain.member.repository.querydsl
+
+import com.ditto.domain.member.entity.MemberBlock
+import com.ditto.domain.member.entity.QMemberBlock.memberBlock
+import com.querydsl.jpa.impl.JPAQueryFactory
+import org.springframework.transaction.annotation.Transactional
+
+@Transactional(readOnly = true)
+class MemberBlockRepositoryImpl(
+    private val queryFactory: JPAQueryFactory,
+) : MemberBlockRepositoryCustom {
+
+    override fun existsBetween(oneId: Long, otherId: Long): Boolean =
+        queryFactory
+            .selectOne()
+            .from(memberBlock)
+            .where(
+                memberBlock.blockerId.eq(oneId).and(memberBlock.blockedMemberId.eq(otherId))
+                    .or(memberBlock.blockerId.eq(otherId).and(memberBlock.blockedMemberId.eq(oneId))),
+            )
+            .fetchFirst() != null
+
+    override fun findAllInvolving(memberIds: Collection<Long>): List<MemberBlock> {
+        if (memberIds.isEmpty()) return emptyList()
+        return queryFactory
+            .selectFrom(memberBlock)
+            .where(
+                memberBlock.blockerId.`in`(memberIds)
+                    .or(memberBlock.blockedMemberId.`in`(memberIds)),
+            )
+            .fetch()
+    }
+}

--- a/domain/src/main/kotlin/com/ditto/domain/memberreport/entity/MemberReportSource.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/memberreport/entity/MemberReportSource.kt
@@ -7,7 +7,7 @@ import com.ditto.common.exception.WarnException
  * 회원 신고 접수 위치 (FE 진입점).
  *
  * [code]는 FE/클라이언트와 주고받는 식별자 (kebab-case). API 계층에서 [from]으로 매핑한다.
- * 채팅 기능이 출시되면 CHAT_ROOM 값을 추가한다 (값 추가 전용).
+ * 값 추가 전용 — 이미 배포된 값의 이름·코드 변경·삭제는 금지한다.
  */
 enum class MemberReportSource(
     val code: String,
@@ -15,6 +15,7 @@ enum class MemberReportSource(
 ) {
     PROFILE("profile", "프로필 화면"),
     MATCH_RESULT("match-result", "매칭 결과 화면"),
+    CHAT_ROOM("chat-room", "채팅방"),
     ;
 
     companion object {

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberBlockTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberBlockTest.kt
@@ -1,0 +1,25 @@
+package com.ditto.domain.member.entity
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class MemberBlockTest : FreeSpec(
+    {
+        "create" - {
+            "차단한 사람과 차단된 사람을 방향 그대로 담는다" {
+                val block = MemberBlock.create(blockerId = 1L, blockedMemberId = 2L)
+
+                block.blockerId shouldBe 1L
+                block.blockedMemberId shouldBe 2L
+            }
+
+            "반대 방향은 별개 행이다 — 서로 차단하면 두 행이 된다" {
+                val forward = MemberBlock.create(blockerId = 1L, blockedMemberId = 2L)
+                val backward = MemberBlock.create(blockerId = 2L, blockedMemberId = 1L)
+
+                forward.blockerId shouldBe backward.blockedMemberId
+                forward.blockedMemberId shouldBe backward.blockerId
+            }
+        }
+    },
+)

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberNotificationSettingTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberNotificationSettingTest.kt
@@ -1,0 +1,51 @@
+package com.ditto.domain.member.entity
+
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.shouldBe
+
+class MemberNotificationSettingTest : FreeSpec(
+    {
+        "defaultOf" - {
+            "매칭·채팅은 수신, 마케팅은 미수신이 기본이다" {
+                val setting = MemberNotificationSetting.defaultOf(memberId = 1L)
+
+                setting.memberId shouldBe 1L
+                setting.matching shouldBe true
+                setting.chat shouldBe true
+                setting.marketing shouldBe false
+            }
+        }
+
+        "update" - {
+            "값이 온 항목만 바꾼다" {
+                val setting = MemberNotificationSetting.defaultOf(memberId = 1L)
+
+                setting.update(matching = null, chat = false, marketing = null)
+
+                setting.matching shouldBe true
+                setting.chat shouldBe false
+                setting.marketing shouldBe false
+            }
+
+            "세 항목을 한 번에 바꿀 수 있다" {
+                val setting = MemberNotificationSetting.defaultOf(memberId = 1L)
+
+                setting.update(matching = false, chat = false, marketing = true)
+
+                setting.matching shouldBe false
+                setting.chat shouldBe false
+                setting.marketing shouldBe true
+            }
+
+            "모두 null이면 아무것도 바뀌지 않는다" {
+                val setting = MemberNotificationSetting.defaultOf(memberId = 1L)
+
+                setting.update(matching = null, chat = null, marketing = null)
+
+                setting.matching shouldBe true
+                setting.chat shouldBe true
+                setting.marketing shouldBe false
+            }
+        }
+    },
+)


### PR DESCRIPTION
Closes #123

## 요약

설정 화면(`6.2 설정`·`6.2.2 차단 목록`)의 알림 토글과 사용자 차단을 추가했다. FE는 완성돼 있었고 MSW 목업으로만 동작하던 부분이다.

| 엔드포인트 | 설명 |
|---|---|
| `GET /api/v1/users/me/notification-settings` | 토글 3종 조회 |
| `PATCH /api/v1/users/me/notification-settings` | 부분 패치 (null = 변경 없음) |
| `GET /api/v1/users/me/blocks` | 차단 목록 (최신순, 사유 미노출) |
| `POST /api/v1/users/me/blocks` | 신고 없이 차단만 (멱등) |
| `DELETE /api/v1/users/me/blocks/{memberId}` | 차단 해제 (멱등) |
| `POST /api/v1/user-reports` | `block` 플래그 추가 |

## 차단은 제재와 별개 물건이다

`member_block`을 새로 뒀다. 기존 `sanction`으로 대체할 수 없기 때문이다.

| | 제재(sanction) | 차단(member_block) |
|---|---|---|
| 효력 시점 | 운영자 검토 후 | 즉시 |
| 범위 | 계정 전체 | (차단한 사람, 차단된 사람) 쌍 |
| 해제 | 운영자 직권만 | 당사자가 언제든 |

**생성 경로는 신고 화면 하단의 선택 체크박스**("이 사용자 차단하기 / 앞으로 이 사용자와 매칭되지 않습니다")다 — 자동 차단이 아니라 체크했을 때만 만든다. 신고가 기각돼도 차단은 남긴다(내 차단은 내 의사).

`POST /users/me/blocks`도 함께 뒀다. 중복 신고 가드가 `RECEIVED` 상태를 막기 때문에(`UserReportService.validateNotDuplicated`), 신고 시 체크를 안 했다면 검토가 끝날 때까지 차단할 방법이 없어진다.

## 효과 집행

화면 문구가 곧 명세다 — "차단한 사용자는 나의 프로필을 볼 수 없고, 매칭에서 제외돼요."

- **프로필 조회**: `UserService.getPublicProfile`에서 차단 쌍이면 `FORBIDDEN`. **방향 무관** — 내가 차단했든 상대가 차단했든 막는다
- **1:1 매칭**: 차단은 회원을 풀에서 빼는 게 아니라 **그 페어만** 깨야 한다. 그래서 기존 제외 정책(`MatchExclusionPolicy`)이 아니라 `MatchParticipant.blockedMemberIds`에 실어 `isValidPair`에서 판정한다. 프로세서는 순수 컴포넌트로 유지되고, 차단 조회는 배치에서 1회 벌크로 끝낸다(`findAllInvolving`)

## 스키마

`member_notification_setting`, `member_block` 두 테이블 추가 (`domain/db/create_sql.sh`로 생성).

알림 설정은 `member` 컬럼을 늘리지 않고 1:1 테이블로 뺐다 — 항목이 늘어날 여지가 크고, 회원 조회 경로마다 따라다닐 값이 아니다. 가입 시 미리 만들지 않으며 행이 없으면 기본값(매칭·채팅 수신, 마케팅 미수신)으로 응답한다. 조회 트랜잭션에서 쓰기를 하지 않는다.

## 함께 고친 것

**`MemberReportSource.CHAT_ROOM` 추가.** FE는 이미 채팅 3곳(`ChatMenuBottomSheet`, `GroupChatMenuBottomSheet`, `GroupMemberMoreModal`)에서 신고를 띄우는데 서버 enum에 값이 없어 현재 400이 난다. enum 주석에 "채팅 기능이 출시되면 CHAT_ROOM 값을 추가한다"고 예고돼 있던 그 작업이다.

## 검증

- [x] `./gradlew build check` (전체 테스트 + Jacoco 게이트) 통과
- [x] REST Docs 6건 — 알림 조회/수정, 차단 목록/생성/해제, 자기 차단 거부
- [x] 차단 효력 통합 테스트 6건 — 프로필 조회 차단(양방향), 매칭 페어 제외
- [x] 기존 `UserReportControllerTest` 문서화 갱신 (`block` 필드)
- [ ] Sonar New Code 게이트는 PR 체크 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)
