### PR TITLE
[#124] feat. 탈퇴 소프트 삭제 — 사유 수집·진행중 가드·30일 복구·삭제 배치

### DIFF
--- a/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/AuthService.kt
@@ -54,6 +54,9 @@ class AuthService(
         // 제재 회원의 재발급 우회 봉쇄 — refresh 경로는 JWT 필터를 지나지 않는다.
         // 예외 시 트랜잭션 롤백으로 위 회전 삭제도 되돌아가 토큰은 남지만, 남아 있어도 이 게이트가 사용을 계속 거부한다.
         // (세션 전량 회수는 제재 적용 트랜잭션의 몫)
+        if (member.isLeft()) {
+            throw WarnException(ErrorCode.MEMBER_LEFT)
+        }
         if (member.isBanned()) {
             throw WarnException(ErrorCode.MEMBER_BANNED)
         }

--- a/api/src/main/kotlin/com/ditto/api/auth/service/MemberSocialAccountService.kt
+++ b/api/src/main/kotlin/com/ditto/api/auth/service/MemberSocialAccountService.kt
@@ -13,11 +13,13 @@ import io.github.oshai.kotlinlogging.KotlinLogging
 import org.springframework.stereotype.Service
 import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
+import org.springframework.beans.factory.annotation.Value
 
 @Service
 class MemberSocialAccountService(
     private val memberRepository: MemberRepository,
     private val socialAccountRepository: SocialAccountRepository,
+    @Value("\${ditto.member.purge.retention-days:30}") private val retentionDays: Long,
 ) {
     @Transactional
     fun findOrCreateMember(
@@ -43,6 +45,7 @@ class MemberSocialAccountService(
                 member.updateEmail(email)
             }
             member.updateOAuthInfo(name = name, phoneNumber = phoneNumber, gender = gender)
+            restoreIfWithinRetention(member)
             return member
         }
 
@@ -64,6 +67,23 @@ class MemberSocialAccountService(
             ),
         )
         return newMember
+    }
+
+    /**
+     * 탈퇴한 회원이 보존 기간 안에 재가입하면 계정을 복구한다 —
+     * "탈퇴 후 30일 이내 재가입하면 계정을 복구할 수 있습니다"(피그마 6.2.4).
+     *
+     * 보존 기간이 지났는데 삭제 배치가 아직 돌지 않아 행이 남아 있는 경우는 복구하지 않는다.
+     * 이때는 LEFT 상태가 유지되므로 인증 게이트가 막고, 배치가 정리한 뒤 새 회원으로 가입하게 된다.
+     */
+    private fun restoreIfWithinRetention(member: Member) {
+        if (!member.isLeft()) return
+        if (member.isRetentionExpiredAt(LocalDateTime.now(), retentionDays)) {
+            log.info { "보존 기간이 지난 탈퇴 회원(id=${member.id})의 재로그인 — 복구하지 않는다" }
+            return
+        }
+        log.info { "탈퇴 회원(id=${member.id}) 복구 (leftAt=${member.leftAt})" }
+        member.restore()
     }
 
     /**

--- a/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
+++ b/api/src/main/kotlin/com/ditto/api/config/auth/JwtAuthenticationFilter.kt
@@ -46,6 +46,12 @@ class JwtAuthenticationFilter(
             return
         }
 
+        // 탈퇴 회원은 어떤 보호 API도 쓸 수 없다. 재가입(소셜 로그인)만이 복구 경로다.
+        if (member.isLeft()) {
+            sendError(response, ErrorCode.MEMBER_LEFT)
+            return
+        }
+
         // 제재 회원은 안내 창구(suspendedAllowedPaths) 외 전면 차단한다.
         // 해제 예정일이 지난 정지는 통과만 시킨다 — 필터는 읽기 전용, status 원복은 배치·로그인이 (ADR 0009).
         if (request.requestURI !in suspendedAllowedPaths) {

--- a/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/controller/UserController.kt
@@ -3,6 +3,7 @@ package com.ditto.api.user.controller
 import com.ditto.api.config.auth.MemberPrincipal
 import com.ditto.api.user.dto.CheckNicknameResponse
 import com.ditto.api.user.dto.CreateUserRequest
+import com.ditto.api.user.dto.LeaveRequest
 import com.ditto.api.user.dto.LeaveResponse
 import com.ditto.api.user.dto.MeResponse
 import com.ditto.api.user.dto.PublicProfileResponse
@@ -55,9 +56,10 @@ class UserController(
     @PostMapping("/api/v1/users/{id}/leave")
     fun leaveUser(
         @PathVariable id: Long,
+        @Valid @RequestBody(required = false) request: LeaveRequest?,
         @AuthenticationPrincipal principal: MemberPrincipal,
     ): ApiResponse<LeaveResponse> {
-        val result = userService.leaveUser(id, principal.memberId)
+        val result = userService.leaveUser(id, principal.memberId, request ?: LeaveRequest())
         return ApiResponse.ok(result)
     }
 }

--- a/api/src/main/kotlin/com/ditto/api/user/dto/LeaveRequest.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/dto/LeaveRequest.kt
@@ -1,0 +1,12 @@
+package com.ditto.api.user.dto
+
+import jakarta.validation.constraints.Size
+
+/**
+ * 탈퇴 요청. 탈퇴 화면(피그마 6.2.4) 2단계에서 사유를 고르지 않으면 제출 버튼이 비활성이므로
+ * 클라이언트는 항상 [reason]을 보낸다. 다만 사유 없는 탈퇴를 서버가 막을 이유는 없어 optional로 둔다.
+ */
+data class LeaveRequest(
+    @field:Size(max = 50)
+    val reason: String? = null,
+)

--- a/api/src/main/kotlin/com/ditto/api/user/service/LeaveProgressChecker.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/LeaveProgressChecker.kt
@@ -1,0 +1,32 @@
+package com.ditto.api.user.service
+
+import com.ditto.domain.chat.repository.ChatRoomRepository
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import org.springframework.stereotype.Component
+
+/**
+ * "진행 중인 매칭이나 채팅이 있으면 탈퇴가 제한됩니다"(피그마 6.2.4)를 판정한다.
+ *
+ * 매칭은 PENDING·ACCEPTED를 진행 중으로 본다 — 수락 대기 중인 요청도 상대가 기다리는 상태다.
+ *
+ * 채팅은 **아직 끝나지 않은 방(SCHEDULED·ACTIVE)** 이 있으면 진행 중으로 본다.
+ * SCHEDULED(개방 예정, 재매칭 방)도 포함한다 — 상대가 곧 열릴 방을 기다리는 상태다.
+ */
+@Component
+class LeaveProgressChecker(
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val chatRoomRepository: ChatRoomRepository,
+) {
+
+    fun hasInProgress(memberId: Long): Boolean =
+        personalMatchRepository.existsByMemberIdAndStatusIn(memberId, ONGOING_MATCH_STATUSES) ||
+            chatRoomRepository.existsUnendedRoomOfMember(memberId)
+
+    companion object {
+        private val ONGOING_MATCH_STATUSES = setOf(
+            PersonalMatchStatus.PENDING,
+            PersonalMatchStatus.ACCEPTED,
+        )
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/user/service/LeftMemberPurgeService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/LeftMemberPurgeService.kt
@@ -1,0 +1,68 @@
+package com.ditto.api.user.service
+
+import com.ditto.api.system.ServerTimeProvider
+import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
+import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import io.github.oshai.kotlinlogging.KotlinLogging
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import org.springframework.transaction.annotation.Transactional
+
+private val log = KotlinLogging.logger {}
+
+/**
+ * 탈퇴 후 보존 기간이 지난 회원을 완전 삭제한다 — "30일이 지나면 모든 데이터가 완전히 삭제됩니다".
+ *
+ * **되돌릴 수 없는 삭제**라서 안전장치를 셋 둔다.
+ * 1. [dryRun]이 참이면 대상만 로그로 남기고 삭제하지 않는다(기본값 — 운영 투입 전 관찰용).
+ * 2. [batchLimit]으로 한 번에 지우는 건수를 제한한다(사고 시 피해 범위 제한).
+ * 3. 삭제 대상 ID·탈퇴 일시를 항상 로그로 남긴다(사후 추적).
+ */
+@Service
+class LeftMemberPurgeService(
+    private val memberRepository: MemberRepository,
+    private val socialAccountRepository: SocialAccountRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val serverTimeProvider: ServerTimeProvider,
+    @Value("\${ditto.member.purge.dry-run:true}") private val dryRun: Boolean,
+    @Value("\${ditto.member.purge.batch-limit:100}") private val batchLimit: Int,
+    @Value("\${ditto.member.purge.retention-days:30}") private val retentionDays: Long,
+) {
+
+    /** 매일 04:00에 실행한다 — 트래픽이 가장 낮은 시간대다. */
+    @Scheduled(cron = "0 0 4 * * *")
+    fun purgeExpired() {
+        purge()
+    }
+
+    @Transactional
+    fun purge(): Int {
+        val now = serverTimeProvider.now()
+        val expired = memberRepository
+            .findAllByStatusAndLeftAtLessThanEqual(MemberStatus.LEFT, now.minusDays(retentionDays))
+            .take(batchLimit)
+
+        if (expired.isEmpty()) {
+            return 0
+        }
+
+        log.info {
+            "탈퇴 보존 기간 경과 회원 ${expired.size}명 (dryRun=$dryRun, retentionDays=$retentionDays): " +
+                expired.joinToString { "id=${it.id}(leftAt=${it.leftAt})" }
+        }
+        if (dryRun) {
+            return 0
+        }
+
+        expired.forEach { member ->
+            refreshTokenRepository.deleteAllByMemberId(member.id)
+            socialAccountRepository.findByMemberId(member.id)?.let { socialAccountRepository.delete(it) }
+            memberRepository.delete(member)
+        }
+        log.info { "탈퇴 회원 ${expired.size}명 완전 삭제 완료" }
+        return expired.size
+    }
+}

--- a/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
+++ b/api/src/main/kotlin/com/ditto/api/user/service/UserService.kt
@@ -4,6 +4,7 @@ import com.ditto.api.match.MatchAccessChecker
 import com.ditto.api.system.ServerTimeProvider
 import com.ditto.api.user.dto.CheckNicknameResponse
 import com.ditto.api.user.dto.CreateUserRequest
+import com.ditto.api.user.dto.LeaveRequest
 import com.ditto.api.user.dto.LeaveResponse
 import com.ditto.api.user.dto.MeResponse
 import com.ditto.api.user.dto.PublicProfileResponse
@@ -33,6 +34,7 @@ class UserService(
     private val socialAccountRepository: SocialAccountRepository,
     private val refreshTokenRepository: RefreshTokenRepository,
     private val serverTimeProvider: ServerTimeProvider,
+    private val leaveProgressChecker: LeaveProgressChecker,
 ) {
 
     @Transactional
@@ -116,8 +118,16 @@ class UserService(
         return CheckNicknameResponse(available = true)
     }
 
+    /**
+     * 탈퇴(소프트 삭제). 데이터를 지우지 않고 상태만 LEFT로 바꾼다 —
+     * 화면이 "30일 이내 재가입하면 계정을 복구할 수 있습니다"를 안내하므로 즉시 삭제할 수 없다.
+     * 실제 삭제는 [LeftMemberPurgeService]가 보존 기간 경과 후 수행한다.
+     *
+     * 제재 중 탈퇴를 더는 막지 않는다 — hard delete 시절에는 제재 이력과 재가입 식별 근거가
+     * 함께 사라져 차단 우회 수단이 됐지만, 소프트 삭제는 둘을 모두 보존한다.
+     */
     @Transactional
-    fun leaveUser(id: Long, memberId: Long): LeaveResponse {
+    fun leaveUser(id: Long, memberId: Long, request: LeaveRequest): LeaveResponse {
         val member = memberRepository.findById(id).orElseThrow {
             WarnException(ErrorCode.NOT_FOUND)
         }
@@ -126,18 +136,16 @@ class UserService(
             throw WarnException(ErrorCode.FORBIDDEN)
         }
 
-        // 제재 중 탈퇴를 거부한다 — hard delete가 제재 이력·재가입 차단 근거(SocialAccount)를 지워
-        // 차단 우회 수단이 되는 것을 막는다. 탈퇴 부분 보존 전환(후속) 시 이 가드는 제거한다.
-        if (member.isBanned() || member.isSuspendedAt(serverTimeProvider.now())) {
-            throw WarnException(ErrorCode.CANNOT_LEAVE_WHILE_SANCTIONED)
+        // "진행 중인 매칭이나 채팅이 있으면 탈퇴가 제한됩니다" — 상대가 기다리는 상태를 남기지 않는다.
+        if (leaveProgressChecker.hasInProgress(id)) {
+            throw WarnException(ErrorCode.CANNOT_LEAVE_WHILE_IN_PROGRESS)
         }
 
-        val response = member.toLeaveResponse()
+        member.leave(reason = request.reason, now = serverTimeProvider.now())
 
+        // 세션은 즉시 끊는다. SocialAccount는 복구·재가입 식별 근거이므로 남긴다.
         refreshTokenRepository.deleteAllByMemberId(id)
-        socialAccountRepository.findByMemberId(id)?.let { socialAccountRepository.delete(it) }
-        memberRepository.delete(member)
 
-        return response
+        return member.toLeaveResponse()
     }
 }

--- a/api/src/main/resources/static/docs/openapi.yaml
+++ b/api/src/main/resources/static/docs/openapi.yaml
@@ -94,7 +94,7 @@ paths:
                     "reason" : "inappropriate-behavior",
                     "source" : "profile",
                     "detail" : "대화 중 폭언을 반복했습니다.",
-                    "imageKeys" : [ "pending/user-reports/1/f0bd55ad-43d3-42a1-a637-04732e3b2654" ]
+                    "imageKeys" : [ "pending/user-reports/1/8ad984e5-7603-49ed-94f3-adacccaa200e" ]
                   }
       responses:
         "200":
@@ -168,10 +168,10 @@ paths:
                         "location" : "seoul",
                         "job" : "it-tech",
                         "caricature" : "m1",
-                        "joinedAt" : "2026-08-04 00:43:16",
+                        "joinedAt" : "2026-08-04 11:30:18",
                         "role" : null,
-                        "createdAt" : "2026-08-04 00:43:16",
-                        "updatedAt" : "2026-08-04 00:43:16"
+                        "createdAt" : "2026-08-04 11:30:18",
+                        "updatedAt" : "2026-08-04 11:30:18"
                       },
                       "error" : null
                     }
@@ -223,18 +223,50 @@ paths:
     get:
       tags:
       - Matching
-      summary: 1:1 매칭 추천 후보 목록 조회
-      description: "회원이 최근 완료한 1:1 퀴즈셋의 추천 후보를 매칭 점수 내림차순으로 조회합니다. 대상 퀴즈셋은 서버가 결정하\
-        며, 응답의 quizSetId 로 확인합니다."
-      operationId: match-candidate-list
+      summary: 1:1 매칭 요청 목록 조회
+      description: 퀴즈셋에 대한 내가 보낸/받은 1:1 매칭 요청 목록을 조회합니다.
+      operationId: match-candidate-listpersonal-match-list
+      parameters:
+      - name: quizSetId
+        in: query
+        description: 퀴즈 세트 ID
+        required: true
+        schema:
+          type: string
       responses:
         "200":
           description: "200"
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/api-v1-matches-1on1-1115011008"
+                $ref: "#/components/schemas/api-v1-matches-1on1-1796185400"
               examples:
+                personal-match-list:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "sent" : [ {
+                          "id" : 1,
+                          "quizSetId" : 10,
+                          "requesterId" : 1,
+                          "receiverId" : 2,
+                          "status" : "PENDING",
+                          "createdAt" : "2026-05-01 12:00:00",
+                          "respondedAt" : null
+                        } ],
+                        "received" : [ {
+                          "id" : 2,
+                          "quizSetId" : 10,
+                          "requesterId" : 3,
+                          "receiverId" : 1,
+                          "status" : "PENDING",
+                          "createdAt" : "2026-05-01 12:00:00",
+                          "respondedAt" : null
+                        } ]
+                      },
+                      "error" : null
+                    }
                 match-candidate-list:
                   value: |-
                     {
@@ -422,8 +454,8 @@ paths:
                           "category" : "성격",
                           "title" : "이번 주 1:1 매칭",
                           "description" : "테스트 퀴즈 세트 설명",
-                          "startDate" : "2026-08-03 00:43:16",
-                          "endDate" : "2026-08-05 00:43:16",
+                          "startDate" : "2026-08-03 11:30:18",
+                          "endDate" : "2026-08-05 11:30:18",
                           "isActive" : true,
                           "matchingType" : "ONE_TO_ONE",
                           "quizzes" : [ {
@@ -440,8 +472,8 @@ paths:
                               "order" : 2
                             } ],
                             "order" : 1,
-                            "createdAt" : "2026-08-04 00:43:16",
-                            "updatedAt" : "2026-08-04 00:43:16"
+                            "createdAt" : "2026-08-04 11:30:18",
+                            "updatedAt" : "2026-08-04 11:30:18"
                           } ]
                         } ]
                       },
@@ -488,8 +520,8 @@ paths:
                         "endDate" : "2026-04-12 23:59:59",
                         "isActive" : true,
                         "matchingType" : "ONE_TO_ONE",
-                        "createdAt" : "2026-08-04 00:43:16",
-                        "updatedAt" : "2026-08-04 00:43:16"
+                        "createdAt" : "2026-08-04 11:30:18",
+                        "updatedAt" : "2026-08-04 11:30:18"
                       },
                       "error" : null
                     }
@@ -566,11 +598,11 @@ paths:
                       "success" : true,
                       "data" : {
                         "uploads" : [ {
-                          "objectKey" : "pending/user-reports/1/28126161-b635-4df5-aa66-b73006723647",
-                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/28126161-b635-4df5-aa66-b73006723647"
+                          "objectKey" : "pending/user-reports/1/6652e3e9-a628-4996-a9e1-9d099ee7ff80",
+                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/6652e3e9-a628-4996-a9e1-9d099ee7ff80"
                         }, {
-                          "objectKey" : "pending/user-reports/1/f982028d-ea2d-48fe-b1e3-2f4063dc456f",
-                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/f982028d-ea2d-48fe-b1e3-2f4063dc456f"
+                          "objectKey" : "pending/user-reports/1/c1b96e5f-8f77-40bd-92be-808b8faca8df",
+                          "uploadUrl" : "https://fake-storage.local/pending/user-reports/1/c1b96e5f-8f77-40bd-92be-808b8faca8df"
                         } ]
                       },
                       "error" : null
@@ -853,10 +885,81 @@ paths:
                     {
                       "success" : true,
                       "data" : {
-                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODU3NzE3OTIsImV4cCI6MTc4NTc3NTM5Mn0.xVB1yJVQq9SXL5r_EGrf2gIH7f3LqWBb_TpO6YY8pKQMiSW1g-P4Mzj0Z696zCt9tXXWnEWUXqSPK59qzBcpVw"
+                        "accessToken" : "eyJhbGciOiJIUzUxMiJ9.eyJzdWIiOiIxIiwicm9sZSI6IlVTRVIiLCJpYXQiOjE3ODU4MTA2MTUsImV4cCI6MTc4NTgxNDIxNX0.sC5_X9wl-nGre52u5Y0uEmG0XUnFPHmCjtfP4SPgVJ6A4dNC8vcxZt-WHaytVXBhSNtaIPV8Y7gIeiRmSdjTJw"
                       },
                       "error" : null
                     }
+  /api/v1/users/me/blocks:
+    get:
+      tags:
+      - Settings
+      summary: 차단 목록 조회
+      description: "내가 차단한 회원 목록을 최신순으로 조회합니다. 차단 사유는 노출하지 않습니다. id는 차단된 회원 ID이며,\
+        \ 해제 API의 경로 변수로 그대로 사용합니다."
+      operationId: blocks-get
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-blocks617562959"
+              examples:
+                blocks-get:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : [ {
+                        "id" : 3,
+                        "nickname" : "나중차단된회원",
+                        "profileImageUrl" : "/assets/avatar/m1.png",
+                        "blockedAt" : "2026-08-04 11:26:49"
+                      }, {
+                        "id" : 2,
+                        "nickname" : "먼저차단된회원",
+                        "profileImageUrl" : "/assets/avatar/m1.png",
+                        "blockedAt" : "2026-08-04 11:26:49"
+                      } ],
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+    post:
+      tags:
+      - Settings
+      summary: 회원 차단
+      description: "신고 없이 차단만 합니다. 이미 차단한 상대면 아무 일도 일어나지 않습니다(멱등). 신고와 함께 차단하려면 POST\
+        \ /api/v1/user-reports 의 block 필드를 사용하세요. 차단하면 상대는 내 프로필을 볼 수 없고, 서로 매칭 후보\
+        에서 제외됩니다."
+      operationId: blocks-create
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/api-v1-users-me-blocks1689110600"
+            examples:
+              blocks-create:
+                value: |-
+                  {
+                    "memberId" : 2
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-blocks-918175200"
+              examples:
+                blocks-create:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : { },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
   /api/v1/users/me/intro-notes:
     get:
       tags:
@@ -924,6 +1027,203 @@ paths:
                     }
       security:
       - bearerAuthJWT: []
+  /api/v1/users/me/notification-settings:
+    get:
+      tags:
+      - Settings
+      summary: 알림 설정 조회
+      description: "설정 화면의 알림 토글 3종을 조회합니다. 한 번도 저장하지 않은 회원은 기본값(매칭·채팅 수신, 마케팅 미수신\
+        )을 받습니다."
+      operationId: notification-settings-get
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-notification-settings1737408490"
+              examples:
+                notification-settings-get:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "matching" : true,
+                        "chat" : true,
+                        "marketing" : false
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+    patch:
+      tags:
+      - Settings
+      summary: 알림 설정 수정
+      description: 부분 패치입니다. 생략(null)한 항목은 변경하지 않습니다.
+      operationId: notification-settings-update
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/api-v1-users-me-notification-settings899749817"
+            examples:
+              notification-settings-update:
+                value: |-
+                  {
+                    "matching" : null,
+                    "chat" : false,
+                    "marketing" : null
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-notification-settings1737408490"
+              examples:
+                notification-settings-update:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "matching" : true,
+                        "chat" : false,
+                        "marketing" : false
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/users/me/profile:
+    get:
+      tags:
+      - Users
+      summary: 내 프로필 조회
+      description: "내 프로필을 조회합니다. 응답 형태는 타인 공개 프로필(GET /api/v1/users/{id}/profile)과\
+        \ 같습니다. introduction은 소개노트 'one-word' 답변이며, 미작성이면 null입니다."
+      operationId: my-profile-get
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-profile1973775834"
+              examples:
+                my-profile-get:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "userId" : 1,
+                        "nickname" : "개굴개굴렌",
+                        "gender" : "MALE",
+                        "age" : 27,
+                        "introduction" : "주말마다 한강 산책하는 걸 좋아해요!",
+                        "profileImageUrl" : "/assets/avatar/m1.png",
+                        "location" : "seoul",
+                        "occupation" : "it-tech",
+                        "interests" : [ "workout" ],
+                        "rating" : null,
+                        "preferredMinAge" : null,
+                        "preferredMaxAge" : null
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+    patch:
+      tags:
+      - Users
+      summary: 내 프로필 수정
+      description: 프로필 수정 화면에서 편집 가능한 항목만 수정합니다 — 캐리커쳐·관심사·한 줄 소개. 닉네임·성별·나이·사는곳·직업은
+        수정할 수 없습니다. 생략(null)한 항목은 변경하지 않습니다. 한 줄 소개는 소개노트 'one-word' 답변으로 저장됩니다.
+      operationId: my-profile-update
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/api-v1-users-me-profile-47273855"
+            examples:
+              my-profile-update:
+                value: |-
+                  {
+                    "introduction" : "주말마다 한강 산책하는 걸 좋아해요!",
+                    "profileImageUrl" : "/assets/avatar/m3.png",
+                    "interests" : [ "workout", "movie-drama", "exhibition" ]
+                  }
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-profile1973775834"
+              examples:
+                my-profile-update:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "userId" : 1,
+                        "nickname" : "개굴개굴렌",
+                        "gender" : "MALE",
+                        "age" : 27,
+                        "introduction" : "주말마다 한강 산책하는 걸 좋아해요!",
+                        "profileImageUrl" : "/assets/avatar/m3.png",
+                        "location" : "seoul",
+                        "occupation" : "it-tech",
+                        "interests" : [ "exhibition", "workout", "movie-drama" ],
+                        "rating" : null,
+                        "preferredMinAge" : null,
+                        "preferredMaxAge" : null
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/users/me/ratings:
+    get:
+      tags:
+      - Users
+      summary: 받은 평가 조회
+      description: "내가 받은 평가 요약입니다. 총 평가가 publicThreshold(3)건 미만이면 비공개로, totalCount만\
+        \ 실제 값이고 평균·노쇼는 0, 코멘트는 빈 배열입니다. 별점 반올림과 코멘트 3개 노출은 클라이언트가 처리합니다."
+      operationId: my-profile-ratings
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-ratings-854326395"
+              examples:
+                my-profile-ratings:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "averageScore" : 4.0,
+                        "totalCount" : 3,
+                        "publicThreshold" : 3,
+                        "noShowCount" : 1,
+                        "ratings" : [ {
+                          "comment" : null,
+                          "createdAt" : "2026-08-04 11:07:27"
+                        }, {
+                          "comment" : "약속 시간 잘 지켜요",
+                          "createdAt" : "2026-08-04 11:07:27"
+                        }, {
+                          "comment" : "대화가 편하고 좋았어요",
+                          "createdAt" : "2026-08-04 11:07:27"
+                        } ]
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
   /api/v1/users/me/sanction:
     get:
       tags:
@@ -950,9 +1250,38 @@ paths:
                           "levelDescription" : "기간 이용 정지",
                           "reason" : null,
                           "reasonDescription" : null,
-                          "startsAt" : "2026-07-28 00:43:16",
-                          "endsAt" : "2026-08-11 00:43:16"
+                          "startsAt" : "2026-07-28 11:30:18",
+                          "endsAt" : "2026-08-11 11:30:18"
                         }
+                      },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
+  /api/v1/users/me/stats:
+    get:
+      tags:
+      - Users
+      summary: 내 통계 조회
+      description: "내 프로필의 '내 통계' 카드용 지표입니다. 참여 주차는 완주한 퀴즈 수, 매칭 성사는 개설된 채팅방 수, 만남\
+        \ 횟수는 상대방 평가에서 '만났어요'를 받은 개수입니다."
+      operationId: my-profile-stats
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-stats-1745696923"
+              examples:
+                my-profile-stats:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : {
+                        "participationWeeks" : 2,
+                        "matchCount" : 1,
+                        "meetingCount" : 1
                       },
                       "error" : null
                     }
@@ -1054,7 +1383,8 @@ paths:
       tags:
       - Users
       summary: 회원 탈퇴
-      description: 회원을 탈퇴 처리합니다.
+      description: "회원을 탈퇴 처리합니다(소프트 삭제). 계정은 즉시 사용 불가가 되지만 데이터는 남으며, 30일 이내 같은 소셜\
+        \ 계정으로 재로그인하면 복구됩니다. 30일이 지나면 배치가 완전 삭제합니다. 진행 중인 매칭이나 채팅이 있으면 거부합니다."
       operationId: user-leave
       parameters:
       - name: id
@@ -1063,6 +1393,17 @@ paths:
         required: true
         schema:
           type: string
+      requestBody:
+        content:
+          application/json;charset=UTF-8:
+            schema:
+              $ref: "#/components/schemas/api-v1-users-id-leave1219645201"
+            examples:
+              user-leave:
+                value: |-
+                  {
+                    "reason" : "not-useful"
+                  }
       responses:
         "200":
           description: "200"
@@ -1086,8 +1427,8 @@ paths:
                         "birthDate" : null,
                         "joinedAt" : null,
                         "role" : null,
-                        "createdAt" : "2026-08-04 00:43:16",
-                        "updatedAt" : "2026-08-04 00:43:16"
+                        "createdAt" : "2026-08-04 11:30:18",
+                        "updatedAt" : "2026-08-04 11:30:18"
                       },
                       "error" : null
                     }
@@ -1452,6 +1793,37 @@ paths:
                       },
                       "error" : null
                     }
+  /api/v1/users/me/blocks/{memberId}:
+    delete:
+      tags:
+      - Settings
+      summary: 차단 해제
+      description: 차단을 해제합니다. 차단하지 않은 상대를 해제해도 성공으로 응답합니다(멱등).
+      operationId: blocks-delete
+      parameters:
+      - name: memberId
+        in: path
+        description: 차단 해제할 회원 ID
+        required: true
+        schema:
+          type: string
+      responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-me-blocks-918175200"
+              examples:
+                blocks-delete:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : { },
+                      "error" : null
+                    }
+      security:
+      - bearerAuthJWT: []
   /api/v1/users/me/intro-notes/{questionCode}:
     put:
       tags:
@@ -1578,8 +1950,7 @@ paths:
       tags:
       - OAuth
       summary: 소셜 로그인 콜백
-      description: "소셜 로그인 인가 코드를 받아 토큰을 발급한 뒤 프론트 콜백 페이지로 리다이렉트한다. accessToken과 회\
-        원가입 필요 여부(signupRequired)는 쿼리 파라미터로, refreshToken은 HttpOnly 쿠키로 전달된다."
+      description: 신규 사용자는 토큰을 발급하지 않습니다. 회원가입이 필요합니다.
       operationId: oauth-callback
       parameters:
       - name: provider
@@ -1595,6 +1966,20 @@ paths:
         schema:
           type: string
       responses:
+        "200":
+          description: "200"
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/api-v1-users-social-login-provider-callback-272682272"
+              examples:
+                oauth-callback-new-user:
+                  value: |-
+                    {
+                      "success" : true,
+                      "data" : { },
+                      "error" : null
+                    }
         "302":
           description: "302"
   /api/v1/admin/quiz-sets/{quizSetId}/matching/regenerate:
@@ -1628,6 +2013,947 @@ paths:
                     }
 components:
   schemas:
+    api-v1-users-me-blocks617562959:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            required:
+            - blockedAt
+            - id
+            - nickname
+            type: object
+            properties:
+              blockedAt:
+                type: string
+                description: 차단 일시
+              nickname:
+                type: string
+                description: 차단된 회원 닉네임
+              id:
+                type: number
+                description: 차단된 회원 ID
+              profileImageUrl:
+                type: string
+                description: 차단된 회원 캐리커쳐
+                nullable: true
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-member-reviews-reviewId-targets-memberId30922589:
+      required:
+      - meetingStatus
+      - rating
+      type: object
+      properties:
+        wantsOneToOneRematch:
+          type: boolean
+          description: 1:1 재매칭 의사. 그룹 평가에서만 필수이며 1:1 평가에는 보낼 수 없다
+          nullable: true
+        meetingStatus:
+          type: string
+          description: "만남 상태 (MET, APPOINTMENT_MADE, CHAT_ONLY, NO_SHOW)"
+        rating:
+          type: number
+          description: 별점 1~5 정수
+        comment:
+          type: string
+          description: "한줄 코멘트. 최대 50자, 공백만 보내면 미입력 처리"
+          nullable: true
+    api-v1-quiz-sets-current-week838676343:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - month
+          - week
+          - weekStartedOn
+          - year
+          type: object
+          properties:
+            week:
+              type: number
+              description: "주차 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
+            month:
+              type: number
+              description: "월 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
+            year:
+              type: number
+              description: "년도 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
+            weekStartedOn:
+              type: string
+              description: "운영 주 시작일 (해당 주 월요일, 주간 식별자)"
+            quizSets:
+              type: array
+              items:
+                required:
+                - category
+                - description
+                - endDate
+                - id
+                - isActive
+                - matchingType
+                - month
+                - startDate
+                - title
+                - week
+                - weekStartedOn
+                - year
+                type: object
+                properties:
+                  week:
+                    type: number
+                    description: "주차 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
+                  endDate:
+                    type: string
+                    description: 종료일시
+                  year:
+                    type: number
+                    description: "년도 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
+                  description:
+                    type: string
+                    description: 퀴즈 세트 설명
+                  isActive:
+                    type: boolean
+                    description: 활성화 여부
+                  title:
+                    type: string
+                    description: 퀴즈 세트 제목
+                  matchingType:
+                    type: string
+                    description: "매칭 타입 (ONE_TO_ONE, GROUP)"
+                  month:
+                    type: number
+                    description: "월 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
+                  weekStartedOn:
+                    type: string
+                    description: "운영 주 시작일 (해당 주 월요일, 주간 식별자)"
+                  quizzes:
+                    type: array
+                    items:
+                      required:
+                      - createdAt
+                      - id
+                      - order
+                      - question
+                      - quizSetId
+                      - updatedAt
+                      type: object
+                      properties:
+                        createdAt:
+                          type: string
+                          description: 생성일시
+                        question:
+                          type: string
+                          description: 퀴즈 질문
+                        quizSetId:
+                          type: number
+                          description: 퀴즈 세트 ID
+                        id:
+                          type: number
+                          description: 퀴즈 ID
+                        choices:
+                          type: array
+                          items:
+                            required:
+                            - content
+                            - id
+                            - order
+                            type: object
+                            properties:
+                              id:
+                                type: number
+                                description: 선택지 ID
+                              content:
+                                type: string
+                                description: 선택지 내용
+                              order:
+                                type: number
+                                description: 선택지 순서
+                        updatedAt:
+                          type: string
+                          description: 수정일시
+                        order:
+                          type: number
+                          description: 퀴즈 순서
+                  id:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  category:
+                    type: string
+                    description: 카테고리
+                  startDate:
+                    type: string
+                    description: 시작일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-chat-rooms-roomId-messages-1177664575:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: object
+          properties:
+            nextCursor:
+              type: number
+              description: 다음 페이지 커서 (더 없으면 null)
+              nullable: true
+            messages:
+              type: array
+              items:
+                required:
+                - content
+                - createdAt
+                - id
+                - messageType
+                - roomId
+                - senderId
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 메시지 생성일시
+                  senderId:
+                    type: number
+                    description: 보낸 회원 ID
+                  messageType:
+                    type: string
+                    description: "메시지 유형 (TEXT, IMAGE, SYSTEM)"
+                  id:
+                    type: number
+                    description: 메시지 ID
+                  content:
+                    type: string
+                    description: 메시지 내용 (IMAGE 는 S3 key)
+                  roomId:
+                    type: number
+                    description: 채팅방 ID
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-ratings-854326395:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - averageScore
+          - noShowCount
+          - publicThreshold
+          - ratings
+          - totalCount
+          type: object
+          properties:
+            ratings:
+              type: array
+              description: 평가 목록 최신순 (비공개 시 빈 배열)
+              items:
+                required:
+                - createdAt
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 평가 확정 일시
+                  comment:
+                    type: string
+                    description: 한줄 코멘트 (미입력이면 null)
+                    nullable: true
+            totalCount:
+              type: number
+              description: 받은 평가 총 건수
+            noShowCount:
+              type: number
+              description: 노쇼 평가를 받은 횟수 (비공개 시 0)
+            publicThreshold:
+              type: number
+              description: 공개 기준 건수 (3)
+            averageScore:
+              type: number
+              description: 평균 별점 (비공개 시 0)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-quiz-sets-id-1569645469:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - totalCount
+          type: object
+          properties:
+            quizzes:
+              type: array
+              items:
+                required:
+                - createdAt
+                - id
+                - order
+                - question
+                - quizSetId
+                - updatedAt
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 생성일시
+                  userAnswer:
+                    type: number
+                    description: 사용자가 선택한 choiceId (미답변 시 null)
+                    nullable: true
+                  question:
+                    type: string
+                    description: 퀴즈 질문
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 퀴즈 ID
+                  choices:
+                    type: array
+                    items:
+                      required:
+                      - content
+                      - id
+                      - order
+                      type: object
+                      properties:
+                        id:
+                          type: number
+                          description: 선택지 ID
+                        content:
+                          type: string
+                          description: 선택지 내용
+                        order:
+                          type: number
+                          description: 선택지 순서
+                  updatedAt:
+                    type: string
+                    description: 수정일시
+                  order:
+                    type: number
+                    description: 퀴즈 순서
+            totalCount:
+              type: number
+              description: 전체 퀴즈 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-stats-1745696923:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - matchCount
+          - meetingCount
+          - participationWeeks
+          type: object
+          properties:
+            matchCount:
+              type: number
+              description: 매칭 성사 (개설된 채팅방 수)
+            participationWeeks:
+              type: number
+              description: 참여 주차 (완주한 퀴즈 수)
+            meetingCount:
+              type: number
+              description: 만남 횟수 ('만났어요' 평가를 받은 개수)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-notification-settings899749817:
+      type: object
+      properties:
+        chat:
+          type: boolean
+          description: 채팅 알림 수신 여부. 생략 시 변경 없음
+          nullable: true
+    api-v1-chat-rooms1291226728:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: array
+          items:
+            required:
+            - counterpartMemberIds
+            - createdAt
+            - expiresAt
+            - isEnded
+            - opensAt
+            - roomId
+            - sourceType
+            - unreadCount
+            type: object
+            properties:
+              createdAt:
+                type: string
+                description: 채팅방 생성일시
+              sourceType:
+                type: string
+                description: "채팅방 유형 (PERSONAL, GROUP)"
+              lastMessage:
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 메시지 생성일시
+                    nullable: true
+                  senderId:
+                    type: number
+                    description: 보낸 회원 ID
+                    nullable: true
+                  messageType:
+                    type: string
+                    description: 메시지 유형
+                    nullable: true
+                  id:
+                    type: number
+                    description: 메시지 ID
+                    nullable: true
+                  content:
+                    type: string
+                    description: 메시지 내용 (IMAGE 는 S3 key)
+                    nullable: true
+                  roomId:
+                    type: number
+                    description: 채팅방 ID
+                    nullable: true
+                description: 마지막 메시지 (없으면 null)
+              opensAt:
+                type: string
+                description: 채팅 개방 시각 (금요일 00:00)
+              unreadCount:
+                type: number
+                description: 안읽음 수
+              isEnded:
+                type: boolean
+                description: 종료 여부. true 면 전송·구독이 막히고 조회만 가능
+              expiresAt:
+                type: string
+                description: 자동 종료 예정 시각 (월요일 00:00). 남은 시간 카운트다운 기준
+              counterpartMemberIds:
+                type: array
+                description: 나를 제외한 참여 회원 ID 목록 (1:1이면 1명)
+                items:
+                  oneOf:
+                  - type: object
+                  - type: boolean
+                  - type: string
+                  - type: number
+              roomId:
+                type: number
+                description: 채팅방 ID
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-intro-notes-questionCode-1298820809:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - completedCount
+          type: object
+          properties:
+            answers:
+              type: array
+              items:
+                required:
+                - answer
+                - question
+                - questionCode
+                type: object
+                properties:
+                  answer:
+                    type: string
+                    description: 답변 (미작성 시 빈 문자열)
+                  question:
+                    type: string
+                    description: 질문 문구
+                  questionCode:
+                    type: string
+                    description: "질문 code (가능한 값: travel-items(여행갈 때 꼭 챙겨야 하는 3가지는\
+                      ?), weekend-morning(주말 아침 10시, 나는 주로 뭐하고 있을까?), friends-say(친\
+                      구들이 나한테 제일 많이 하는 말은?), stress-relief(스트레스 받을 때 나만의 해소법은?), best-choice(최\
+                      근 1년 내 가장 잘한 선택은?), happiest-moment(나를 가장 행복하게 만드는 순간은?), most-used-apps(요\
+                      즘 내가 가장 많이 쓰는 앱 3개는?), favorite-time(하루 중 가장 좋아하는 시간대는? 그때 주\
+                      로 뭐해?), non-negotiable(내가 절대 양보 못하는 것은?), one-word(나를 한 단어로\
+                      \ 표현한다면?))"
+            completedCount:
+              type: number
+              description: 작성 완료된 답변 수
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-id-leave1219645201:
+      type: object
+      properties:
+        reason:
+          type: string
+          description: "탈퇴 사유 code (선택, 최대 50자)"
+          nullable: true
+    api-v1-users-auth-refresh1774976609:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - accessToken
+          type: object
+          properties:
+            accessToken:
+              type: string
+              description: 새 JWT 액세스 토큰
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-profile-47273855:
+      type: object
+      properties:
+        interests:
+          type: array
+          description: "관심사 code 1~5개. 생략 시 변경 없음. 가능한 값: workout, movie-drama, exhibition,\
+            \ performance, photography, reading, music, cooking, travel, gaming, finance,\
+            \ self-improvement, pets, etc"
+          nullable: true
+          items:
+            oneOf:
+            - type: object
+            - type: boolean
+            - type: string
+            - type: number
+        profileImageUrl:
+          type: string
+          description: 캐리커쳐 경로. 생략 시 변경 없음
+          nullable: true
+        introduction:
+          type: string
+          description: "한 줄 소개 (최대 50자, 공백만 입력 불가). 생략 시 변경 없음"
+          nullable: true
+    api-v1-matches-group-decline-789252668:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-current1012077415:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - participantCount
+          - status
+          type: object
+          properties:
+            answeredQuizzes:
+              type: number
+              description: 답변한 퀴즈 수
+              nullable: true
+            totalQuizzes:
+              type: number
+              description: 전체 퀴즈 수
+              nullable: true
+            quizSetId:
+              type: number
+              description: 참여 중인 퀴즈 세트 ID
+              nullable: true
+            participantCount:
+              type: number
+              description: 완료한 참여자 수
+            quizSetTitle:
+              type: string
+              description: 참여 중인 퀴즈 세트 제목
+              nullable: true
+            status:
+              type: string
+              description: "진행 상태 (NOT_STARTED, IN_PROGRESS, COMPLETED)"
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-chat-rooms-roomId-read-1623720830:
+      required:
+      - lastReadMessageId
+      type: object
+      properties:
+        lastReadMessageId:
+          type: number
+          description: 마지막으로 읽은 메시지 ID
+    api-v1-chat-rooms-roomId-read-1118618011:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: object
+          description: 응답 데이터 (없음)
+          nullable: true
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-matches-1on1-1796185400:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - algorithmVersion
+          - candidates
+          - matchingType
+          - quizSetId
+          - received
+          - sent
+          type: object
+          properties:
+            candidates:
+              type: array
+              description: 추천 후보 목록 (매칭 점수 내림차순)
+              items:
+                required:
+                - location
+                - matchRate
+                - nickname
+                - profileImageUrl
+                - scoreBreakdown
+                - userId
+                type: object
+                properties:
+                  scoreBreakdown:
+                    required:
+                    - matchedQuestions
+                    - quizMatchRate
+                    - reasons
+                    - totalQuestions
+                    type: object
+                    properties:
+                      totalQuestions:
+                        type: number
+                        description: 전체 비교 문항 수
+                      reasons:
+                        type: array
+                        description: 매칭 사유 문구
+                        items:
+                          oneOf:
+                          - type: object
+                          - type: boolean
+                          - type: string
+                          - type: number
+                      quizMatchRate:
+                        type: number
+                        description: 퀴즈 답변 일치율 (0~100)
+                      matchedQuestions:
+                        type: number
+                        description: 일치한 문항 수
+                    description: 매칭 점수 상세
+                  gender:
+                    type: string
+                    description: "성별 (MALE / FEMALE, 없으면 null)"
+                    nullable: true
+                  nickname:
+                    type: string
+                    description: 닉네임
+                  location:
+                    type: string
+                    description: 사는 곳 코드
+                  matchRate:
+                    type: number
+                    description: 매칭 점수 (0~100)
+                  profileImageUrl:
+                    type: string
+                    description: 프로필 이미지 (캐리커쳐)
+                  userId:
+                    type: number
+                    description: 후보 회원 ID
+                  introduction:
+                    type: string
+                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
+                    nullable: true
+                  age:
+                    type: number
+                    description: 나이 (없으면 null)
+                    nullable: true
+            algorithmVersion:
+              type: string
+              description: 매칭 알고리즘 버전
+            quizSetId:
+              type: number
+              description: 후보가 속한 퀴즈 세트 ID
+            received:
+              type: array
+              description: 내가 받은 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태
+            matchingType:
+              type: string
+              description: 매칭 타입 (ONE_TO_ONE / GROUP)
+            sent:
+              type: array
+              description: 내가 보낸 요청 목록
+              items:
+                required:
+                - createdAt
+                - id
+                - quizSetId
+                - receiverId
+                - requesterId
+                - status
+                type: object
+                properties:
+                  createdAt:
+                    type: string
+                    description: 요청 생성일시
+                  receiverId:
+                    type: number
+                    description: 수신자 ID
+                  requesterId:
+                    type: number
+                    description: 요청자 ID
+                  quizSetId:
+                    type: number
+                    description: 퀴즈 세트 ID
+                  id:
+                    type: number
+                    description: 매칭 ID
+                  status:
+                    type: string
+                    description: 상태 (PENDING / ACCEPTED / REJECTED / CANCELLED / EXPIRED)
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-nickname-nickname-availability-125958969:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - available
+          type: object
+          properties:
+            available:
+              type: boolean
+              description: 닉네임 사용 가능 여부
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-1640911349:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - age
+          - birthDate
+          - caricature
+          - createdAt
+          - email
+          - gender
+          - id
+          - interests
+          - job
+          - joinedAt
+          - location
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
+          type: object
+          properties:
+            caricature:
+              type: string
+              description: 프로필 캐리커쳐
+            gender:
+              type: string
+              description: 성별
+            joinedAt:
+              type: string
+              description: 가입일시
+            createdAt:
+              type: string
+              description: 생성일시
+            phoneNumber:
+              type: string
+              description: 전화번호
+            nickname:
+              type: string
+              description: 닉네임
+            name:
+              type: string
+              description: 이름
+            location:
+              type: string
+              description: 사는곳 code
+            id:
+              type: number
+              description: 사용자 ID
+            job:
+              type: string
+              description: 직업 code
+            interests:
+              type: array
+              description: 관심사 code 목록
+              items:
+                oneOf:
+                - type: object
+                - type: boolean
+                - type: string
+                - type: number
+            age:
+              type: number
+              description: 나이대
+            updatedAt:
+              type: string
+              description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-user-reports900126493:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - id
+          type: object
+          properties:
+            id:
+              type: number
+              description: 접수된 신고 ID
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-quiz-progress-answers-1062387050:
+      required:
+      - choiceId
+      - quizId
+      type: object
+      properties:
+        choiceId:
+          type: number
+          description: 선택한 선택지 ID
+        quizId:
+          type: number
+          description: 퀴즈 ID
+    api-v1-chat-rooms-roomId-image-upload-urls1777271249:
+      type: object
+      properties:
+        files:
+          type: array
+          items:
+            required:
+            - contentLength
+            - contentType
+            type: object
+            properties:
+              contentLength:
+                type: number
+                description: 이미지 바이트 크기 (최대 10MB)
+              contentType:
+                type: string
+                description: 이미지 MIME 타입 (image/* 만 허용)
+    api-v1-users-id-leave-1444522536:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - age
+          - birthDate
+          - createdAt
+          - email
+          - gender
+          - id
+          - joinedAt
+          - name
+          - nickname
+          - phoneNumber
+          - role
+          - updatedAt
+          type: object
+          properties:
+            createdAt:
+              type: string
+              description: 생성일시
+            nickname:
+              type: string
+              description: 닉네임
+            id:
+              type: number
+              description: 사용자 ID
+            updatedAt:
+              type: string
+              description: 수정일시
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-matches-request-1327932902:
       required:
       - error
@@ -1802,26 +3128,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-member-reviews-reviewId-targets-memberId30922589:
-      required:
-      - meetingStatus
-      - rating
-      type: object
-      properties:
-        wantsOneToOneRematch:
-          type: boolean
-          description: 1:1 재매칭 의사. 그룹 평가에서만 필수이며 1:1 평가에는 보낼 수 없다
-          nullable: true
-        meetingStatus:
-          type: string
-          description: "만남 상태 (MET, APPOINTMENT_MADE, CHAT_ONLY, NO_SHOW)"
-        rating:
-          type: number
-          description: 별점 1~5 정수
-        comment:
-          type: string
-          description: "한줄 코멘트. 최대 50자, 공백만 보내면 미입력 처리"
-          nullable: true
     api-v1-member-reviews-reviewId-targets-memberId-750014847:
       required:
       - error
@@ -1868,230 +3174,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-quiz-sets-current-week838676343:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - month
-          - week
-          - weekStartedOn
-          - year
-          type: object
-          properties:
-            week:
-              type: number
-              description: "주차 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
-            month:
-              type: number
-              description: "월 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
-            year:
-              type: number
-              description: "년도 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
-            weekStartedOn:
-              type: string
-              description: "운영 주 시작일 (해당 주 월요일, 주간 식별자)"
-            quizSets:
-              type: array
-              items:
-                required:
-                - category
-                - description
-                - endDate
-                - id
-                - isActive
-                - matchingType
-                - month
-                - startDate
-                - title
-                - week
-                - weekStartedOn
-                - year
-                type: object
-                properties:
-                  week:
-                    type: number
-                    description: "주차 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
-                  endDate:
-                    type: string
-                    description: 종료일시
-                  year:
-                    type: number
-                    description: "년도 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
-                  description:
-                    type: string
-                    description: 퀴즈 세트 설명
-                  isActive:
-                    type: boolean
-                    description: 활성화 여부
-                  title:
-                    type: string
-                    description: 퀴즈 세트 제목
-                  matchingType:
-                    type: string
-                    description: "매칭 타입 (ONE_TO_ONE, GROUP)"
-                  month:
-                    type: number
-                    description: "월 (weekStartedOn 파생 표시값, FE 전환 후 제거 예정)"
-                  weekStartedOn:
-                    type: string
-                    description: "운영 주 시작일 (해당 주 월요일, 주간 식별자)"
-                  quizzes:
-                    type: array
-                    items:
-                      required:
-                      - createdAt
-                      - id
-                      - order
-                      - question
-                      - quizSetId
-                      - updatedAt
-                      type: object
-                      properties:
-                        createdAt:
-                          type: string
-                          description: 생성일시
-                        question:
-                          type: string
-                          description: 퀴즈 질문
-                        quizSetId:
-                          type: number
-                          description: 퀴즈 세트 ID
-                        id:
-                          type: number
-                          description: 퀴즈 ID
-                        choices:
-                          type: array
-                          items:
-                            required:
-                            - content
-                            - id
-                            - order
-                            type: object
-                            properties:
-                              id:
-                                type: number
-                                description: 선택지 ID
-                              content:
-                                type: string
-                                description: 선택지 내용
-                              order:
-                                type: number
-                                description: 선택지 순서
-                        updatedAt:
-                          type: string
-                          description: 수정일시
-                        order:
-                          type: number
-                          description: 퀴즈 순서
-                  id:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  category:
-                    type: string
-                    description: 카테고리
-                  startDate:
-                    type: string
-                    description: 시작일시
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-matches-1on1-1115011008:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - algorithmVersion
-          - candidates
-          - matchingType
-          - quizSetId
-          type: object
-          properties:
-            candidates:
-              type: array
-              description: 추천 후보 목록 (매칭 점수 내림차순)
-              items:
-                required:
-                - location
-                - matchRate
-                - nickname
-                - profileImageUrl
-                - scoreBreakdown
-                - userId
-                type: object
-                properties:
-                  scoreBreakdown:
-                    required:
-                    - matchedQuestions
-                    - quizMatchRate
-                    - reasons
-                    - totalQuestions
-                    type: object
-                    properties:
-                      totalQuestions:
-                        type: number
-                        description: 전체 비교 문항 수
-                      reasons:
-                        type: array
-                        description: 매칭 사유 문구
-                        items:
-                          oneOf:
-                          - type: object
-                          - type: boolean
-                          - type: string
-                          - type: number
-                      quizMatchRate:
-                        type: number
-                        description: 퀴즈 답변 일치율 (0~100)
-                      matchedQuestions:
-                        type: number
-                        description: 일치한 문항 수
-                    description: 매칭 점수 상세
-                  gender:
-                    type: string
-                    description: "성별 (MALE / FEMALE, 없으면 null)"
-                    nullable: true
-                  nickname:
-                    type: string
-                    description: 닉네임
-                  location:
-                    type: string
-                    description: 사는 곳 코드
-                  matchRate:
-                    type: number
-                    description: 매칭 점수 (0~100)
-                  profileImageUrl:
-                    type: string
-                    description: 프로필 이미지 (캐리커쳐)
-                  userId:
-                    type: number
-                    description: 후보 회원 ID
-                  introduction:
-                    type: string
-                    description: "자기소개 (소개노트 한 단어, 없으면 null)"
-                    nullable: true
-                  age:
-                    type: number
-                    description: 나이 (없으면 null)
-                    nullable: true
-            algorithmVersion:
-              type: string
-              description: 매칭 알고리즘 버전
-            quizSetId:
-              type: number
-              description: 후보가 속한 퀴즈 세트 ID
-            matchingType:
-              type: string
-              description: 매칭 타입 (ONE_TO_ONE / GROUP)
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-user-reports-image-upload-urls-641010299:
       required:
       - error
@@ -2115,121 +3197,6 @@ components:
                   objectKey:
                     type: string
                     description: 업로드 대상 객체 키 (신고 접수 시 전달)
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-chat-rooms-roomId-messages-1177664575:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          type: object
-          properties:
-            nextCursor:
-              type: number
-              description: 다음 페이지 커서 (더 없으면 null)
-              nullable: true
-            messages:
-              type: array
-              items:
-                required:
-                - content
-                - createdAt
-                - id
-                - messageType
-                - roomId
-                - senderId
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 메시지 생성일시
-                  senderId:
-                    type: number
-                    description: 보낸 회원 ID
-                  messageType:
-                    type: string
-                    description: "메시지 유형 (TEXT, IMAGE, SYSTEM)"
-                  id:
-                    type: number
-                    description: 메시지 ID
-                  content:
-                    type: string
-                    description: 메시지 내용 (IMAGE 는 S3 key)
-                  roomId:
-                    type: number
-                    description: 채팅방 ID
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-quiz-progress-quiz-sets-id-1569645469:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - totalCount
-          type: object
-          properties:
-            quizzes:
-              type: array
-              items:
-                required:
-                - createdAt
-                - id
-                - order
-                - question
-                - quizSetId
-                - updatedAt
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 생성일시
-                  userAnswer:
-                    type: number
-                    description: 사용자가 선택한 choiceId (미답변 시 null)
-                    nullable: true
-                  question:
-                    type: string
-                    description: 퀴즈 질문
-                  quizSetId:
-                    type: number
-                    description: 퀴즈 세트 ID
-                  id:
-                    type: number
-                    description: 퀴즈 ID
-                  choices:
-                    type: array
-                    items:
-                      required:
-                      - content
-                      - id
-                      - order
-                      type: object
-                      properties:
-                        id:
-                          type: number
-                          description: 선택지 ID
-                        content:
-                          type: string
-                          description: 선택지 내용
-                        order:
-                          type: number
-                          description: 선택지 순서
-                  updatedAt:
-                    type: string
-                    description: 수정일시
-                  order:
-                    type: number
-                    description: 퀴즈 순서
-            totalCount:
-              type: number
-              description: 전체 퀴즈 수
         success:
           type: boolean
           description: 성공 여부
@@ -2347,87 +3314,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-chat-rooms1291226728:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          type: array
-          items:
-            required:
-            - counterpartMemberIds
-            - createdAt
-            - expiresAt
-            - isEnded
-            - opensAt
-            - roomId
-            - sourceType
-            - unreadCount
-            type: object
-            properties:
-              createdAt:
-                type: string
-                description: 채팅방 생성일시
-              sourceType:
-                type: string
-                description: "채팅방 유형 (PERSONAL, GROUP)"
-              lastMessage:
-                type: object
-                properties:
-                  createdAt:
-                    type: string
-                    description: 메시지 생성일시
-                    nullable: true
-                  senderId:
-                    type: number
-                    description: 보낸 회원 ID
-                    nullable: true
-                  messageType:
-                    type: string
-                    description: 메시지 유형
-                    nullable: true
-                  id:
-                    type: number
-                    description: 메시지 ID
-                    nullable: true
-                  content:
-                    type: string
-                    description: 메시지 내용 (IMAGE 는 S3 key)
-                    nullable: true
-                  roomId:
-                    type: number
-                    description: 채팅방 ID
-                    nullable: true
-                description: 마지막 메시지 (없으면 null)
-              opensAt:
-                type: string
-                description: 채팅 개방 시각 (금요일 00:00)
-              unreadCount:
-                type: number
-                description: 안읽음 수
-              isEnded:
-                type: boolean
-                description: 종료 여부. true 면 전송·구독이 막히고 조회만 가능
-              expiresAt:
-                type: string
-                description: 자동 종료 예정 시각 (월요일 00:00). 남은 시간 카운트다운 기준
-              counterpartMemberIds:
-                type: array
-                description: 나를 제외한 참여 회원 ID 목록 (1:1이면 1명)
-                items:
-                  oneOf:
-                  - type: object
-                  - type: boolean
-                  - type: string
-                  - type: number
-              roomId:
-                type: number
-                description: 채팅방 ID
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-member-reviews-883881201:
       required:
       - error
@@ -2522,6 +3408,19 @@ components:
         success:
           type: boolean
           description: 성공 여부
+    api-v1-users-social-login-provider-callback-272682272:
+      required:
+      - data
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: object
+          description: 빈 객체 (신규 사용자)
+        success:
+          type: boolean
+          description: 성공 여부
     api-v1-users-2041696623:
       required:
       - caricature
@@ -2582,47 +3481,6 @@ components:
         quizSetId:
           type: number
           description: 퀴즈 세트 ID
-    api-v1-users-me-intro-notes-questionCode-1298820809:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - completedCount
-          type: object
-          properties:
-            answers:
-              type: array
-              items:
-                required:
-                - answer
-                - question
-                - questionCode
-                type: object
-                properties:
-                  answer:
-                    type: string
-                    description: 답변 (미작성 시 빈 문자열)
-                  question:
-                    type: string
-                    description: 질문 문구
-                  questionCode:
-                    type: string
-                    description: "질문 code (가능한 값: travel-items(여행갈 때 꼭 챙겨야 하는 3가지는\
-                      ?), weekend-morning(주말 아침 10시, 나는 주로 뭐하고 있을까?), friends-say(친\
-                      구들이 나한테 제일 많이 하는 말은?), stress-relief(스트레스 받을 때 나만의 해소법은?), best-choice(최\
-                      근 1년 내 가장 잘한 선택은?), happiest-moment(나를 가장 행복하게 만드는 순간은?), most-used-apps(요\
-                      즘 내가 가장 많이 쓰는 앱 3개는?), favorite-time(하루 중 가장 좋아하는 시간대는? 그때 주\
-                      로 뭐해?), non-negotiable(내가 절대 양보 못하는 것은?), one-word(나를 한 단어로\
-                      \ 표현한다면?))"
-            completedCount:
-              type: number
-              description: 작성 완료된 답변 수
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-users-me-intro-notes-questionCode974133747:
       required:
       - answer
@@ -2657,6 +3515,52 @@ components:
             roomId:
               type: number
               description: 배정된 그룹 방 ID
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-notification-settings1737408490:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          required:
+          - chat
+          - marketing
+          - matching
+          type: object
+          properties:
+            marketing:
+              type: boolean
+              description: 마케팅 정보 수신 여부
+            chat:
+              type: boolean
+              description: 채팅 알림 수신 여부
+            matching:
+              type: boolean
+              description: 매칭 알림 수신 여부
+        success:
+          type: boolean
+          description: 성공 여부
+    api-v1-users-me-blocks1689110600:
+      required:
+      - memberId
+      type: object
+      properties:
+        memberId:
+          type: number
+          description: 차단할 회원 ID
+    api-v1-users-me-blocks-918175200:
+      required:
+      - error
+      - success
+      type: object
+      properties:
+        data:
+          type: object
+          description: 응답 본문 없음
+          nullable: true
         success:
           type: boolean
           description: 성공 여부
@@ -2710,23 +3614,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-auth-refresh1774976609:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - accessToken
-          type: object
-          properties:
-            accessToken:
-              type: string
-              description: 새 JWT 액세스 토큰
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-request-793255208:
       required:
       - quizSetId
@@ -2739,15 +3626,6 @@ components:
         quizSetId:
           type: number
           description: 퀴즈 세트 ID
-    api-v1-matches-group-decline-789252668:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        success:
-          type: boolean
-          description: 성공 여부
     api-v1-matches-request-id-reject-1480143692:
       required:
       - error
@@ -2793,201 +3671,6 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-quiz-progress-current1012077415:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - participantCount
-          - status
-          type: object
-          properties:
-            answeredQuizzes:
-              type: number
-              description: 답변한 퀴즈 수
-              nullable: true
-            totalQuizzes:
-              type: number
-              description: 전체 퀴즈 수
-              nullable: true
-            quizSetId:
-              type: number
-              description: 참여 중인 퀴즈 세트 ID
-              nullable: true
-            participantCount:
-              type: number
-              description: 완료한 참여자 수
-            quizSetTitle:
-              type: string
-              description: 참여 중인 퀴즈 세트 제목
-              nullable: true
-            status:
-              type: string
-              description: "진행 상태 (NOT_STARTED, IN_PROGRESS, COMPLETED)"
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-chat-rooms-roomId-read-1623720830:
-      required:
-      - lastReadMessageId
-      type: object
-      properties:
-        lastReadMessageId:
-          type: number
-          description: 마지막으로 읽은 메시지 ID
-    api-v1-chat-rooms-roomId-read-1118618011:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          type: object
-          description: 응답 데이터 (없음)
-          nullable: true
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-nickname-nickname-availability-125958969:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - available
-          type: object
-          properties:
-            available:
-              type: boolean
-              description: 닉네임 사용 가능 여부
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-users-1640911349:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - age
-          - birthDate
-          - caricature
-          - createdAt
-          - email
-          - gender
-          - id
-          - interests
-          - job
-          - joinedAt
-          - location
-          - name
-          - nickname
-          - phoneNumber
-          - role
-          - updatedAt
-          type: object
-          properties:
-            caricature:
-              type: string
-              description: 프로필 캐리커쳐
-            gender:
-              type: string
-              description: 성별
-            joinedAt:
-              type: string
-              description: 가입일시
-            createdAt:
-              type: string
-              description: 생성일시
-            phoneNumber:
-              type: string
-              description: 전화번호
-            nickname:
-              type: string
-              description: 닉네임
-            name:
-              type: string
-              description: 이름
-            location:
-              type: string
-              description: 사는곳 code
-            id:
-              type: number
-              description: 사용자 ID
-            job:
-              type: string
-              description: 직업 code
-            interests:
-              type: array
-              description: 관심사 code 목록
-              items:
-                oneOf:
-                - type: object
-                - type: boolean
-                - type: string
-                - type: number
-            age:
-              type: number
-              description: 나이대
-            updatedAt:
-              type: string
-              description: 수정일시
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-user-reports900126493:
-      required:
-      - error
-      - success
-      type: object
-      properties:
-        data:
-          required:
-          - id
-          type: object
-          properties:
-            id:
-              type: number
-              description: 접수된 신고 ID
-        success:
-          type: boolean
-          description: 성공 여부
-    api-v1-quiz-progress-answers-1062387050:
-      required:
-      - choiceId
-      - quizId
-      type: object
-      properties:
-        choiceId:
-          type: number
-          description: 선택한 선택지 ID
-        quizId:
-          type: number
-          description: 퀴즈 ID
-    api-v1-chat-rooms-roomId-image-upload-urls1777271249:
-      type: object
-      properties:
-        files:
-          type: array
-          items:
-            required:
-            - contentLength
-            - contentType
-            type: object
-            properties:
-              contentLength:
-                type: number
-                description: 이미지 바이트 크기 (최대 10MB)
-              contentType:
-                type: string
-                description: 이미지 MIME 타입 (image/* 만 허용)
     api-v1-chat-rooms-roomId-image-upload-urls-1366152212:
       required:
       - error
@@ -3083,7 +3766,7 @@ components:
         success:
           type: boolean
           description: 성공 여부
-    api-v1-users-id-leave-1444522536:
+    api-v1-users-me-profile1973775834:
       required:
       - error
       - success
@@ -3091,32 +3774,50 @@ components:
       properties:
         data:
           required:
-          - age
-          - birthDate
-          - createdAt
-          - email
-          - gender
-          - id
-          - joinedAt
-          - name
+          - interests
           - nickname
-          - phoneNumber
-          - role
-          - updatedAt
+          - userId
           type: object
           properties:
-            createdAt:
+            occupation:
               type: string
-              description: 생성일시
+              description: 직업 code
+              nullable: true
+            gender:
+              type: string
+              description: 성별 (MALE/FEMALE)
+              nullable: true
             nickname:
               type: string
               description: 닉네임
-            id:
-              type: number
-              description: 사용자 ID
-            updatedAt:
+            location:
               type: string
-              description: 수정일시
+              description: 사는 곳 code
+              nullable: true
+            interests:
+              type: array
+              description: 관심사 code 목록
+              items:
+                oneOf:
+                - type: object
+                - type: boolean
+                - type: string
+                - type: number
+            profileImageUrl:
+              type: string
+              description: 캐리커쳐 경로
+              nullable: true
+            userId:
+              type: number
+              description: 회원 ID
+            introduction:
+              type: string
+              description: "한 줄 소개 (소개노트 one-word 답변, 미작성이면 null)"
+              nullable: true
+            age:
+              type: number
+              description: 나이
+              nullable: true
         success:
           type: boolean
           description: 성공 여부

--- a/api/src/test/kotlin/com/ditto/api/user/MemberLeaveTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/MemberLeaveTest.kt
@@ -1,0 +1,284 @@
+package com.ditto.api.user
+
+import com.ditto.api.auth.service.MemberSocialAccountService
+import com.ditto.api.auth.service.AuthService
+import com.ditto.api.system.ServerTimeProvider
+import com.ditto.domain.refreshtoken.repository.RefreshTokenRepository
+import com.ditto.api.support.IntegrationTest
+import com.ditto.api.user.dto.LeaveRequest
+import com.ditto.api.user.service.LeftMemberPurgeService
+import com.ditto.api.user.service.UserService
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.chat.ChatRoomFixture
+import com.ditto.domain.chat.ChatRoomMemberFixture
+import com.ditto.domain.chat.repository.ChatRoomMemberRepository
+import com.ditto.domain.chat.repository.ChatRoomRepository
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.match.repository.PersonalMatchRepository
+import com.ditto.domain.member.entity.Member
+import com.ditto.domain.member.entity.MemberStatus
+import com.ditto.domain.member.repository.MemberRepository
+import com.ditto.domain.socialaccount.entity.SocialAccount
+import com.ditto.domain.socialaccount.entity.SocialProvider
+import com.ditto.domain.socialaccount.repository.SocialAccountRepository
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.matchers.nulls.shouldNotBeNull
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+import javax.sql.DataSource
+
+/**
+ * 탈퇴 소프트 삭제와 30일 복구. 명세는 탈퇴 화면(피그마 6.2.4)의 안내 문구다.
+ */
+class MemberLeaveTest(
+    private val userService: UserService,
+    private val memberSocialAccountService: MemberSocialAccountService,
+    private val leftMemberPurgeService: LeftMemberPurgeService,
+    private val memberRepository: MemberRepository,
+    private val socialAccountRepository: SocialAccountRepository,
+    private val personalMatchRepository: PersonalMatchRepository,
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
+    private val chatRoomRepository: ChatRoomRepository,
+    private val refreshTokenRepository: RefreshTokenRepository,
+    private val serverTimeProvider: ServerTimeProvider,
+    private val authService: AuthService,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    fun saveActive(nickname: String) =
+        memberRepository.save(Member(nickname = nickname).apply { activate() })
+
+
+    "탈퇴는 데이터를 지우지 않고 상태만 바꾼다" - {
+        "탈퇴하면 LEFT가 되고 사유·일시가 남는다" {
+            val member = saveActive("탈퇴회원")
+
+            userService.leaveUser(member.id, member.id, LeaveRequest(reason = "not-useful"))
+
+            val left = memberRepository.findById(member.id).orElseThrow()
+            left.status shouldBe MemberStatus.LEFT
+            left.leaveReason shouldBe "not-useful"
+            left.leftAt.shouldNotBeNull()
+        }
+
+        "SocialAccount는 보존한다 — 복구·재가입 식별 근거다" {
+            val member = saveActive("소셜보존회원")
+            socialAccountRepository.save(
+                SocialAccount.create(
+                    memberId = member.id,
+                    provider = SocialProvider.KAKAO,
+                    providerUserId = "kakao-preserve-1",
+                ),
+            )
+
+            userService.leaveUser(member.id, member.id, LeaveRequest(reason = "etc"))
+
+            socialAccountRepository.findByMemberId(member.id).shouldNotBeNull()
+        }
+
+        "제재 중에도 탈퇴할 수 있다 — 소프트 삭제는 제재 이력을 보존한다" {
+            val member = memberRepository.save(
+                Member(nickname = "정지중탈퇴회원").apply {
+                    activate()
+                    suspendUntil(LocalDateTime.now().plusDays(7))
+                },
+            )
+
+            userService.leaveUser(member.id, member.id, LeaveRequest(reason = "etc"))
+
+            memberRepository.findById(member.id).orElseThrow().status shouldBe MemberStatus.LEFT
+        }
+
+        "남의 계정은 탈퇴시킬 수 없다" {
+            val member = saveActive("본인")
+            val other = saveActive("타인")
+
+            val exception = shouldThrow<WarnException> {
+                userService.leaveUser(other.id, member.id, LeaveRequest())
+            }
+            exception.errorCode shouldBe ErrorCode.FORBIDDEN
+        }
+    }
+
+    "진행 중인 매칭·채팅이 있으면 탈퇴가 제한된다" - {
+        "수락된 매칭이 있으면 거부한다" {
+            val member = saveActive("매칭중회원")
+            val partner = saveActive("매칭상대")
+            personalMatchRepository.save(
+                PersonalMatchFixture.create(
+                    requesterId = member.id,
+                    receiverId = partner.id,
+                    status = PersonalMatchStatus.ACCEPTED,
+                ),
+            )
+
+            val exception = shouldThrow<WarnException> {
+                userService.leaveUser(member.id, member.id, LeaveRequest())
+            }
+            exception.errorCode shouldBe ErrorCode.CANNOT_LEAVE_WHILE_IN_PROGRESS
+        }
+
+        "끝나지 않은 채팅방이 있으면 거부한다" {
+            val member = saveActive("채팅중회원")
+            val room = chatRoomRepository.save(ChatRoomFixture.personal(sourceId = 1L))
+            chatRoomMemberRepository.save(ChatRoomMemberFixture.create(roomId = room.id, memberId = member.id))
+
+            val exception = shouldThrow<WarnException> {
+                userService.leaveUser(member.id, member.id, LeaveRequest())
+            }
+            exception.errorCode shouldBe ErrorCode.CANNOT_LEAVE_WHILE_IN_PROGRESS
+        }
+
+        "종료된 채팅방만 있으면 탈퇴할 수 있다" {
+            val member = saveActive("채팅끝난회원")
+            val room = ChatRoomFixture.personal(sourceId = 2L).apply {
+                expire(ChatRoomFixture.DEFAULT_NOW.plusDays(3))
+            }
+            chatRoomRepository.save(room)
+            chatRoomMemberRepository.save(ChatRoomMemberFixture.create(roomId = room.id, memberId = member.id))
+
+            userService.leaveUser(member.id, member.id, LeaveRequest())
+
+            memberRepository.findById(member.id).orElseThrow().status shouldBe MemberStatus.LEFT
+        }
+
+        "거절된 매칭만 있으면 탈퇴할 수 있다" {
+            val member = saveActive("거절만있는회원")
+            val partner = saveActive("거절한상대")
+            personalMatchRepository.save(
+                PersonalMatchFixture.create(
+                    requesterId = member.id,
+                    receiverId = partner.id,
+                    status = PersonalMatchStatus.REJECTED,
+                ),
+            )
+
+            userService.leaveUser(member.id, member.id, LeaveRequest())
+
+            memberRepository.findById(member.id).orElseThrow().status shouldBe MemberStatus.LEFT
+        }
+    }
+
+    "재가입 시 보존 기간 안이면 복구한다" - {
+        "30일 이내 재로그인하면 ACTIVE로 돌아온다" {
+            val member = saveActive("복구대상회원")
+            socialAccountRepository.save(
+                SocialAccount.create(
+                    memberId = member.id,
+                    provider = SocialProvider.KAKAO,
+                    providerUserId = "kakao-restore-1",
+                ),
+            )
+            userService.leaveUser(member.id, member.id, LeaveRequest(reason = "etc"))
+
+            val found = memberSocialAccountService.findOrCreateMember(
+                provider = SocialProvider.KAKAO,
+                providerUserId = "kakao-restore-1",
+                email = null,
+                birthDate = null,
+            )
+
+            found.id shouldBe member.id
+            found.status shouldBe MemberStatus.ACTIVE
+            found.leftAt shouldBe null
+            found.leaveReason shouldBe null
+        }
+
+        "보존 기간이 지났으면 복구하지 않는다" {
+            val member = saveActive("기간경과회원")
+            socialAccountRepository.save(
+                SocialAccount.create(
+                    memberId = member.id,
+                    provider = SocialProvider.KAKAO,
+                    providerUserId = "kakao-expired-1",
+                ),
+            )
+            member.leave(reason = "etc", now = LocalDateTime.now().minusDays(31))
+            memberRepository.save(member)
+
+            val found = memberSocialAccountService.findOrCreateMember(
+                provider = SocialProvider.KAKAO,
+                providerUserId = "kakao-expired-1",
+                email = null,
+                birthDate = null,
+            )
+
+            found.status shouldBe MemberStatus.LEFT
+        }
+    }
+
+    // 탈퇴는 세션을 즉시 끊으므로 정상 흐름에서는 갱신할 토큰 자체가 없다.
+    // 이 게이트는 그 삭제를 지나온 토큰(경합·유실)에 대한 두 번째 방어선이라, 탈퇴 뒤에 발급해 직접 태운다.
+    "탈퇴 회원의 토큰은 갱신이 거부된다 (refresh 경로는 JWT 필터를 지나지 않는다)" {
+        val member = saveActive("토큰갱신탈퇴회원")
+        userService.leaveUser(member.id, member.id, LeaveRequest(reason = "etc"))
+        val refreshToken = authService.createRefreshToken(member.id)
+
+        val exception = shouldThrow<WarnException> {
+            authService.refresh(refreshToken.token)
+        }
+        exception.errorCode shouldBe ErrorCode.MEMBER_LEFT
+    }
+
+    "삭제 배치는 보존 기간이 지난 회원만 지운다" - {
+        "기간 미경과 회원은 건드리지 않는다" {
+            val member = saveActive("최근탈퇴회원")
+            userService.leaveUser(member.id, member.id, LeaveRequest(reason = "etc"))
+
+            leftMemberPurgeService.purge()
+
+            memberRepository.findById(member.id).isPresent shouldBe true
+        }
+
+        "dryRun을 끄면 보존 기간이 지난 회원을 실제로 삭제한다" {
+            val member = saveActive("실제삭제대상")
+            socialAccountRepository.save(
+                SocialAccount.create(
+                    memberId = member.id,
+                    provider = SocialProvider.KAKAO,
+                    providerUserId = "kakao-purge-1",
+                ),
+            )
+            member.leave(reason = "etc", now = LocalDateTime.now().minusDays(31))
+            memberRepository.save(member)
+
+            val purgeService = LeftMemberPurgeService(
+                memberRepository = memberRepository,
+                socialAccountRepository = socialAccountRepository,
+                refreshTokenRepository = refreshTokenRepository,
+                serverTimeProvider = serverTimeProvider,
+                dryRun = false,
+                batchLimit = 100,
+                retentionDays = 30,
+            )
+
+            purgeService.purge() shouldBe 1
+
+            memberRepository.findById(member.id).isPresent shouldBe false
+            socialAccountRepository.findByMemberId(member.id) shouldBe null
+        }
+
+        "삭제 대상이 없으면 0을 반환한다" {
+            leftMemberPurgeService.purge() shouldBe 0
+        }
+
+        "스케줄 진입점도 같은 동작을 한다" {
+            // @Scheduled 가 호출하는 래퍼 — 대상이 없으면 아무 일도 하지 않는다.
+            leftMemberPurgeService.purgeExpired()
+
+            memberRepository.findAll().none { it.isLeft() } shouldBe true
+        }
+
+        "dryRun 기본값에서는 삭제하지 않고 대상만 집계한다" {
+            val member = saveActive("기간경과탈퇴회원")
+            member.leave(reason = "etc", now = LocalDateTime.now().minusDays(31))
+            memberRepository.save(member)
+
+            // 테스트 프로필의 dry-run 기본값(true)이라 실제 삭제는 일어나지 않는다.
+            leftMemberPurgeService.purge() shouldBe 0
+            memberRepository.findById(member.id).isPresent shouldBe true
+        }
+    }
+})

--- a/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserControllerTest.kt
@@ -1,6 +1,7 @@
 package com.ditto.api.user
 
 import com.ditto.api.support.RestDocsTest
+import com.ditto.api.user.dto.LeaveRequest
 import com.ditto.api.user.dto.CreateUserRequest
 import com.ditto.domain.member.entity.Gender
 import com.ditto.domain.member.entity.Interest
@@ -296,7 +297,9 @@ class UserControllerTest : RestDocsTest() {
         mockMvc.perform(
             post("/api/v1/users/{id}/leave", member.id)
                 .withApiKey()
-                .withBearerToken(member.id),
+                .withBearerToken(member.id)
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsString(LeaveRequest(reason = "not-useful"))),
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.success").value(true))
@@ -310,9 +313,16 @@ class UserControllerTest : RestDocsTest() {
                         ResourceSnippetParameters.builder()
                             .tag("Users")
                             .summary("회원 탈퇴")
-                            .description("회원을 탈퇴 처리합니다.")
+                            .description(
+                                "회원을 탈퇴 처리합니다(소프트 삭제). 계정은 즉시 사용 불가가 되지만 데이터는 남으며, " +
+                                    "30일 이내 같은 소셜 계정으로 재로그인하면 복구됩니다. 30일이 지나면 배치가 완전 삭제합니다. " +
+                                    "진행 중인 매칭이나 채팅이 있으면 거부합니다.",
+                            )
                             .pathParameters(
                                 parameterWithName("id").description("사용자 ID"),
+                            )
+                            .requestFields(
+                                fieldWithPath("reason").description("탈퇴 사유 code (선택, 최대 50자)").optional(),
                             )
                             .responseFields(
                                 fieldWithPath("success").description("성공 여부"),

--- a/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
+++ b/api/src/test/kotlin/com/ditto/api/user/UserServiceTest.kt
@@ -3,6 +3,7 @@ package com.ditto.api.user
 import com.ditto.api.auth.service.AuthService
 import com.ditto.api.support.IntegrationTest
 import com.ditto.api.user.dto.CreateUserRequest
+import com.ditto.api.user.dto.LeaveRequest
 import com.ditto.api.user.service.UserService
 import com.ditto.common.exception.ErrorCode
 import com.ditto.common.exception.ErrorException
@@ -308,23 +309,28 @@ class UserServiceTest(
             }
         }
 
-        "회원 탈퇴" - {
-            "탈퇴 시 회원이 삭제된다" {
-                val member = memberRepository.save(Member(nickname = "탈퇴유저"))
+        "회원 탈퇴 (소프트 삭제)" - {
+            "탈퇴 시 회원이 삭제되지 않고 LEFT 상태가 된다" {
+                val member = memberRepository.save(Member(nickname = "탈퇴유저").apply { activate() })
                 socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "leave-user"))
                 authService.createRefreshToken(member.id)
 
                 val result = userService.leaveUser(
                     id = member.id,
                     memberId = member.id,
+                    request = LeaveRequest(reason = "not-useful"),
                 )
 
                 result.id shouldBe member.id
-                memberRepository.findById(member.id).isEmpty shouldBe true
+                val left = memberRepository.findById(member.id).orElseThrow()
+                left.status shouldBe MemberStatus.LEFT
+                left.leaveReason shouldBe "not-useful"
+                // 재가입 복구·제재 회피 방지 근거이므로 소셜 계정은 남긴다.
+                socialAccountRepository.findByMemberId(member.id) shouldNotBe null
             }
 
             "탈퇴 시 해당 회원의 모든 리프레시 토큰이 삭제된다" {
-                val member = memberRepository.save(Member(nickname = "탈퇴유저"))
+                val member = memberRepository.save(Member(nickname = "탈퇴유저").apply { activate() })
                 socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "leave-user-2"))
                 val token1 = authService.createRefreshToken(member.id)
                 val token2 = authService.createRefreshToken(member.id)
@@ -332,6 +338,7 @@ class UserServiceTest(
                 userService.leaveUser(
                     id = member.id,
                     memberId = member.id,
+                    request = LeaveRequest(),
                 )
 
                 refreshTokenRepository.findByToken(token1.token) shouldBe null
@@ -343,12 +350,13 @@ class UserServiceTest(
                     userService.leaveUser(
                         id = 99999L,
                         memberId = 1L,
+                        request = LeaveRequest(),
                     )
                 }
                 exception.errorCode shouldBe ErrorCode.NOT_FOUND
             }
 
-            "이용 정지 중인 회원은 탈퇴할 수 없다" {
+            "이용 정지 중인 회원도 탈퇴할 수 있다 — 소프트 삭제는 제재 이력을 보존한다" {
                 val member = memberRepository.save(
                     Member(nickname = "정지탈퇴유저").apply {
                         activate()
@@ -356,36 +364,19 @@ class UserServiceTest(
                     },
                 )
 
-                val exception = shouldThrow<WarnException> {
-                    userService.leaveUser(id = member.id, memberId = member.id)
-                }
-                exception.errorCode shouldBe ErrorCode.CANNOT_LEAVE_WHILE_SANCTIONED
+                userService.leaveUser(id = member.id, memberId = member.id, request = LeaveRequest())
+
+                memberRepository.findById(member.id).orElseThrow().status shouldBe MemberStatus.LEFT
             }
 
-            "영구 차단 회원은 탈퇴할 수 없다 — 재가입 차단 근거(SocialAccount) 보존" {
+            "영구 차단 회원도 탈퇴할 수 있고 재가입 차단 근거(SocialAccount)는 보존된다" {
                 val member = memberRepository.save(Member(nickname = "차단탈퇴유저").apply { activate(); ban() })
                 socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "banned-user"))
 
-                val exception = shouldThrow<WarnException> {
-                    userService.leaveUser(id = member.id, memberId = member.id)
-                }
+                userService.leaveUser(id = member.id, memberId = member.id, request = LeaveRequest())
 
-                exception.errorCode shouldBe ErrorCode.CANNOT_LEAVE_WHILE_SANCTIONED
+                memberRepository.findById(member.id).orElseThrow().status shouldBe MemberStatus.LEFT
                 socialAccountRepository.findByMemberId(member.id) shouldNotBe null
-            }
-
-            "정지 해제 예정일이 지난 회원은 탈퇴할 수 있다" {
-                val member = memberRepository.save(
-                    Member(nickname = "만료정지탈퇴").apply {
-                        activate()
-                        suspendUntil(java.time.LocalDateTime.now().minusDays(1))
-                    },
-                )
-                socialAccountRepository.save(SocialAccount.create(member.id, SocialProvider.KAKAO, "expired-user"))
-
-                userService.leaveUser(id = member.id, memberId = member.id)
-
-                memberRepository.findById(member.id).isEmpty shouldBe true
             }
 
             "다른 회원의 ID로 탈퇴 요청하면 예외가 발생한다" {
@@ -396,6 +387,7 @@ class UserServiceTest(
                     userService.leaveUser(
                         id = memberB.id,
                         memberId = memberA.id,
+                        request = LeaveRequest(),
                     )
                 }
                 exception.errorCode shouldBe ErrorCode.FORBIDDEN

--- a/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
+++ b/common/src/main/kotlin/com/ditto/common/exception/ErrorCode.kt
@@ -36,6 +36,8 @@ enum class ErrorCode(
     MEMBER_BANNED(403, "6007", "영구 차단된 계정입니다."),
     QUIZ_BLOCKED_BY_SANCTION(403, "6008", "제재로 인해 이번 주 퀴즈에 참여할 수 없습니다."),
     CANNOT_LEAVE_WHILE_SANCTIONED(403, "6009", "제재 중에는 탈퇴할 수 없습니다."),
+    CANNOT_LEAVE_WHILE_IN_PROGRESS(403, "6011", "진행 중인 매칭이나 채팅이 있어 탈퇴할 수 없습니다."),
+    MEMBER_LEFT(403, "6012", "탈퇴한 계정입니다."),
     REPORT_ALREADY_REVIEWED(409, "6010", "이미 검토가 완료된 신고입니다."),
     CHAT_ROOM_NOT_FOUND(404, "7001", "존재하지 않는 채팅방입니다."),
     NOT_CHAT_ROOM_MEMBER(403, "7002", "채팅방에 참여한 회원이 아닙니다."),

--- a/docs/adr/0016-member-leave-soft-delete-and-restore.md
+++ b/docs/adr/0016-member-leave-soft-delete-and-restore.md
@@ -1,0 +1,46 @@
+# ADR 0016 — 회원 탈퇴는 소프트 삭제로 처리하고 30일 안에 재가입하면 복구한다
+
+- 상태: Accepted
+- 근거: Issue #124, 피그마 `6.2.4 탈퇴` 화면 안내 문구, 기획 확인(2026-08-03)
+
+## Context
+
+탈퇴는 hard delete였다. `UserService.leaveUser`가 `RefreshToken`·`SocialAccount`·`Member`를 즉시 지웠다.
+
+그 구현에는 부작용이 있었다. 제재(SUSPENDED/BANNED) 회원이 탈퇴하면 제재 이력과 재가입 식별 근거(`SocialAccount`)가 함께 사라져 **차단 우회 수단**이 된다. 그래서 제재 중 탈퇴를 아예 거부하는 가드(`CANNOT_LEAVE_WHILE_SANCTIONED`)를 뒀고, 코드 주석에 "탈퇴 부분 보존 전환(후속) 시 이 가드는 제거한다"고 남겨 뒀다.
+
+한편 탈퇴 화면은 다른 정책을 안내하고 있었다.
+
+- "진행 중인 매칭이나 채팅이 있으면 탈퇴가 제한됩니다" → 구현은 제재 중일 때만 거부
+- "탈퇴 후 30일 이내 재가입하면 계정을 복구할 수 있습니다 / 30일이 지나면 모든 데이터가 완전히 삭제됩니다" → 구현은 즉시 완전 삭제
+- 탈퇴 사유 선택(제출 필수) → 요청 바디를 받지 않아 사유가 유실
+
+화면이 약속한 복구를 지키려면 즉시 삭제를 유지할 수 없다.
+
+## Decision
+
+**탈퇴 시점에는 아무것도 삭제하지 않는다.** `MemberStatus.LEFT`로 전이하고 `left_at`·`leave_reason`만 기록한다. 세션(refreshToken)은 즉시 끊고, `SocialAccount`는 남긴다.
+
+**복구는 재가입이 곧 복구다.** `MemberSocialAccountService.findOrCreateMember`는 `SocialAccount`가 있으면 기존 `Member`를 반환하므로, 그 경로에 "LEFT이고 보존 기간 안이면 `restore()`" 분기만 더했다. 별도 복구 API는 두지 않는다 — 화면에도 그런 흐름이 없다.
+
+**완전 삭제는 배치가 한다.** `LeftMemberPurgeService`가 `left_at + 30일`이 지난 회원을 지운다.
+
+**제재 중 탈퇴 가드는 제거한다.** 소프트 삭제는 제재 이력과 `SocialAccount`를 모두 보존하므로 우회 수단이 되지 않는다. 예고했던 후속 작업이 이 ADR이다.
+
+**진행 중 가드를 추가한다.** 진행 중인 매칭(`PENDING`/`ACCEPTED`)이나 끝나지 않은 채팅방(`SCHEDULED`/`ACTIVE`)이 있으면 `CANNOT_LEAVE_WHILE_IN_PROGRESS`로 거부한다.
+
+**LEFT는 인증 게이트에서 막는다.** `JwtAuthenticationFilter`와 `AuthService.refresh` 양쪽에 넣는다 — refresh는 필터를 지나지 않으므로 한쪽만으로는 우회된다(제재 게이트와 같은 구조).
+
+## Consequences
+
+- 탈퇴 회원의 행이 최대 30일 남는다. 닉네임 유일키도 그 기간 점유된다 — 탈퇴자가 쓰던 닉네임을 다른 사람이 즉시 쓸 수 없다. 복구 시 닉네임이 살아 있어야 하므로 의도된 결과다.
+- `left_at`이 지났는데 배치가 아직 돌지 않은 회원이 재로그인하면 복구하지 않는다. LEFT가 유지돼 인증 게이트가 막고, 배치가 정리한 뒤 새 회원으로 가입한다. 이 짧은 구간에서 로그인이 거부되는 것을 감수한다 — 복구 기한을 넘긴 사용자에게 기한을 늘려주는 것보다 낫다.
+- 삭제 배치는 되돌릴 수 없다. `ditto.member.purge.dry-run`을 **기본 true**로 두어 운영 투입 전 대상만 로그로 관찰하고, `batch-limit`으로 1회 삭제량을 제한한다.
+- 채팅의 "진행 중" 판정은 아직 끝나지 않은 방(`SCHEDULED`·`ACTIVE`) 기준이다. `SCHEDULED`(개방 예정, 재매칭 방)도 포함한다 — 상대가 곧 열릴 방을 기다리는 상태다. 종료(`ENDED`)된 방만 남은 회원은 탈퇴할 수 있다.
+- **약관·개인정보 처리방침과 충돌한다.** 현행 문서는 "회원 탈퇴 시 원칙: 즉시 파기"(처리방침 4.1), "탈퇴 요청 시 즉시 처리"(이용약관 제7조), "탈퇴 요청 시 즉시 삭제"(처리방침 8.2)를 약속하고 있고, 예외는 "신고 접수·법적 분쟁 시 1년 보존"뿐이다. 30일 보관 근거 조항 추가와 공지가 별도로 정리돼야 한다(구현은 기획 결정에 따라 선행 진행).
+
+## Links
+
+- Issue #124
+- [ADR 0009](0009-sanction-ssot-and-lazy-expiry.md) — 제재 SSOT·lazy 만료(게이트 구조를 여기서 따랐다)
+- `docs/domains/member.md`, `docs/domains/auth.md`

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -17,6 +17,7 @@
 - [0011 — 평가 데이터 모델: 진행 단위/응답 분리와 상태 표현 최소화](0011-review-progress-and-answer-split.md)
 - [0014 — ECS 태스크 메모리 예산 재배분: Metaspace 128m→256m, 힙 비율 45%→35%](0014-ecs-metaspace-heap-rebalance.md)
 - [0015 — chat_room의 원본 식별자는 (source_type, source_id)로 접두어를 맞춘다](0015-chat-room-source-type-naming.md)
+- [0016 — 회원 탈퇴는 소프트 삭제로 처리하고 30일 안에 재가입하면 복구한다](0016-member-leave-soft-delete-and-restore.md)
 
 ## 언제 ADR을 쓰는가
 

--- a/docs/domains/auth.md
+++ b/docs/domains/auth.md
@@ -6,7 +6,7 @@
 - `JWT` — access(짧음, Bearer 헤더) / refresh(HttpOnly 쿠키). subject = 내부 `memberId`. role claim은 FE 표시 전용(서버 인가에 미파싱).
 - `ApiKey` — `X-API-Key` 헤더. 보호 API는 ApiKey+JWT 둘 다 요구.
 - `MemberPrincipal` — JWT 인증 주체. `{memberId}` 단일 필드. (`config/auth/MemberPrincipal.kt`)
-- `MemberStatus` — `PENDING`(소셜 로그인만 완료) / `ACTIVE`(회원가입 완료). (`domain/.../member/entity/MemberStatus.kt`)
+- `MemberStatus` — `PENDING`(소셜 로그인만 완료) / `ACTIVE`(회원가입 완료) / `SUSPENDED` / `BANNED` / `LEFT`(탈퇴). (`domain/.../member/entity/MemberStatus.kt`)
 - `MemberRole` — `USER` / `ADMIN`. 인가 판단 소스. (`MemberRole.kt`)
 - `AdminPrincipal` — `/admin/**` Thymeleaf UI 세션 주체. `{memberId, name, email}`. (`admin/auth/AdminPrincipal.kt`)
 
@@ -16,6 +16,7 @@
 - OAuth 콜백은 FE로 302 리다이렉트, refreshToken은 HttpOnly·Secure·SameSite 쿠키로만 전달(URL·로그·히스토리 노출 차단). [ADR 0004](../adr/0004-oauth-callback-redirect-and-cookie.md)
 - 카카오 동의항목(email·생년월일)은 콜백 쿼리가 아니라 `GET /api/v1/users/me`로 전달. PENDING 허용은 `JwtAuthenticationFilter`의 `pendingAllowedPaths`로 처리. [ADR 0005](../adr/0005-kakao-consent-via-me-api.md)
 - PENDING 게이트: 회원가입 미완료 회원은 `pendingAllowedPaths` 외 보호 API 접근 시 `SIGNUP_REQUIRED`.
+- 탈퇴 게이트: LEFT 회원은 보호 API 접근·토큰 갱신이 모두 `MEMBER_LEFT`(403)로 거부된다. 복구 경로는 재가입(소셜 로그인)뿐이다. `refresh`는 필터를 지나지 않으므로 `AuthService.refresh`에도 같은 게이트가 있다. [ADR 0016](../adr/0016-member-leave-soft-delete-and-restore.md)
 - 제재 게이트: SUSPENDED(해제 전)/BANNED 회원은 `suspendedAllowedPaths` 외 보호 API 접근 시 `MEMBER_SUSPENDED`/`MEMBER_BANNED`(403). 해제 예정일 경과한 정지는 통과만(원복은 배치·로그인 — [ADR 0009](../adr/0009-sanction-ssot-and-lazy-expiry.md)). 우회 경로 봉쇄: `AuthService.refresh`(필터 미경유)도 동일 거부, 로그인은 아래 콜백 계약으로 안내.
 - 제재 로그인 콜백 계약(FE): 제재 회원 로그인 시 토큰 없이 `?sanctioned=true&sanctionCode=MEMBER_SUSPENDED|MEMBER_BANNED&suspendedUntil=<ISO-8601, 정지만>`으로 리다이렉트. (`OAuthService.getSanctionCallbackUrl`)
 - 어드민 인가는 `@PreAuthorize`가 아니라 `JwtAuthenticationFilter`의 경로 prefix 검사: `/api/v1/admin` 경로는 `member.isAdmin()` 아니면 `403 FORBIDDEN`. [ADR 0006](../adr/0006-admin-authz-filter-path-check.md)

--- a/docs/domains/member.md
+++ b/docs/domains/member.md
@@ -5,7 +5,7 @@
 회원과 그 속성. **골격 문서** — 불변식·상태전이는 회원 작업 시 코드 확인 후 채운다.
 
 ## 용어
-`Member`, `MemberStatus`(상태), `MemberRole`(역할), `Gender`/`GenderPreference`(성별·선호), `Job`, `Location`, `Interest`(관심사).
+`Member`, `MemberStatus`(상태 — PENDING/ACTIVE/SUSPENDED/BANNED/LEFT), `MemberRole`(역할), `Gender`/`GenderPreference`(성별·선호), `Job`, `Location`, `Interest`(관심사).
 
 ## 불변식
 - 가입 완료(`register`)는 PENDING에서만 가능 — 제재(SUSPENDED/BANNED) 회원이 이 경로로 ACTIVE가 될 수 없다 (`INVALID_STATUS_TRANSITION`).
@@ -13,6 +13,10 @@
 - BANNED는 정지(`suspendUntil`)로 낮출 수 없다. 해제는 `reinstate`(어드민 직권)로만.
 - `reinstate`는 SUSPENDED/BANNED에서만 호출 가능.
 - 온보딩 필수 정보: 관심사·사는곳·직업·캐리커쳐는 가입 완료 시 항상 채운다 (`register`).
+- `left_at`·`leave_reason`은 LEFT일 때만 값이 존재한다 (`leave`가 설정, `restore`가 비움).
+- 탈퇴는 소프트 삭제다 — 데이터를 지우지 않고 LEFT로 전이하며, 완전 삭제는 30일 경과 후 배치가 한다 ([ADR 0016](../adr/0016-member-leave-soft-delete-and-restore.md)).
+- 제재 중에도 탈퇴할 수 있다. 소프트 삭제가 제재 이력과 `SocialAccount`를 보존하므로 차단 우회가 되지 않는다.
+- 진행 중인 매칭(PENDING/ACCEPTED)이나 채팅방이 있으면 탈퇴할 수 없다.
 - TODO: 역할(Role) 부여 규칙.
 
 ## 상태 전이
@@ -22,6 +26,8 @@ PENDING → ACTIVE                    (register — 가입 완료)
 ACTIVE → SUSPENDED                  (suspendUntil — 기간 이용 정지, 2차 제재)
 ACTIVE|SUSPENDED → BANNED           (ban — 영구 차단, 3차·중대 위반)
 SUSPENDED|BANNED → ACTIVE           (reinstate — 정지 만료·어드민 직권 해제)
+ACTIVE|SUSPENDED|BANNED → LEFT      (leave — 탈퇴, 소프트 삭제)
+LEFT → ACTIVE                       (restore — 30일 내 재가입 시 복구)
 ```
 
 - 1차 제재(경고)는 status를 바꾸지 않는다 — 퀴즈 참여만 sanction 조회로 차단.

--- a/domain/db/V20260803234144_회원 탈퇴 소프트 삭제 컬럼 추가.sql
+++ b/domain/db/V20260803234144_회원 탈퇴 소프트 삭제 컬럼 추가.sql
@@ -1,0 +1,15 @@
+-- 탈퇴를 hard delete에서 소프트 삭제로 전환한다.
+-- 탈퇴 화면(피그마 6.2.4)이 "탈퇴 후 30일 이내 재가입하면 계정을 복구할 수 있습니다 /
+-- 30일이 지나면 모든 데이터가 완전히 삭제됩니다"를 안내하므로, 즉시 삭제로는 그 약속을 지킬 수 없다.
+--
+-- status에 LEFT 값이 추가되지만 VARCHAR 저장이라 컬럼 변경은 없다.
+-- social_account는 탈퇴 시에도 보존한다 — 재가입 시 같은 회원을 찾아내는 유일한 근거이며(복구),
+-- 동시에 제재 회피용 재가입을 막는 근거이기도 하다.
+ALTER TABLE member
+    ADD COLUMN left_at DATETIME(6) NULL COMMENT '탈퇴 일시 (LEFT일 때만 값 존재)';
+
+ALTER TABLE member
+    ADD COLUMN leave_reason VARCHAR(50) NULL COMMENT '탈퇴 사유 code (탈퇴 화면 선택값)';
+
+-- 30일 경과 회원을 찾는 삭제 배치의 조회 조건.
+CREATE INDEX member_index_3 ON member (status, left_at);

--- a/domain/src/main/kotlin/com/ditto/domain/chat/repository/ChatRoomMemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/chat/repository/ChatRoomMemberRepository.kt
@@ -8,6 +8,9 @@ interface ChatRoomMemberRepository : JpaRepository<ChatRoomMember, Long> {
     /** 내가 참여한 채팅방 멤버 레코드 목록 */
     fun findByMemberId(memberId: Long): List<ChatRoomMember>
 
+    /** 내가 참여한 채팅방 수 — 탈퇴 가드(진행 중 채팅 판정)에 쓴다. */
+    fun countByMemberId(memberId: Long): Long
+
     fun findByRoomIdIn(roomIds: Collection<Long>): List<ChatRoomMember>
 
     fun findByRoomIdAndMemberId(roomId: Long, memberId: Long): ChatRoomMember?

--- a/domain/src/main/kotlin/com/ditto/domain/chat/repository/ChatRoomRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/chat/repository/ChatRoomRepository.kt
@@ -25,4 +25,5 @@ interface ChatRoomRepository : JpaRepository<ChatRoom, Long>, ChatRoomRepository
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Transactional(propagation = Propagation.MANDATORY)
     fun findWithLockById(id: Long): ChatRoom?
+
 }

--- a/domain/src/main/kotlin/com/ditto/domain/chat/repository/querydsl/ChatRoomRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/chat/repository/querydsl/ChatRoomRepositoryCustom.kt
@@ -17,4 +17,10 @@ interface ChatRoomRepositoryCustom {
 
     /** [at] 시점에 개방 시각이 됐는데 아직 열리지 않은 방 — 개방 후보. */
     fun findAllIdsDueToOpen(at: LocalDateTime): List<Long>
+
+    /**
+     * 회원이 참여한 방 중 아직 끝나지 않은(SCHEDULED·ACTIVE) 방이 있는지 — 탈퇴 가드용.
+     * "진행 중"의 판정 근거가 방 상태라서 `chat_room_member`를 조인해 확인한다.
+     */
+    fun existsUnendedRoomOfMember(memberId: Long): Boolean
 }

--- a/domain/src/main/kotlin/com/ditto/domain/chat/repository/querydsl/ChatRoomRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/chat/repository/querydsl/ChatRoomRepositoryImpl.kt
@@ -2,6 +2,7 @@ package com.ditto.domain.chat.repository.querydsl
 
 import com.ditto.domain.chat.entity.ChatRoomStatus
 import com.ditto.domain.chat.entity.QChatRoom.chatRoom
+import com.ditto.domain.chat.entity.QChatRoomMember.chatRoomMember
 import com.querydsl.jpa.impl.JPAQueryFactory
 import java.time.LocalDateTime
 import org.springframework.transaction.annotation.Transactional
@@ -30,4 +31,15 @@ class ChatRoomRepositoryImpl(
                 chatRoom.opensAt.loe(at),
             )
             .fetch()
+
+    override fun existsUnendedRoomOfMember(memberId: Long): Boolean =
+        queryFactory
+            .selectOne()
+            .from(chatRoom)
+            .join(chatRoomMember).on(chatRoomMember.roomId.eq(chatRoom.id))
+            .where(
+                chatRoomMember.memberId.eq(memberId),
+                chatRoom.status.ne(ChatRoomStatus.ENDED),
+            )
+            .fetchFirst() != null
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryCustom.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryCustom.kt
@@ -17,4 +17,10 @@ interface PersonalMatchRepositoryCustom {
         status: PersonalMatchStatus,
         memberId: Long,
     ): PersonalMatch?
+
+    /**
+     * 해당 회원이 낀 매칭 중 주어진 상태가 하나라도 있는지 (퀴즈셋 무관, 방향 무관) — 탈퇴 가드에 쓴다.
+     * 페어가 (memberId1, memberId2)로 정규화돼 있어 양쪽 컬럼을 모두 본다.
+     */
+    fun existsByMemberIdAndStatusIn(memberId: Long, statuses: Collection<PersonalMatchStatus>): Boolean
 }

--- a/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryImpl.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/match/repository/querydsl/PersonalMatchRepositoryImpl.kt
@@ -37,4 +37,19 @@ class PersonalMatchRepositoryImpl(
             personalMatch.memberId1.eq(memberId).or(personalMatch.memberId2.eq(memberId)),
         )
         .fetchFirst()
+
+    override fun existsByMemberIdAndStatusIn(
+        memberId: Long,
+        statuses: Collection<PersonalMatchStatus>,
+    ): Boolean {
+        if (statuses.isEmpty()) return false
+        return queryFactory
+            .selectOne()
+            .from(personalMatch)
+            .where(
+                personalMatch.memberId1.eq(memberId).or(personalMatch.memberId2.eq(memberId)),
+                personalMatch.status.`in`(statuses),
+            )
+            .fetchFirst() != null
+    }
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/Member.kt
@@ -98,6 +98,14 @@ class Member(
     @Comment("프로필 캐리커쳐 (FE에서 받은 문자열 그대로 저장)")
     @Column(nullable = true, length = 100)
     var caricature: String? = null,
+
+    @Comment("탈퇴 일시 (LEFT일 때만 값 존재)")
+    @Column(name = "left_at", nullable = true)
+    var leftAt: LocalDateTime? = null,
+
+    @Comment("탈퇴 사유 code (탈퇴 화면 선택값)")
+    @Column(name = "leave_reason", nullable = true, length = 50)
+    var leaveReason: String? = null,
 ) : BaseEntity() {
 
     fun activate() {
@@ -124,6 +132,45 @@ class Member(
         if (name != null) this.name = name
         if (phoneNumber != null) this.phoneNumber = phoneNumber
         if (gender != null) this.gender = gender
+    }
+
+    fun isLeft(): Boolean = status == MemberStatus.LEFT
+
+    /**
+     * 탈퇴 처리(소프트 삭제). 데이터는 지우지 않고 상태만 [MemberStatus.LEFT]로 바꾼다 —
+     * 30일 안에 재가입하면 [restore]로 되돌리고, 그 뒤에 배치가 완전 삭제한다.
+     *
+     * 제재 중에도 탈퇴할 수 있다. hard delete 시절에는 제재 이력과 재가입 식별 근거(SocialAccount)가
+     * 함께 사라져 차단 우회 수단이 됐지만, 소프트 삭제는 둘을 모두 보존하므로 막을 이유가 없다.
+     */
+    fun leave(reason: String?, now: LocalDateTime) {
+        if (status == MemberStatus.LEFT) {
+            throw WarnException(ErrorCode.INVALID_STATUS_TRANSITION, "이미 탈퇴한 회원입니다.")
+        }
+        status = MemberStatus.LEFT
+        leftAt = now
+        leaveReason = reason
+    }
+
+    /**
+     * 탈퇴 복구. 재가입(소셜 로그인) 시 [leftAt]이 보존 기간 안이면 호출된다.
+     *
+     * 탈퇴 이전 상태를 따로 저장하지 않으므로 ACTIVE로 되돌린다 — 제재 상태는 `sanction` 도메인이
+     * SSOT이고 로그인·배치가 다시 반영하므로 여기서 복원할 필요가 없다.
+     */
+    fun restore() {
+        if (status != MemberStatus.LEFT) {
+            throw WarnException(ErrorCode.INVALID_STATUS_TRANSITION)
+        }
+        status = MemberStatus.ACTIVE
+        leftAt = null
+        leaveReason = null
+    }
+
+    /** 탈퇴 후 [retentionDays]일이 지났는지 — 완전 삭제 대상 판정. */
+    fun isRetentionExpiredAt(now: LocalDateTime, retentionDays: Long): Boolean {
+        val leftAt = leftAt ?: return false
+        return leftAt.plusDays(retentionDays) <= now
     }
 
     fun isPending(): Boolean = status == MemberStatus.PENDING

--- a/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberStatus.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/entity/MemberStatus.kt
@@ -5,4 +5,5 @@ enum class MemberStatus(private val description: String) {
     ACTIVE("회원가입 완료"),
     SUSPENDED("이용 정지 (suspended_until까지)"),
     BANNED("영구 차단"),
+    LEFT("탈퇴 (30일 내 재가입 시 복구 가능)"),
 }

--- a/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
+++ b/domain/src/main/kotlin/com/ditto/domain/member/repository/MemberRepository.kt
@@ -12,6 +12,9 @@ interface MemberRepository : JpaRepository<Member, Long> {
     /** 특정 상태이면서 정지 해제 예정일이 지난 회원 목록 (만료 원복 배치용). */
     fun findAllByStatusAndSuspendedUntilLessThanEqual(status: MemberStatus, until: LocalDateTime): List<Member>
 
+    /** 탈퇴 보존 기간이 지난 회원을 찾는 삭제 배치용 — leftAt이 [leftBefore] 이전인 LEFT 회원. */
+    fun findAllByStatusAndLeftAtLessThanEqual(status: MemberStatus, leftBefore: LocalDateTime): List<Member>
+
     /** 이메일 정확 일치 회원 목록(같은 이메일에 여러 명 가능). */
     fun findByEmailOrderByIdAsc(email: String): List<Member>
 

--- a/domain/src/test/kotlin/com/ditto/domain/chat/repository/ChatRoomUnendedQueryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/chat/repository/ChatRoomUnendedQueryTest.kt
@@ -1,0 +1,54 @@
+package com.ditto.domain.chat.repository
+
+import com.ditto.domain.chat.ChatRoomFixture
+import com.ditto.domain.chat.entity.ChatRoomMember
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+/**
+ * `existsUnendedRoomOfMember` — 탈퇴 가드가 쓰는 판정.
+ * 방 상태와 참여 여부를 조인해서 보므로 리포지토리 레벨에서 확인한다.
+ */
+class ChatRoomUnendedQueryTest(
+    private val chatRoomRepository: ChatRoomRepository,
+    private val chatRoomMemberRepository: ChatRoomMemberRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    "참여한 방이 ACTIVE면 참이다" {
+        val room = chatRoomRepository.save(ChatRoomFixture.personal(sourceId = 1L))
+        chatRoomMemberRepository.save(ChatRoomMember.of(roomId = room.id, memberId = 10L))
+
+        chatRoomRepository.existsUnendedRoomOfMember(10L) shouldBe true
+    }
+
+    "참여한 방이 모두 ENDED면 거짓이다" {
+        val room = ChatRoomFixture.personal(sourceId = 2L).apply {
+            expire(ChatRoomFixture.DEFAULT_NOW.plusDays(3))
+        }
+        chatRoomRepository.save(room)
+        chatRoomMemberRepository.save(ChatRoomMember.of(roomId = room.id, memberId = 11L))
+
+        chatRoomRepository.existsUnendedRoomOfMember(11L) shouldBe false
+    }
+
+    "방에 참여하지 않은 회원은 거짓이다 — 남의 방은 세지 않는다" {
+        val room = chatRoomRepository.save(ChatRoomFixture.personal(sourceId = 3L))
+        chatRoomMemberRepository.save(ChatRoomMember.of(roomId = room.id, memberId = 12L))
+
+        chatRoomRepository.existsUnendedRoomOfMember(99L) shouldBe false
+    }
+
+    "끝난 방과 안 끝난 방이 섞여 있으면 참이다" {
+        val ended = ChatRoomFixture.personal(sourceId = 4L).apply {
+            expire(ChatRoomFixture.DEFAULT_NOW.plusDays(3))
+        }
+        chatRoomRepository.save(ended)
+        val active = chatRoomRepository.save(ChatRoomFixture.personal(sourceId = 5L))
+        chatRoomMemberRepository.save(ChatRoomMember.of(roomId = ended.id, memberId = 13L))
+        chatRoomMemberRepository.save(ChatRoomMember.of(roomId = active.id, memberId = 13L))
+
+        chatRoomRepository.existsUnendedRoomOfMember(13L) shouldBe true
+    }
+})

--- a/domain/src/test/kotlin/com/ditto/domain/match/repository/PersonalMatchOngoingQueryTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/match/repository/PersonalMatchOngoingQueryTest.kt
@@ -1,0 +1,59 @@
+package com.ditto.domain.match.repository
+
+import com.ditto.domain.match.PersonalMatchFixture
+import com.ditto.domain.match.entity.PersonalMatchStatus
+import com.ditto.domain.support.IntegrationTest
+import io.kotest.matchers.shouldBe
+import javax.sql.DataSource
+
+/**
+ * `existsByMemberIdAndStatusIn` — 탈퇴 가드가 쓰는 판정.
+ * 페어가 (memberId1, memberId2)로 정규화돼 있어 양쪽 컬럼을 모두 보는지 확인한다.
+ */
+class PersonalMatchOngoingQueryTest(
+    private val personalMatchRepository: PersonalMatchRepository,
+    dataSource: DataSource,
+) : IntegrationTest(dataSource, {
+
+    val ongoing = setOf(PersonalMatchStatus.PENDING, PersonalMatchStatus.ACCEPTED)
+
+    "요청자로 낀 진행 중 매칭을 찾는다" {
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 10L, receiverId = 20L, status = PersonalMatchStatus.ACCEPTED),
+        )
+
+        personalMatchRepository.existsByMemberIdAndStatusIn(10L, ongoing) shouldBe true
+    }
+
+    "수신자로 낀 진행 중 매칭도 찾는다 — 방향 무관" {
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 10L, receiverId = 20L, status = PersonalMatchStatus.ACCEPTED),
+        )
+
+        personalMatchRepository.existsByMemberIdAndStatusIn(20L, ongoing) shouldBe true
+    }
+
+    "거절된 매칭만 있으면 거짓이다" {
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 10L, receiverId = 20L, status = PersonalMatchStatus.REJECTED),
+        )
+
+        personalMatchRepository.existsByMemberIdAndStatusIn(10L, ongoing) shouldBe false
+    }
+
+    "매칭에 끼지 않은 회원은 거짓이다" {
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 10L, receiverId = 20L, status = PersonalMatchStatus.ACCEPTED),
+        )
+
+        personalMatchRepository.existsByMemberIdAndStatusIn(99L, ongoing) shouldBe false
+    }
+
+    "상태 목록이 비어 있으면 쿼리 없이 거짓이다" {
+        personalMatchRepository.save(
+            PersonalMatchFixture.create(requesterId = 10L, receiverId = 20L, status = PersonalMatchStatus.ACCEPTED),
+        )
+
+        personalMatchRepository.existsByMemberIdAndStatusIn(10L, emptySet()) shouldBe false
+    }
+})

--- a/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberLeaveTransitionTest.kt
+++ b/domain/src/test/kotlin/com/ditto/domain/member/entity/MemberLeaveTransitionTest.kt
@@ -1,0 +1,103 @@
+package com.ditto.domain.member.entity
+
+import com.ditto.common.exception.ErrorCode
+import com.ditto.common.exception.WarnException
+import com.ditto.domain.member.MemberFixture
+import io.kotest.assertions.throwables.shouldThrow
+import io.kotest.core.spec.style.FreeSpec
+import io.kotest.matchers.nulls.shouldBeNull
+import io.kotest.matchers.shouldBe
+import java.time.LocalDateTime
+
+class MemberLeaveTransitionTest : FreeSpec(
+    {
+        val leftAt = LocalDateTime.of(2026, 8, 1, 12, 0)
+
+        "leave" - {
+            "탈퇴하면 LEFT가 되고 일시·사유가 남는다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+
+                member.leave(reason = "not-useful", now = leftAt)
+
+                member.status shouldBe MemberStatus.LEFT
+                member.leftAt shouldBe leftAt
+                member.leaveReason shouldBe "not-useful"
+                member.isLeft() shouldBe true
+            }
+
+            "사유 없이도 탈퇴할 수 있다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+
+                member.leave(reason = null, now = leftAt)
+
+                member.status shouldBe MemberStatus.LEFT
+                member.leaveReason.shouldBeNull()
+            }
+
+            "제재 중인 회원도 탈퇴할 수 있다 — 소프트 삭제는 제재 이력을 보존한다" {
+                val banned = MemberFixture.create(status = MemberStatus.BANNED)
+
+                banned.leave(reason = "etc", now = leftAt)
+
+                banned.status shouldBe MemberStatus.LEFT
+            }
+
+            "이미 탈퇴한 회원은 다시 탈퇴할 수 없다 — 최초 탈퇴 시각이 덮이면 복구 기한이 어긋난다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+                member.leave(reason = "etc", now = leftAt)
+
+                val exception = shouldThrow<WarnException> {
+                    member.leave(reason = "etc", now = leftAt.plusDays(1))
+                }
+
+                exception.errorCode shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+                member.leftAt shouldBe leftAt
+            }
+        }
+
+        "restore" - {
+            "복구하면 ACTIVE로 돌아오고 탈퇴 기록이 비워진다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+                member.leave(reason = "etc", now = leftAt)
+
+                member.restore()
+
+                member.status shouldBe MemberStatus.ACTIVE
+                member.leftAt.shouldBeNull()
+                member.leaveReason.shouldBeNull()
+            }
+
+            "탈퇴하지 않은 회원은 복구할 수 없다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+
+                val exception = shouldThrow<WarnException> {
+                    member.restore()
+                }
+
+                exception.errorCode shouldBe ErrorCode.INVALID_STATUS_TRANSITION
+            }
+        }
+
+        "isRetentionExpiredAt" - {
+            "보존 기간이 지나면 참이다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+                member.leave(reason = "etc", now = leftAt)
+
+                member.isRetentionExpiredAt(leftAt.plusDays(30), retentionDays = 30) shouldBe true
+            }
+
+            "경계(정확히 30일)는 만료로 본다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+                member.leave(reason = "etc", now = leftAt)
+
+                member.isRetentionExpiredAt(leftAt.plusDays(30).minusSeconds(1), retentionDays = 30) shouldBe false
+            }
+
+            "탈퇴하지 않은 회원은 만료 대상이 아니다" {
+                val member = MemberFixture.create(status = MemberStatus.ACTIVE)
+
+                member.isRetentionExpiredAt(leftAt.plusYears(1), retentionDays = 30) shouldBe false
+            }
+        }
+    },
+)


### PR DESCRIPTION
Closes #124

## 요약

탈퇴를 hard delete에서 소프트 삭제로 전환했다. 탈퇴 화면(`6.2.4`)이 안내하는 세 가지를 구현이 지키지 못하고 있었다.

| 화면 안내 | 기존 구현 | 이 PR |
|---|---|---|
| 진행 중인 매칭·채팅 있으면 제한 | 제재 중일 때만 거부 | 진행 중 매칭·채팅 가드 추가 |
| 30일 이내 재가입 시 복구 | 즉시 완전 삭제 | 소프트 삭제 + 재가입 복구 |
| 탈퇴 사유 선택 | 바디를 받지 않아 유실 | `{reason}` 수집 |

설계 배경은 [ADR 0016](docs/adr/0016-member-leave-soft-delete-and-restore.md)에 정리했다.

## 복구는 재가입이 곧 복구다

별도 복구 API를 두지 않았다. `MemberSocialAccountService.findOrCreateMember`가 `SocialAccount`가 있으면 기존 `Member`를 반환하므로, 그 경로에 "LEFT이고 보존 기간 안이면 `restore()`" 분기만 더하면 재로그인이 곧 복구가 된다. 화면에도 별도 복구 흐름이 없다.

그래서 탈퇴 시 `SocialAccount`를 **지우지 않는다.** 이 행이 복구의 유일한 근거이면서, 동시에 제재 회피용 재가입을 막는 근거이기도 하다.

## 제재 중 탈퇴 가드를 제거했다

`CANNOT_LEAVE_WHILE_SANCTIONED`를 없앴다. hard delete 시절에는 탈퇴가 제재 이력과 `SocialAccount`를 함께 지워 **차단 우회 수단**이었지만, 소프트 삭제는 둘을 모두 보존하므로 막을 이유가 없다. `UserService`의 기존 주석("탈퇴 부분 보존 전환(후속) 시 이 가드는 제거한다")이 예고한 그 작업이다.

## 인증 게이트는 두 곳에

`JwtAuthenticationFilter`와 `AuthService.refresh` **양쪽**에 LEFT 게이트를 넣었다. refresh는 필터를 지나지 않아 한쪽만으로는 우회된다 — 제재 게이트가 같은 이유로 두 곳에 있는 구조를 그대로 따랐다.

## 삭제 배치 안전장치

되돌릴 수 없는 삭제라 셋을 뒀다.

1. `ditto.member.purge.dry-run` **기본 true** — 운영 투입 전에는 대상만 로그로 남기고 지우지 않는다
2. `batch-limit`(기본 100) — 1회 삭제량 제한
3. 삭제 대상 ID·`leftAt`을 항상 로그로 남긴다

운영에서 실제 삭제를 켤 때 `dry-run=false`로 바꿔야 한다. **이 PR 상태로는 30일 경과 회원이 삭제되지 않는다** — 의도된 기본값이다.

## 진행 중 판정은 실제 방 상태 기준이다

최초 작성 시에는 `chat_room`에 종료 개념이 없어 "방이 존재하면 진행 중"으로 근사했지만, #120(채팅 종료 생명주기)이 머지되어 리베이스하면서 **끝나지 않은 방(`SCHEDULED`·`ACTIVE`) 기준**으로 정밀화했다.

`SCHEDULED`(개방 예정, 재매칭 방)도 진행 중으로 본다 — 상대가 곧 열릴 방을 기다리는 상태다. 종료(`ENDED`)된 방만 남은 회원은 탈퇴할 수 있고, 그 케이스도 테스트로 덮었다.

## ⚠️ 약관·개인정보 처리방침과 충돌한다

기획 결정에 따라 구현을 선행했지만, 별도로 정리돼야 한다. 현행 문서는 정반대를 약속하고 있다.

- 개인정보 처리방침 4.1: "회원 탈퇴 시 — 원칙: **즉시 파기** / 예외: 신고 접수 또는 법적 분쟁 시 1년간 보존"
- 이용약관 제7조: "회원 탈퇴를 요청할 수 있으며 ... 이를 **즉시 처리**합니다"
- 처리방침 8.2: "'회원탈퇴' ... 요청 시 **즉시 삭제** 등 조치"

(출처: `ditto-fe/src/features/settings/model/policies.ts`) 30일 보관 근거 조항 추가가 필요하며, 처리방침 자체 규정상 이용자 권리의 중요한 변경은 최소 30일 전 공지 대상이다.

## 검증

- [x] `./gradlew build check` (전체 테스트 + Jacoco 게이트) 통과
- [x] 통합 테스트 12건 — 소프트 삭제·SocialAccount 보존·제재 중 탈퇴 허용·진행중 가드·30일 복구·기간 경과 미복구·배치 대상 판정
- [x] 기존 `UserServiceTest` 탈퇴 테스트를 소프트 삭제 의미로 갱신 (hard delete 단언 → LEFT 전이 단언)
- [x] `UserControllerTest` 문서화에 `reason` 필드 추가
- [x] ADR 0016 + `docs/domains/member.md`·`auth.md` 갱신
- [ ] Sonar New Code 게이트는 PR 체크 확인 필요

🤖 Generated with [Claude Code](https://claude.com/claude-code)

